### PR TITLE
Bug fix for line number calculations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description='Slither is a Solidity static analysis framework written in Python 3.',
     url='https://github.com/trailofbits/slither',
     author='Trail of Bits',
-    version='0.6.0',
+    version='0.6.1',
     packages=find_packages(),
     python_requires='>=3.6',
     install_requires=['prettytable>=0.7.2', 'pysha3>=1.0.2'],

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -450,6 +450,11 @@ def parse_args(detector_classes, printer_classes):
                         action='store_true',
                         default=defaults_flag_in_config['legacy_ast'])
 
+    parser.add_argument('--ignore-return-value',
+                        help=argparse.SUPPRESS,
+                        action='store_true',
+                        default=False)
+
     # if the json is splitted in different files
     parser.add_argument('--splitted',
                         help=argparse.SUPPRESS,
@@ -591,6 +596,8 @@ def main_impl(all_detector_classes, all_printer_classes):
             logger.info('%s analyzed (%d contracts)', filename, number_contracts)
         else:
             logger.info('%s analyzed (%d contracts), %d result(s) found', filename, number_contracts, len(results))
+        if args.ignore_return_value:
+            return
         exit(results)
 
     except Exception:

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -19,12 +19,12 @@ class SourceMapping(Context):
             Not done in an efficient way
         """
         total_length = len(source_code)
-        source_code = source_code.split('\n')
+        source_code = source_code.splitlines(True)
         counter = 0
         i = 0
         lines = []
         while counter < total_length:
-            counter += len(source_code[i]) +1
+            counter += len(source_code[i])
             i = i+1
             if counter > start:
                 lines.append(i)

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -89,7 +89,7 @@ class SlitherSolc(Slither):
         if 'sourcePaths' in data_loaded:
             for sourcePath in data_loaded['sourcePaths']:
                 if os.path.isfile(sourcePath):
-                    with open(sourcePath, encoding='utf8') as f:
+                    with open(sourcePath, encoding='utf8', newline='') as f:
                         source_code = f.read()
                     self.source_code[sourcePath] = source_code
 
@@ -152,13 +152,13 @@ class SlitherSolc(Slither):
 
         self._source_units[sourceUnit] = name
         if os.path.isfile(name) and not name in self.source_code:
-            with open(name, encoding='utf8') as f:
+            with open(name, encoding='utf8', newline='') as f:
                 source_code = f.read()
             self.source_code[name] = source_code
         else:
             lib_name = os.path.join('node_modules', name)
             if os.path.isfile(lib_name) and not name in self.source_code:
-                with open(lib_name, encoding='utf8') as f:
+                with open(lib_name, encoding='utf8', newline='') as f:
                     source_code = f.read()
                 self.source_code[name] = source_code
 


### PR DESCRIPTION
This issue aims to resolve #180 . By default, python's `open()` function parses CR LF (`\r\n`) line endings as LF (`\n`). During line number calculation, a byte offset is converted into line numbers by splitting the string with a `\n` character, and summing up the length of each line until the correct line byte range is found. With the removal of CR control characters, a miscalculation of line lengths would cause a later-than-intended line range to be reported.

This fixes the issue by adding a `newline=''` argument to the `open()` functions related to source mapping. The use of a blank new line will allow python's new line related parsing functions to work, while retaining CR LF line endings. Reference: https://stackoverflow.com/questions/20350305/python-read-crlf-text-file-as-is-with-crlf

NOTE: This means that the `source_code` string property for a source mapping will now retain CR characters within them. This property is not currently used for anything but line number calculations, making it non-problematic. In the future, if code intends to print/operate on these source code properties, it should be mindful that line endings can be CR LF or LF.