### PR TITLE
 Fixed data dependency to propagate return values of functions to call sites

### DIFF
--- a/examples/scripts/data_dependency.sol
+++ b/examples/scripts/data_dependency.sol
@@ -102,3 +102,16 @@ contract PropagateThroughArguments {
         var_not_tainted = y;
     }
 }
+
+contract PropagateThroughReturnValue {
+  uint var_dependant;
+  uint var_state;
+
+  function foo() public {
+    var_dependant = bar();
+  }
+
+  function bar() internal returns (uint) {
+    return (var_state);
+  }
+}

--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -10,6 +10,7 @@ from slither.slithir.variables import (Constant, LocalIRVariable,
                                        StateIRVariable, TemporaryVariable,
                                        TemporaryVariableSSA, TupleVariableSSA)
 from slither.core.solidity_types.type import Type
+from slither.core.cfg.node import NodeType
 
 ###################################################################################
 ###################################################################################
@@ -174,13 +175,12 @@ def compute_dependency(slither):
             found_return = False
             if (not found_return):
                 for node in function.nodes:
-                    if (not found_return):
+                    if (node.type == NodeType.RETURN):
+                        found_return = True
                         for ir in node.irs_ssa:
                             if isinstance(ir, Return):
                                 return_values[function] = ir.values
-                                found_return = True
                                 break
-                    else:
                         break
                 
     for contract in slither.contracts:

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -43,6 +43,8 @@ class Function(ChildContract, SourceMapping):
         self._parameters_ssa = []
         self._returns = []
         self._returns_ssa = []
+        self._return_values = None
+        self._return_values_ssa = None
         self._vars_read = []
         self._vars_written = []
         self._state_vars_read = []
@@ -467,6 +469,36 @@ class Function(ChildContract, SourceMapping):
             expressions = [e for e in expressions if e]
             self._expressions = expressions
         return self._expressions
+
+    @property
+    def return_values(self):
+        """
+            list(Return Values): List of the return values
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.slithir.operations import Return
+        
+        if self._return_values is None:
+            return_values = list()
+            returns = [n for n in self.nodes if n.type == NodeType.RETURN]
+            [return_values.extend(ir.values) for node in returns for ir in node.irs if isinstance(ir, Return)]
+            self._return_values = return_values
+        return self._return_values
+    
+    @property
+    def return_values_ssa(self):
+        """
+            list(Return Values in SSA form): List of the return values in ssa form
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.slithir.operations import Return
+        
+        if self._return_values_ssa is None:
+            return_values_ssa = list()
+            returns = [n for n in self.nodes if n.type == NodeType.RETURN]
+            [return_values_ssa.extend(ir.values) for node in returns for ir in node.irs_ssa if isinstance(ir, Return)]
+            self._return_values_ssa = return_values_ssa
+        return self._return_values_ssa
 
     # endregion
     ###################################################################################


### PR DESCRIPTION
This PR addresses https://github.com/crytic/slither/issues/192 to fix data dependency to propagate return values of functions to call sites.

With this fix, for the below contract:
```
contract PropagateThroughReturnValue {
  uint var_dependant;
  uint var_state;

  function foo() public {
    var_dependant = bar();
  }

  function bar() internal returns (uint) {
    return (var_state);
  }
}
```

the `data_dependency` printer output below shows that `var_dependent` in `foo` depends on `var_state` returned from `bar` because of the call site `var_dependant = bar();` in `foo`:

```
Contract PropagateThroughReturnValue
+---------------+---------------+
|    Variable   |  Dependencies |
+---------------+---------------+
| var_dependant | ['var_state'] |
|   var_state   | ['var_state'] |
+---------------+---------------+
```
