### PR TITLE
Improve conversion of Literals 

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -86,6 +86,7 @@ class Function(ChildContract, SourceMapping):
         self._reachable_from_nodes = set()
         self._reachable_from_functions = set()
 
+
     ###################################################################################
     ###################################################################################
     # region General properties

--- a/slither/core/declarations/structure.py
+++ b/slither/core/declarations/structure.py
@@ -10,6 +10,8 @@ class Structure(ChildContract, SourceMapping):
         self._name = None
         self._canonical_name = None
         self._elems = None
+        # Name of the elements in the order of declaration
+        self._elems_ordered = None
 
     @property
     def canonical_name(self):
@@ -22,6 +24,13 @@ class Structure(ChildContract, SourceMapping):
     @property
     def elems(self):
         return self._elems
+
+    @property
+    def elems_ordered(self):
+        ret = []
+        for e in self._elems_ordered:
+            ret.append(self._elems[e])
+        return ret
 
     def __str__(self):
         return self.name

--- a/slither/core/expressions/literal.py
+++ b/slither/core/expressions/literal.py
@@ -2,13 +2,18 @@ from slither.core.expressions.expression import Expression
 
 class Literal(Expression):
 
-    def __init__(self, value):
+    def __init__(self, value, type):
         super(Literal, self).__init__()
         self._value = value
+        self._type = type
 
     @property
     def value(self):
         return self._value
+
+    @property
+    def type(self):
+        return self._type
 
     def __str__(self):
         # be sure to handle any character

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -10,7 +10,7 @@ class ArrayType(Type):
         assert isinstance(t, Type)
         if length:
             if isinstance(length, int):
-                length = Literal(length)
+                length = Literal(length, 'uint256')
             assert isinstance(length, Expression)
         super(ArrayType, self).__init__()
         self._type = t
@@ -18,7 +18,7 @@ class ArrayType(Type):
 
         if length:
             if not isinstance(length, Literal):
-                cf = ConstantFolding(length)
+                cf = ConstantFolding(length, "uint256")
                 length = cf.result()
             self._length_value = length
         else:

--- a/slither/core/variables/state_variable.py
+++ b/slither/core/variables/state_variable.py
@@ -3,7 +3,6 @@ from slither.core.children.child_contract import ChildContract
 
 class StateVariable(ChildContract, Variable):
 
-
     @property
     def canonical_name(self):
         return '{}:{}'.format(self.contract.name, self.name)

--- a/slither/slithir/variables/constant.py
+++ b/slither/slithir/variables/constant.py
@@ -1,17 +1,41 @@
 from .variable import SlithIRVariable
-from slither.core.solidity_types.elementary_type import ElementaryType
+from slither.core.solidity_types.elementary_type import ElementaryType, Int, Uint
+
 
 class Constant(SlithIRVariable):
 
-    def __init__(self, val):
+    def __init__(self, val, type=None):
         super(Constant, self).__init__()
         assert isinstance(val, str)
-        if val.isdigit():
-            self._type = ElementaryType('uint256')
-            self._val = int(val)
+
+        self._original_value = val
+
+        if type:
+            assert isinstance(type, ElementaryType)
+            self._type = type
+            if type.type in Int + Uint:
+                if val.startswith('0x'):
+                    self._val = int(val, 16)
+                else:
+                    if 'e' in val:
+                        base, expo = val.split('e')
+                        self._val = int(float(base)* (10 ** int(expo)))
+                    elif 'E' in val:
+                        base, expo = val.split('E')
+                        self._val = int(float(base) * (10 ** int(expo)))
+                    else:
+                        self._val = int(val)
+            elif type.type == 'bool':
+                self._val = val == 'true'
+            else:
+                self._val = val
         else:
-            self._type = ElementaryType('string')
-            self._val = val
+            if val.isdigit():
+                self._type = ElementaryType('uint256')
+                self._val = int(val)
+            else:
+                self._type = ElementaryType('string')
+                self._val = val
 
     @property
     def value(self):
@@ -20,9 +44,17 @@ class Constant(SlithIRVariable):
         If the expression was an hexadecimal delcared as hex'...'
         return a str
         Returns:
-            (str, int)
+            (str | int | bool)
         '''
         return self._val
+
+    @property
+    def original_value(self):
+        '''
+        Return the string representation of the value
+        :return: str
+        '''
+        return self._original_value
 
     def __str__(self):
         return str(self.value)

--- a/slither/solc_parsing/declarations/structure.py
+++ b/slither/solc_parsing/declarations/structure.py
@@ -16,6 +16,7 @@ class StructureSolc(Structure):
         self._name = name
         self._canonical_name = canonicalName
         self._elems = {}
+        self._elems_ordered = []
 
         self._elemsNotParsed = elems
 
@@ -28,5 +29,6 @@ class StructureSolc(Structure):
             elem.analyze(self.contract)
 
             self._elems[elem.name] = elem
+            self._elems_ordered.append(elem.name)
         self._elemsNotParsed = []
 

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -479,6 +479,12 @@ def parse_expression(expression, caller_context):
                     value = str(convert_subdenomination(value, expression['subdenomination']))
             elif not value and value != "":
                 value = '0x'+expression['hexValue']
+            type = expression['typeDescriptions']['typeString']
+
+            # Length declaration for array was None until solc 0.5.5
+            if type is None:
+                if expression['kind'] == 'number':
+                    type = 'int_const'
         else:
             value = expression['attributes']['value']
             if value:
@@ -489,7 +495,15 @@ def parse_expression(expression, caller_context):
                 # see https://solidity.readthedocs.io/en/v0.4.25/types.html?highlight=hex#hexadecimal-literals
                 assert 'hexvalue' in expression['attributes']
                 value = '0x'+expression['attributes']['hexvalue']
-        literal = Literal(value)
+            type = expression['attributes']['type']
+
+        if type.startswith('int_const '):
+            type = ElementaryType('uint256')
+        elif type.startswith('bool'):
+            type = ElementaryType('bool')
+        else:
+            type = ElementaryType('string')
+        literal = Literal(value, type)
         return literal
 
     elif name == 'Identifier':

--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -32,7 +32,7 @@ def _find_from_type_name(name, contract, contracts, structures, enums):
     if name_elementary in ElementaryTypeName:
         depth = name.count('[')
         if depth:
-            return ArrayType(ElementaryType(name_elementary), Literal(depth))
+            return ArrayType(ElementaryType(name_elementary), Literal(depth, 'uint256'))
         else:
             return ElementaryType(name_elementary)
     # We first look for contract
@@ -78,7 +78,7 @@ def _find_from_type_name(name, contract, contracts, structures, enums):
                 depth+=1
             var_type = next((st for st in all_structures if st.contract.name+"."+st.name == name_struct), None)
             if var_type:
-                return ArrayType(UserDefinedType(var_type), Literal(depth))
+                return ArrayType(UserDefinedType(var_type), Literal(depth, 'uint256'))
 
     if not var_type:
         var_type = next((f for f in contract.functions if f.name == name), None)

--- a/slither/utils/type.py
+++ b/slither/utils/type.py
@@ -1,0 +1,31 @@
+from slither.core.solidity_types import (ArrayType, MappingType, ElementaryType)
+
+def _add_mapping_parameter(t, l):
+    while isinstance(t, MappingType):
+        l.append(t.type_from)
+        t = t.type_to
+    _add_array_parameter(t, l)
+
+def _add_array_parameter(t, l):
+    while isinstance(t, ArrayType):
+        l.append(ElementaryType('uint256'))
+        t = t.type
+
+def export_nested_types_from_variable(variable):
+    """
+    Export the list of nested types (mapping/array)
+    :param variable:
+    :return: list(Type)
+    """
+    l = []
+    if isinstance(variable.type, MappingType):
+        t = variable.type
+        _add_mapping_parameter(t, l)
+
+    if isinstance(variable.type, ArrayType):
+        v = variable
+        _add_array_parameter(v.type, l)
+
+    return l
+
+

--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -20,8 +20,12 @@ def set_val(expression, val):
 
 class ConstantFolding(ExpressionVisitor):
 
+    def __init__(self, expression, type):
+        super(ConstantFolding, self).__init__(expression)
+        self._type = type
+
     def result(self):
-        return Literal(int(get_val(self._expression)))
+        return Literal(int(get_val(self._expression)), self._type)
 
     def _post_identifier(self, expression):
         if not expression.value.is_constant:
@@ -29,7 +33,7 @@ class ConstantFolding(ExpressionVisitor):
         expr = expression.value.expression
         # assumption that we won't have infinite loop
         if not isinstance(expr, Literal):
-            cf = ConstantFolding(expr)
+            cf = ConstantFolding(expr, self._type)
             expr = cf.result()
         set_val(expression, int(expr.value))
 

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -173,7 +173,8 @@ class ExpressionToSlithIR(ExpressionVisitor):
         set_val(expression, val)
 
     def _post_literal(self, expression):
-        set_val(expression, Constant(expression.value))
+        cst = Constant(expression.value, expression.type)
+        set_val(expression, cst)
 
     def _post_member_access(self, expression):
         expr = get(expression.expression)


### PR DESCRIPTION
Close https://github.com/crytic/slither/issues/223

- Improve literals parsing and Constant conversion:
        - add bool type to constant
        - convert integer using 'e' (1e10)
        - convert constant uint -> int when possible
- Api added:
        - Constant.original_value: str version of the constant expression
        - Structure.elems_ordered: keep original structure declaration order

https://github.com/crytic/slither/pull/216 will need to use `constant.original_value`