### PR TITLE
Add support for type(X) operation (creationCode, runtimeCode, name)

### DIFF
--- a/slither/core/declarations/solidity_variables.py
+++ b/slither/core/declarations/solidity_variables.py
@@ -1,6 +1,6 @@
 # https://solidity.readthedocs.io/en/v0.4.24/units-and-global-variables.html
 from slither.core.context.context import Context
-from slither.core.solidity_types import ElementaryType
+from slither.core.solidity_types import ElementaryType, TypeInformation
 
 SOLIDITY_VARIABLES = {"now":'uint256',
                       "this":'address',
@@ -57,7 +57,8 @@ SOLIDITY_FUNCTIONS = {"gasleft()":['uint256'],
                       "abi.encodeWithSelector()":["bytes"],
                       "abi.encodeWithSignature()":["bytes"],
                       # abi.decode returns an a list arbitrary types
-                      "abi.decode()":[]}
+                      "abi.decode()":[],
+                      "type(address)":[]}
 
 def solidity_function_signature(name):
     """
@@ -125,10 +126,15 @@ class SolidityVariableComposed(SolidityVariable):
 
 
 class SolidityFunction:
+    # Non standard handling of type(address). This function returns an undefined object
+    # The type is dynamic
+    # https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#type-information
+    # As a result, we set return_type during the Ir conversion
 
     def __init__(self, name):
         assert name in SOLIDITY_FUNCTIONS
         self._name = name
+        self._return_type = [ElementaryType(x) for x in SOLIDITY_FUNCTIONS[self.name]]
 
     @property
     def name(self):
@@ -140,7 +146,11 @@ class SolidityFunction:
 
     @property
     def return_type(self):
-        return [ElementaryType(x) for x in SOLIDITY_FUNCTIONS[self.name]]
+        return self._return_type
+
+    @return_type.setter
+    def return_type(self, r):
+        self._return_type = r
 
     def __str__(self):
         return self._name

--- a/slither/core/solidity_types/__init__.py
+++ b/slither/core/solidity_types/__init__.py
@@ -3,3 +3,4 @@ from .elementary_type import ElementaryType
 from .function_type import FunctionType
 from .mapping_type import MappingType
 from .user_defined_type import UserDefinedType
+from .type_information import TypeInformation

--- a/slither/core/solidity_types/type_information.py
+++ b/slither/core/solidity_types/type_information.py
@@ -1,0 +1,23 @@
+from slither.core.solidity_types.type import Type
+
+# Use to model the Type(X) function, which returns an undefined type
+# https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#type-information
+class TypeInformation(Type):
+    def __init__(self, c):
+        from slither.core.declarations.contract import Contract
+
+        assert isinstance(c, (Contract))
+        super(TypeInformation, self).__init__()
+        self._type = c
+
+    @property
+    def type(self):
+        return self._type
+
+    def __str__(self):
+        return f'type({self.type.name})'
+
+    def __eq__(self, other):
+        if not isinstance(other, TypeInformation):
+            return False
+        return self.type == other.type


### PR DESCRIPTION
This PR adds support for `type(X)` operation: https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#type-information