### PR TITLE
[WIP] Fix source mapping where utf8 char length != byte length

### DIFF
--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -21,6 +21,7 @@ class SourceMapping(Context):
             Not done in an efficient way
         """
         total_length = len(source_code)
+        source_code = source_code.encode('utf-8')
         source_code = source_code.splitlines(True)
         counter = 0
         i = 0

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -20,8 +20,8 @@ class SourceMapping(Context):
 
             Not done in an efficient way
         """
-        total_length = len(source_code)
         source_code = source_code.encode('utf-8')
+        total_length = len(source_code)
         source_code = source_code.splitlines(True)
         counter = 0
         i = 0
@@ -30,17 +30,18 @@ class SourceMapping(Context):
         ending_column = None
         while counter < total_length:
             # Determine the length of the line, and advance the line number
-            lineLength = len(source_code[i])
+            line_content = source_code[i]
+            line_length = len(line_content)
             i = i + 1
 
             # Determine our column numbers.
-            if starting_column is None and counter + lineLength > start:
+            if starting_column is None and counter + line_length > start:
                 starting_column = (start - counter) + 1
-            if starting_column is not None and ending_column is None and counter + lineLength > start + length:
+            if starting_column is not None and ending_column is None and counter + line_length > start + length:
                 ending_column = ((start + length) - counter) + 1
 
             # Advance the current position counter, and determine line numbers.
-            counter += lineLength
+            counter += line_length
             if counter > start:
                 lines.append(i)
 

--- a/tests/source_mapping.sol
+++ b/tests/source_mapping.sol
@@ -1,0 +1,22 @@
+contract A{
+
+    // ëëëëëëëëëëëëë这这这这这这这这这这
+
+    address unused;
+
+
+    address unused2;
+
+
+    // ই এই এই এইই এই এই এইই এই এই এই
+
+    address unused3;
+
+
+    address unused4;
+
+    // 这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这这
+    address used;
+
+
+}


### PR DESCRIPTION
This PR aims to resolve #251 . Source mapping was previously calculating based off of character/string length, as opposed to byte length. Source code is now encoded in utf-8 format prior to any length calculations.