### PR TITLE
slither core/parsing changes required for slither-format

### DIFF
--- a/slither/core/cfg/node.py
+++ b/slither/core/cfg/node.py
@@ -155,6 +155,7 @@ class Node(SourceMapping, ChildFunction):
         self._library_calls = []
         self._low_level_calls = []
         self._external_calls_as_expressions = []
+        self._internal_calls_as_expressions = []
         self._irs = []
         self._irs_ssa = []
 
@@ -367,6 +368,13 @@ class Node(SourceMapping, ChildFunction):
             list(CallExpression): List of message calls (that creates a transaction)
         """
         return self._external_calls_as_expressions
+
+    @property
+    def internal_calls_as_expressions(self):
+        """
+            list(CallExpression): List of internal calls (that dont create a transaction)
+        """
+        return self._internal_calls_as_expressions
 
     @property
     def calls_as_expression(self):

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -367,26 +367,6 @@ class Contract(ChildSlither, SourceMapping):
         '''
         return [f for f in self.functions if f.is_writing(variable)]
 
-    def get_source_var_declaration(self, var):
-        """ Return the source mapping where the variable is declared
-
-        Args:
-            var (str): variable name
-        Returns:
-            (dict): sourceMapping
-        """
-        return next((x.source_mapping for x in self.variables if x.name == var))
-
-    def get_source_event_declaration(self, event):
-        """ Return the source mapping where the event is declared
-
-        Args:
-            event (str): event name
-        Returns:
-            (dict): sourceMapping
-        """
-        return next((x.source_mapping for x in self.events if x.name == event))
-
     def get_function_from_signature(self, function_signature):
         """
             Return a function from a signature

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -393,15 +393,6 @@ class Function(ChildContract, SourceMapping):
 
         return list(self._slithir_variables)
 
-    def get_source_var_declaration(self, var):
-        """ Return the source mapping where the variable is declared
-        Args:
-            var (str): variable name
-        Returns:
-            (dict): sourceMapping
-        """
-        return next((x.source_mapping for x in self.variables if x.name == var))
-
     # endregion
     ###################################################################################
     ###################################################################################

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -39,8 +39,10 @@ class Function(ChildContract, SourceMapping):
         self._slithir_variables = set() # slithir Temporary and references variables (but not SSA)
         self._parameters = []
         self._parameters_ssa = []
+        self._parameters_src = None
         self._returns = []
         self._returns_ssa = []
+        self._returns_src = None
         self._return_values = None
         self._return_values_ssa = None
         self._vars_read = []
@@ -390,6 +392,15 @@ class Function(ChildContract, SourceMapping):
         '''
 
         return list(self._slithir_variables)
+
+    def get_source_var_declaration(self, var):
+        """ Return the source mapping where the variable is declared
+        Args:
+            var (str): variable name
+        Returns:
+            (dict): sourceMapping
+        """
+        return next((x.source_mapping for x in self.variables if x.name == var))
 
     # endregion
     ###################################################################################

--- a/slither/solc_parsing/cfg/node.py
+++ b/slither/solc_parsing/cfg/node.py
@@ -62,4 +62,6 @@ class NodeSolc(Node):
             pp = FindCalls(expression)
             self._expression_calls = pp.result()
             self._external_calls_as_expressions = [c for c in self.calls_as_expression if not isinstance(c.called, Identifier)]
+            self._internal_calls_as_expressions = [c for c in self.calls_as_expression if isinstance(c.called, Identifier)]
+            
 

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -835,6 +835,8 @@ class FunctionSolc(Function):
     def _parse_params(self, params):
         assert params[self.get_key()] == 'ParameterList'
 
+        self.parameters_src = params['src']
+        
         if self.is_compact_ast:
             params = params['parameters']
         else:
@@ -860,6 +862,8 @@ class FunctionSolc(Function):
 
         assert returns[self.get_key()] == 'ParameterList'
 
+        self.returns_src = returns['src']
+        
         if self.is_compact_ast:
             returns = returns['parameters']
         else:

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -27,6 +27,7 @@ from slither.utils.utils import unroll
 from slither.visitors.expression.export_values import ExportValues
 from slither.visitors.expression.has_conditional import HasConditional
 from slither.solc_parsing.exceptions import ParsingError
+from slither.core.source_mapping.source_mapping import SourceMapping
 
 logger = logging.getLogger("FunctionSolc")
 
@@ -835,7 +836,8 @@ class FunctionSolc(Function):
     def _parse_params(self, params):
         assert params[self.get_key()] == 'ParameterList'
 
-        self.parameters_src = params['src']
+        self.parameters_src = SourceMapping()
+        self.parameters_src.set_offset(params['src'], self.contract.slither)
         
         if self.is_compact_ast:
             params = params['parameters']
@@ -862,7 +864,8 @@ class FunctionSolc(Function):
 
         assert returns[self.get_key()] == 'ParameterList'
 
-        self.returns_src = returns['src']
+        self.returns_src = SourceMapping()
+        self.returns_src.set_offset(returns['src'], self.contract.slither)
         
         if self.is_compact_ast:
             returns = returns['parameters']

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -294,7 +294,9 @@ def parse_call(expression, caller_context):
 
     if isinstance(called, SuperCallExpression):
         return SuperCallExpression(called, arguments, type_return)
-    return CallExpression(called, arguments, type_return)
+    call_expression = CallExpression(called, arguments, type_return)
+    call_expression.set_offset(expression['src'], caller_context.slither)
+    return call_expression
 
 def parse_super_name(expression, is_compact_ast):
     if is_compact_ast:
@@ -539,6 +541,7 @@ def parse_expression(expression, caller_context):
         var = find_variable(value, caller_context, referenced_declaration)
 
         identifier = Identifier(var)
+        identifier.set_offset(expression['src'], caller_context.slither)
         return identifier
 
     elif name == 'IndexAccess':
@@ -667,6 +670,7 @@ def parse_expression(expression, caller_context):
             arguments = [parse_expression(a, caller_context) for a in children[1::]]
 
         call = CallExpression(called, arguments, 'Modifier')
+        call.set_offset(expression['src'], caller_context.slither)
         return call
 
     raise ParsingError('Expression not parsed %s'%name)


### PR DESCRIPTION
This PR replaces PR #233 which was created against a stale `dev` branch by mistake. Same set of changes as PR #233 required for slither-format tool:

1. Adds _internal_calls_as_expressions to complement _external_calls_as_expressions
2. Adds source_mapping hooks for function parameters and returns
3. Sets source_mapping offsets for function calls, modifier calls and identifier uses