### PR TITLE
Support for crytic-compile exported archives + simplified main entry point

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import logging
 import os
-import subprocess
 import sys
 import traceback
 
@@ -23,7 +22,7 @@ from slither.utils.colors import red, yellow, set_colorization_enabled
 from slither.utils.command_line import (output_detectors, output_results_to_markdown,
                                         output_detectors_json, output_printers,
                                         output_to_markdown, output_wiki)
-from crytic_compile import CryticCompile
+from crytic_compile import compile_all, is_supported
 from slither.exceptions import SlitherException
 
 logging.basicConfig()
@@ -56,7 +55,7 @@ def process_single(target, args, detector_classes, printer_classes):
 
 
 def process_all(target, args, detector_classes, printer_classes):
-    compilations = CryticCompile.compile_all(target, **vars(args))
+    compilations = compile_all(target, **vars(args))
     results = []
     analyzed_contracts_count = 0
     for compilation in compilations:
@@ -579,7 +578,7 @@ def main_impl(all_detector_classes, all_printer_classes):
         filename = args.filename
 
         # Determine if we are handling ast from solc
-        if args.solc_ast:
+        if args.solc_ast or (filename.endswith('.json') and not is_supported(filename)):
             globbed_filenames = glob.glob(filename, recursive=True)
             filenames = glob.glob(os.path.join(filename, "*.json"))
             if not filenames:

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -23,7 +23,7 @@ from slither.utils.colors import red, yellow, set_colorization_enabled
 from slither.utils.command_line import (output_detectors, output_results_to_markdown,
                                         output_detectors_json, output_printers,
                                         output_to_markdown, output_wiki)
-from crytic_compile import is_supported
+from crytic_compile import CryticCompile
 from slither.exceptions import SlitherException
 
 logging.basicConfig()
@@ -35,7 +35,8 @@ logger = logging.getLogger("Slither")
 ###################################################################################
 ###################################################################################
 
-def process(filename, args, detector_classes, printer_classes):
+
+def process_single(target, args, detector_classes, printer_classes):
     """
     The core high-level code for running Slither static analysis.
 
@@ -46,11 +47,24 @@ def process(filename, args, detector_classes, printer_classes):
     if args.legacy_ast:
         ast = '--ast-json'
     args.filter_paths = parse_filter_paths(args)
-    slither = Slither(filename,
+    slither = Slither(target,
                       ast_format=ast,
+                      solc_arguments=args.solc_args,
                       **vars(args))
 
     return _process(slither, detector_classes, printer_classes)
+
+
+def process_all(target, args, detector_classes, printer_classes):
+    compilations = CryticCompile.compile_all(target, **vars(args))
+    results = []
+    analyzed_contracts_count = 0
+    for compilation in compilations:
+        (current_results, current_analyzed_count) = process_single(compilation, args, detector_classes, printer_classes)
+        results.extend(current_results)
+        analyzed_contracts_count += current_analyzed_count
+    return results, analyzed_contracts_count
+
 
 def _process(slither, detector_classes, printer_classes):
     for detector_cls in detector_classes:
@@ -75,7 +89,7 @@ def _process(slither, detector_classes, printer_classes):
     return results, analyzed_contracts_count
 
 
-def process_files(filenames, args, detector_classes, printer_classes):
+def process_from_asts(filenames, args, detector_classes, printer_classes):
     all_contracts = []
 
     for filename in filenames:
@@ -83,15 +97,9 @@ def process_files(filenames, args, detector_classes, printer_classes):
             contract_loaded = json.load(f)
             all_contracts.append(contract_loaded['ast'])
 
-    slither = Slither(all_contracts,
-                      solc=args.solc,
-                      disable_solc_warnings=args.disable_solc_warnings,
-                      solc_arguments=args.solc_args,
-                      filter_paths=parse_filter_paths(args),
-                      triage_mode=args.triage_mode,
-                      exclude_dependencies=args.exclude_dependencies)
+    return process_single(all_contracts, args, detector_classes, printer_classes)
 
-    return _process(slither, detector_classes, printer_classes)
+
 
 # endregion
 ###################################################################################
@@ -296,7 +304,7 @@ def parse_args(detector_classes, printer_classes):
 
     group_detector = parser.add_argument_group('Detectors')
     group_printer = parser.add_argument_group('Printers')
-    group_misc = parser.add_argument_group('Additional option')
+    group_misc = parser.add_argument_group('Additional options')
 
     group_detector.add_argument('--detect',
                                 help='Comma-separated list of detectors, defaults to all, '
@@ -570,28 +578,25 @@ def main_impl(all_detector_classes, all_printer_classes):
     try:
         filename = args.filename
 
-        globbed_filenames = glob.glob(filename, recursive=True)
-
-        if os.path.isfile(filename) or is_supported(filename):
-            (results, number_contracts) = process(filename, args, detector_classes, printer_classes)
-
-        elif os.path.isdir(filename) or len(globbed_filenames) > 0:
-            extension = "*.sol" if not args.solc_ast else "*.json"
-            filenames = glob.glob(os.path.join(filename, extension))
+        # Determine if we are handling ast from solc
+        if args.solc_ast:
+            globbed_filenames = glob.glob(filename, recursive=True)
+            filenames = glob.glob(os.path.join(filename, "*.json"))
             if not filenames:
                 filenames = globbed_filenames
             number_contracts = 0
             results = []
-            if args.splitted and args.solc_ast:
-                (results, number_contracts) = process_files(filenames, args, detector_classes, printer_classes)
+            if args.splitted:
+                (results, number_contracts) = process_from_asts(filenames, args, detector_classes, printer_classes)
             else:
                 for filename in filenames:
-                    (results_tmp, number_contracts_tmp) = process(filename, args, detector_classes, printer_classes)
+                    (results_tmp, number_contracts_tmp) = process_single(filename, args, detector_classes, printer_classes)
                     number_contracts += number_contracts_tmp
                     results += results_tmp
 
+        # Rely on CryticCompile to discern the underlying type of compilations.
         else:
-            raise Exception("Unrecognised file/dir path: '#{filename}'".format(filename=filename))
+            (results, number_contracts) = process_all(filename, args, detector_classes, printer_classes)
 
         if args.json:
             output_json(results, None if stdout_json else args.json)

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -61,8 +61,11 @@ class Slither(Context):
         :param path:
         :return:
         """
-        with open(path, encoding='utf8', newline='') as f:
-            self.source_code[path] = f.read()
+        if path in self.crytic_compile.src_content:
+            self.source_code[path] = self.crytic_compile.src_content[path]
+        else:
+            with open(path, encoding='utf8', newline='') as f:
+                self.source_code[path] = f.read()
 
     # endregion
     ###################################################################################

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -101,7 +101,7 @@ class SourceMapping(Context):
         else:
             filename = filename_used
 
-        if filename in slither.crytic_compile.src_content:
+        if slither.crytic_compile and filename in slither.crytic_compile.src_content:
             source_code = slither.crytic_compile.src_content[filename]
             (lines, starting_column, ending_column) = SourceMapping._compute_line(source_code,
                                                                                   s,

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -90,18 +90,23 @@ class SourceMapping(Context):
 
             is_dependency = slither.crytic_compile.is_dependency(filename_absolute)
 
-            if filename_absolute in slither.source_code:
+            if filename_absolute in slither.source_code or filename_absolute in slither.crytic_compile.src_content:
                 filename = filename_absolute
             elif filename_relative in slither.source_code:
                 filename = filename_relative
             elif filename_short in slither.source_code:
                 filename = filename_short
-            else:#
-                filename = filename_used.used
+            else:
+                filename = filename_used
         else:
             filename = filename_used
 
-        if filename in slither.source_code:
+        if filename in slither.crytic_compile.src_content:
+            source_code = slither.crytic_compile.src_content[filename]
+            (lines, starting_column, ending_column) = SourceMapping._compute_line(source_code,
+                                                                                  s,
+                                                                                  l)
+        elif filename in slither.source_code:
             source_code = slither.source_code[filename]
             (lines, starting_column, ending_column) = SourceMapping._compute_line(source_code,
                                                                                   s,

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -22,14 +22,14 @@ logger_printer = logging.getLogger("Printers")
 
 class Slither(SlitherSolc):
 
-    def __init__(self, contract, **kwargs):
+    def __init__(self, target, **kwargs):
         '''
             Args:
-                contract (str| list(json))
+                target (str | list(json) | CryticCompile)
             Keyword Args:
                 solc (str): solc binary location (default 'solc')
                 disable_solc_warnings (bool): True to disable solc warnings (default false)
-                solc_argeuments (str): solc arguments (default '')
+                solc_arguments (str): solc arguments (default '')
                 ast_format (str): ast format (default '--ast-compact-json')
                 filter_paths (list(str)): list of path to filter (default [])
                 triage_mode (bool): if true, switch to triage mode (default false)
@@ -46,14 +46,17 @@ class Slither(SlitherSolc):
 
         '''
         # list of files provided (see --splitted option)
-        if isinstance(contract, list):
-            self._init_from_list(contract)
-        elif contract.endswith('.json'):
-            self._init_from_raw_json(contract)
+        if isinstance(target, list):
+            self._init_from_list(target)
+        elif isinstance(target, str) and target.endswith('.json'):
+            self._init_from_raw_json(target)
         else:
             super(Slither, self).__init__('')
             try:
-                crytic_compile = CryticCompile(contract, **kwargs)
+                if isinstance(target, CryticCompile):
+                    crytic_compile = target
+                else:
+                    crytic_compile = CryticCompile(target, **kwargs)
                 self._crytic_compile = crytic_compile
             except InvalidCompilation as e:
                 raise SlitherError('Invalid compilation: \n'+str(e))


### PR DESCRIPTION
This pull request aims to move all glob pattern matching and other compilation related code from slither into crytic-compile, and add support for crytic-compile exported archives (in accordance with https://github.com/crytic/crytic-compile/pull/24).

For more information, read the above referenced pull request.