### PR TITLE
Fix config file 

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -46,7 +46,6 @@ def process(filename, args, detector_classes, printer_classes):
     ast = '--ast-compact-json'
     if args.legacy_ast:
         ast = '--ast-json'
-    args.filter_paths = parse_filter_paths(args)
     slither = Slither(filename,
                       ast_format=ast,
                       **vars(args))
@@ -85,7 +84,6 @@ def process_files(filenames, args, detector_classes, printer_classes):
             all_contracts.append(contract_loaded['ast'])
 
     slither = Slither(all_contracts,
-                      filter_paths=parse_filter_paths(args),
                       **vars(args))
 
     return _process(slither, detector_classes, printer_classes)
@@ -422,6 +420,8 @@ def parse_args(detector_classes, printer_classes):
 
     args = parser.parse_args()
     read_config_file(args)
+
+    args.filter_paths = parse_filter_paths(args)
 
     return args
 

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -485,6 +485,8 @@ def main_impl(all_detector_classes, all_printer_classes):
     :param all_detector_classes: A list of all detectors that can be included/excluded.
     :param all_printer_classes: A list of all printers that can be included.
     """
+    # Set logger of Slither to info, to catch warnings related to the arg parsing
+    logger.setLevel(logging.INFO)
     args = parse_args(all_detector_classes, all_printer_classes)
 
     # Set colorization option

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -1,8 +1,48 @@
+import os
+import logging
 import json
 from collections import defaultdict
 from prettytable import PrettyTable
+from crytic_compile.cryticparser.defaults import defaults_flag_in_config as defaults_flag_in_config_crytic_compile
 
 from slither.detectors.abstract_detector import classification_txt
+from .colors import yellow, red
+
+logger = logging.getLogger("Slither")
+
+# Those are the flags shared by the command line and the config file
+defaults_flag_in_config = {
+    'detectors_to_run': 'all',
+    'printers_to_run': None,
+    'detectors_to_exclude': None,
+    'exclude_dependencies': False,
+    'exclude_informational': False,
+    'exclude_low': False,
+    'exclude_medium': False,
+    'exclude_high': False,
+    'json': None,
+    'disable_color': False,
+    'filter_paths': None,
+    # debug command
+    'legacy_ast': False,
+    'ignore_return_value': False,
+    **defaults_flag_in_config_crytic_compile
+    }
+
+def read_config_file(args):
+    if os.path.isfile(args.config_file):
+        try:
+            with open(args.config_file) as f:
+                config = json.load(f)
+                for key, elem in config.items():
+                    if key not in defaults_flag_in_config:
+                        logger.info(yellow('{} has an unknown key: {} : {}'.format(args.config_file, key, elem)))
+                        continue
+                    if getattr(args, key) == defaults_flag_in_config[key]:
+                        setattr(args, key, elem)
+        except json.decoder.JSONDecodeError as e:
+            logger.error(red('Impossible to read {}, please check the file {}'.format(args.config_file, e)))
+
 
 def output_to_markdown(detector_classes, printer_classes, filter_wiki):
 


### PR DESCRIPTION
This PR fixes:
- the config file options that are not correctly sent to `crytic-compile`
- the legacy options in Slither that are not anymore relevant

See https://github.com/crytic/slither/issues/289