### PR TITLE
Fix types of inserted constants

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -227,32 +227,32 @@ class ExpressionToSlithIR(ExpressionVisitor):
             self._result.append(operation)
             set_val(expression, value)
         elif expression.type in [UnaryOperationType.PLUSPLUS_PRE]:
-            operation = Binary(value, value, Constant("1"), BinaryType.ADDITION)
+            operation = Binary(value, value, Constant("1", value.type), BinaryType.ADDITION)
             self._result.append(operation)
             set_val(expression, value)
         elif expression.type in [UnaryOperationType.MINUSMINUS_PRE]:
-            operation = Binary(value, value, Constant("1"), BinaryType.SUBTRACTION)
+            operation = Binary(value, value, Constant("1", value.type), BinaryType.SUBTRACTION)
             self._result.append(operation)
             set_val(expression, value)
         elif expression.type in [UnaryOperationType.PLUSPLUS_POST]:
             lvalue = TemporaryVariable(self._node)
             operation = Assignment(lvalue, value, value.type)
             self._result.append(operation)
-            operation = Binary(value, value, Constant("1"), BinaryType.ADDITION)
+            operation = Binary(value, value, Constant("1", value.type), BinaryType.ADDITION)
             self._result.append(operation)
             set_val(expression, lvalue)
         elif expression.type in [UnaryOperationType.MINUSMINUS_POST]:
             lvalue = TemporaryVariable(self._node)
             operation = Assignment(lvalue, value, value.type)
             self._result.append(operation)
-            operation = Binary(value, value, Constant("1"), BinaryType.SUBTRACTION)
+            operation = Binary(value, value, Constant("1", value.type), BinaryType.SUBTRACTION)
             self._result.append(operation)
             set_val(expression, lvalue)
         elif expression.type in [UnaryOperationType.PLUS_PRE]:
             set_val(expression, value)
         elif expression.type in [UnaryOperationType.MINUS_PRE]:
             lvalue = TemporaryVariable(self._node)
-            operation = Binary(lvalue, Constant("0"), value, BinaryType.SUBTRACTION)
+            operation = Binary(lvalue, Constant("0", value.type), value, BinaryType.SUBTRACTION)
             self._result.append(operation)
             set_val(expression, lvalue)
         else:


### PR DESCRIPTION
I think another case where types are incorrect is in:

```
    function addTest(uint8 a, uint32 b) external pure returns(uint32){
        return a+b;
    }
```

because the lvalue type is automatically set to `variable_left`  https://github.com/crytic/slither/blob/5d6ab217a84be5147c46476ad1ea18b000eef87b/slither/slithir/convert.py#L365


but this isn't always correct, because type of uint X+uint Y should be uint max(X,Y)   (same for int)