### PR TITLE
Add JSON output functionality for printers

### DIFF
--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -170,14 +170,20 @@ class PrinterInheritanceGraph(AbstractPrinter):
             Args:
                 filename(string)
         """
+        json_results = {}
         if filename == '':
             filename = 'contracts.dot'
         if not filename.endswith('.dot'):
             filename += ".dot"
         info = 'Inheritance Graph: ' + filename
         self.info(info)
+        json_results['filename'] = filename
         with open(filename, 'w', encoding='utf8') as f:
             f.write('digraph "" {\n')
+            json_results['digraph'] = []
             for c in self.contracts:
+                json_results['digraph'].append(self._summary(c))
                 f.write(self._summary(c))
             f.write('}')
+
+        return json_results

--- a/slither/printers/summary/contract.py
+++ b/slither/printers/summary/contract.py
@@ -20,9 +20,11 @@ class ContractSummary(AbstractPrinter):
         """
 
         txt = ""
+        json_result = {}
         for c in self.contracts:
             (name, _inheritance, _var, func_summaries, _modif_summaries) = c.get_summary()
             txt += blue("\n+ Contract %s\n"%name)
+            json_result[name] = {}
             # (c_name, f_name, visi, _, _, _, _, _) in func_summaries
             public = [(elem[0], (elem[1], elem[2]) ) for elem in func_summaries]
 
@@ -33,15 +35,24 @@ class ContractSummary(AbstractPrinter):
 
             for contract, functions in public:
                 txt += blue("  - From {}\n".format(contract))
+                json_result[name]['from'] = str(contract)
                 functions = sorted(functions)
+                json_result[name]['functions'] = {}
+                json_result[name]['functions']['visible'] = []
+                json_result[name]['functions']['invisible'] = []
+                json_result[name]['functions']['others'] = []
                 for (function, visi) in functions:
                     if visi in ['external', 'public']:
+                        json_result[name]['functions']['visible'].append({'function':function,'visi':visi})
                         txt += green("    - {} ({})\n".format(function, visi))
                 for (function, visi) in functions:
                     if visi in ['internal', 'private']:
+                        json_result[name]['functions']['invisible'].append({'function':function,'visi':visi})
                         txt += magenta("    - {} ({})\n".format(function, visi))
                 for (function, visi) in functions:
                     if visi not in ['external', 'public', 'internal', 'private']:
+                        json_result[name]['functions']['others'].append({'function':function,'visi':visi})
                         txt += "    - {}  ({})\n".format(function, visi)
 
         self.info(txt)
+        return json_result

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -155,7 +155,18 @@ class Slither(SlitherSolc):
         :return: List of registered printers outputs.
         """
 
-        return [p.output(self.filename) for p in self._printers]
+        results = []
+
+        for p in self._printers:
+            result = p.output(self.filename)
+            result['name'] = p.ARGUMENT
+            if 'filename' in result:
+                result['result_type'] = 'graph'
+            else:
+                result['result_type'] = 'text'
+
+            results.append(result)
+        return results
 
     def _check_common_things(self, thing_name, cls, base_cls, instances_list):
 

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -11,8 +11,7 @@ from .colors import yellow, red
 logger = logging.getLogger("Slither")
 
 DEFAULT_JSON_OUTPUT_TYPES = ["detectors"]
-JSON_OUTPUT_TYPES = ["compilations", "console", "detectors", "list-detectors", "list-printers"]
-
+JSON_OUTPUT_TYPES = ["compilations", "console", "detectors", "list-detectors", "list-printers","printers"]
 
 # Those are the flags shared by the command line and the config file
 defaults_flag_in_config = {


### PR DESCRIPTION
This changes the code to return the result as output if --json argument
is passed to printers.

Solves https://github.com/crytic/slither/issues/286