### PR TITLE
Improve solc-version detector

### DIFF
--- a/scripts/tests_generate_expected_json_5.sh
+++ b/scripts/tests_generate_expected_json_5.sh
@@ -20,6 +20,7 @@ generate_expected_json(){
     sed "s|$CURRENT_PATH|$TRAVIS_PATH|g" "$output_filename_txt" -i
 }
 
+#generate_expected_json tests/solc_version_incorrect_05.ast.json "solc-version"
 #generate_expected_json tests/uninitialized-0.5.1.sol "uninitialized-state"
 #generate_expected_json tests/backdoor.sol "backdoor"
 #generate_expected_json tests/backdoor.sol "suicidal"

--- a/scripts/travis_test_5.sh
+++ b/scripts/travis_test_5.sh
@@ -69,6 +69,7 @@ test_slither(){
 }
 
 
+test_slither tests/solc_version_incorrect_05.ast.json "solc-version"
 test_slither tests/unchecked_lowlevel-0.5.1.sol "unchecked-lowlevel"
 test_slither tests/unchecked_send-0.5.1.sol "unchecked-send"
 test_slither tests/uninitialized-0.5.1.sol "uninitialized-state"

--- a/scripts/travis_test_etherscan.sh
+++ b/scripts/travis_test_etherscan.sh
@@ -10,7 +10,7 @@ chmod +x solc-0.4.25
 
 slither 0x7F37f78cBD74481E593F9C737776F7113d76B315 --solc "./solc-0.4.25"
 
-if [ $? -ne 5 ]
+if [ $? -ne 6 ]
 then
     echo "Etherscan test failed"
     exit -1

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
@@ -1,0 +1,69 @@
+{
+  "success": true,
+  "error": null,
+  "results": {
+    "detectors": [
+      {
+        "check": "solc-version",
+        "impact": "Informational",
+        "confidence": "High",
+        "description": "Pragma version \"^0.5.5\" is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html) (None)\n",
+        "elements": [
+          {
+            "type": "pragma",
+            "name": "^0.5.5",
+            "source_mapping": {
+              "start": 63,
+              "length": 23,
+              "filename_used": "solc_version_incorrect_05.sol",
+              "filename_relative": null,
+              "filename_absolute": null,
+              "filename_short": null,
+              "lines": [],
+              "starting_column": null,
+              "ending_column": null
+            },
+            "type_specific_fields": {
+              "directive": [
+                "solidity",
+                "^",
+                "0.5",
+                ".5"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "check": "solc-version",
+        "impact": "Informational",
+        "confidence": "High",
+        "description": "Pragma version \"0.5.7\" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (None)\n",
+        "elements": [
+          {
+            "type": "pragma",
+            "name": "0.5.7",
+            "source_mapping": {
+              "start": 87,
+              "length": 22,
+              "filename_used": "solc_version_incorrect_05.sol",
+              "filename_relative": null,
+              "filename_absolute": null,
+              "filename_short": null,
+              "lines": [],
+              "starting_column": null,
+              "ending_column": null
+            },
+            "type_specific_fields": {
+              "directive": [
+                "solidity",
+                "0.5",
+                ".7"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
@@ -1,0 +1,5 @@
+INFO:Detectors:[92m
+Pragma version "^0.5.5" is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html) (None)
+Pragma version "0.5.7" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (None)
+Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-version-of-solidity[0m
+INFO:Slither:tests/solc_version_incorrect_05.ast.json analyzed (1 contracts), 2 result(s) found

--- a/tests/solc_version_incorrect_05.ast.json
+++ b/tests/solc_version_incorrect_05.ast.json
@@ -1,0 +1,82 @@
+JSON AST:
+
+
+======= solc_version_incorrect_05.sol =======
+{
+	"attributes" : 
+	{
+		"absolutePath" : "solc_version_incorrect_05.sol",
+		"exportedSymbols" : 
+		{
+			"Contract" : 
+			[
+				3
+			]
+		}
+	},
+	"children" : 
+	[
+		{
+			"attributes" : 
+			{
+				"literals" : 
+				[
+					"solidity",
+					"^",
+					"0.5",
+					".5"
+				]
+			},
+			"id" : 1,
+			"name" : "PragmaDirective",
+			"src" : "63:23:0"
+		},
+		{
+			"attributes" : 
+			{
+				"literals" : 
+				[
+					"solidity",
+					"0.5",
+					".7"
+				]
+			},
+			"id" : 2,
+			"name" : "PragmaDirective",
+			"src" : "87:22:0"
+		},
+		{
+			"attributes" : 
+			{
+				"baseContracts" : 
+				[
+					null
+				],
+				"contractDependencies" : 
+				[
+					null
+				],
+				"contractKind" : "contract",
+				"documentation" : null,
+				"fullyImplemented" : true,
+				"linearizedBaseContracts" : 
+				[
+					3
+				],
+				"name" : "Contract",
+				"nodes" : 
+				[
+					null
+				],
+				"scope" : 4
+			},
+			"id" : 3,
+			"name" : "ContractDefinition",
+			"src" : "111:21:0"
+		}
+	],
+	"id" : 4,
+	"name" : "SourceUnit",
+	"src" : "63:70:0"
+}
+======= solc_version_incorrect_05.sol:Contract =======

--- a/tests/solc_version_incorrect_05.sol
+++ b/tests/solc_version_incorrect_05.sol
@@ -1,0 +1,7 @@
+// The version pragma below should get flagged by the detector
+pragma solidity ^0.5.5;
+pragma solidity 0.5.7;
+
+contract Contract{
+
+}


### PR DESCRIPTION
Add two new types of incorrect Solidity: too new (>=5.4), and buggy versions (0.4.22, 0.5.5, 0.5.6).
Close #189