### PR TITLE
API: add contract.state_variables_ordered

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -33,6 +33,7 @@ class Contract(ChildSlither, SourceMapping):
         self._structures = {}
         self._events = {}
         self._variables = {}
+        self._variables_ordered = [] # contain also shadowed variables
         self._modifiers = {}
         self._functions = {}
 
@@ -195,6 +196,13 @@ class Contract(ChildSlither, SourceMapping):
             list(StateVariable): List of the state variables.
         '''
         return list(self._variables.values())
+
+    @property
+    def state_variables_ordered(self):
+        '''
+            list(StateVariable): List of the state variables by order of declaration. Contains also shadowed variables
+        '''
+        return list(self._variables_ordered)
 
     @property
     def state_variables_inherited(self):

--- a/slither/printers/summary/variable_order.py
+++ b/slither/printers/summary/variable_order.py
@@ -23,9 +23,9 @@ class VariableOrder(AbstractPrinter):
         for contract in self.slither.contracts_derived:
             txt += '\n{}:\n'.format(contract.name)
             table = PrettyTable(['Name', 'Type'])
-            for variable in contract.state_variables:
+            for variable in contract.state_variables_ordered:
                 if not variable.is_constant:
-                    table.add_row([variable.name, str(variable.type)])
+                    table.add_row([variable.canonical_name, str(variable.type)])
             txt += str(table) + '\n'
 
         self.info(txt)

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -222,6 +222,7 @@ class ContractSolc04(Contract):
     def parse_state_variables(self):
         for father in self.inheritance_reverse:
             self._variables.update(father.variables_as_dict())
+            self._variables_ordered += father.state_variables_ordered
 
         for varNotParsed in self._variablesNotParsed:
             var = StateVariableSolc(varNotParsed)
@@ -229,6 +230,7 @@ class ContractSolc04(Contract):
             var.set_contract(self)
 
             self._variables[var.name] = var
+            self._variables_ordered.append(var)
 
     def _parse_modifier(self, modifier):
 


### PR DESCRIPTION
- Keep track of the declaration order + shadowed variables
- Print canonical name in the variable order printer
Fix #250