### PR TITLE
Adds event.full_name for JSON output of events in naming-convention detector

### DIFF
--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -93,7 +93,8 @@ Solidity defines a [naming convention](https://solidity.readthedocs.io/en/v0.4.2
                     json = self.generate_json_result(info)
                     self.add_event_to_json(event, json, {
                         "target": "event",
-                        "convention": "CapWords"
+                        "convention": "CapWords",
+                        "full_name": event.full_name
                     })
                     results.append(json)
 


### PR DESCRIPTION
The recent PR https://github.com/crytic/slither/pull/226 with JSON output improvements makes most earlier changes in #234 irrelevant/stale. The only change missing (`event.full_name`) is in this PR.
