### PR TITLE
slither core/parsing changes required for slither-format

### DIFF
--- a/slither/core/cfg/node.py
+++ b/slither/core/cfg/node.py
@@ -155,6 +155,7 @@ class Node(SourceMapping, ChildFunction):
         self._library_calls = []
         self._low_level_calls = []
         self._external_calls_as_expressions = []
+        self._internal_calls_as_expressions = []
         self._irs = []
         self._irs_ssa = []
 
@@ -368,6 +369,13 @@ class Node(SourceMapping, ChildFunction):
         """
         return self._external_calls_as_expressions
 
+    @property
+    def internal_calls_as_expressions(self):
+        """
+            list(CallExpression): List of internal calls (that dont create a transaction)
+        """
+        return self._internal_calls_as_expressions
+    
     @property
     def calls_as_expression(self):
         return list(self._expression_calls)

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -39,10 +39,12 @@ class Function(ChildContract, SourceMapping):
         self._slithir_variables = set() # slithir Temporary and references variables (but not SSA)
         self._parameters = []
         self._parameters_ssa = []
+        self._parameters_src = None
         self._returns = []
         self._returns_ssa = []
         self._return_values = None
         self._return_values_ssa = None
+        self._returns_src = None
         self._vars_read = []
         self._vars_written = []
         self._state_vars_read = []
@@ -391,6 +393,15 @@ class Function(ChildContract, SourceMapping):
 
         return list(self._slithir_variables)
 
+    def get_source_var_declaration(self, var):
+        """ Return the source mapping where the variable is declared
+        Args:
+            var (str): variable name
+        Returns:
+            (dict): sourceMapping
+        """
+        return next((x.source_mapping for x in self.variables if x.name == var))
+    
     # endregion
     ###################################################################################
     ###################################################################################

--- a/slither/solc_parsing/cfg/node.py
+++ b/slither/solc_parsing/cfg/node.py
@@ -62,4 +62,6 @@ class NodeSolc(Node):
             pp = FindCalls(expression)
             self._expression_calls = pp.result()
             self._external_calls_as_expressions = [c for c in self.calls_as_expression if not isinstance(c.called, Identifier)]
+            self._internal_calls_as_expressions = [c for c in self.calls_as_expression if isinstance(c.called, Identifier)]
+            
 

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -835,6 +835,8 @@ class FunctionSolc(Function):
     def _parse_params(self, params):
         assert params[self.get_key()] == 'ParameterList'
 
+        self.parameters_src = params['src']
+        
         if self.is_compact_ast:
             params = params['parameters']
         else:
@@ -860,6 +862,8 @@ class FunctionSolc(Function):
 
         assert returns[self.get_key()] == 'ParameterList'
 
+        self.returns_src = returns['src']
+        
         if self.is_compact_ast:
             returns = returns['parameters']
         else:

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -294,7 +294,9 @@ def parse_call(expression, caller_context):
 
     if isinstance(called, SuperCallExpression):
         return SuperCallExpression(called, arguments, type_return)
-    return CallExpression(called, arguments, type_return)
+    call_expression = CallExpression(called, arguments, type_return)
+    call_expression.set_offset(expression['src'], caller_context.slither)
+    return call_expression
 
 def parse_super_name(expression, is_compact_ast):
     if is_compact_ast:
@@ -539,6 +541,7 @@ def parse_expression(expression, caller_context):
         var = find_variable(value, caller_context, referenced_declaration)
 
         identifier = Identifier(var)
+        identifier.set_offset(expression['src'], caller_context.slither)
         return identifier
 
     elif name == 'IndexAccess':
@@ -667,6 +670,7 @@ def parse_expression(expression, caller_context):
             arguments = [parse_expression(a, caller_context) for a in children[1::]]
 
         call = CallExpression(called, arguments, 'Modifier')
+        call.set_offset(expression['src'], caller_context.slither)
         return call
 
     raise ParsingError('Expression not parsed %s'%name)


### PR DESCRIPTION
This PR makes the below changes required for `slither-format` tool:

1. Adds `_internal_calls_as_expressions` to complement `_external_calls_as_expressions`
2. Adds source_mapping hooks for function parameters and returns
3. Sets source_mapping offsets for function calls, modifier calls and identifier uses

