### PR TITLE
[WIP]Printer: constructor summary

### DIFF
--- a/examples/printers/constructors.sol
+++ b/examples/printers/constructors.sol
@@ -1,0 +1,26 @@
+pragma solidity >=0.4.22 <0.6.0;
+contract test{
+    uint a;
+    constructor()public{
+        a =5;
+    }
+    
+}
+contract test2 is test{
+    constructor()public{
+        a=10;
+    }
+}
+contract test3 is test2{
+    address owner;
+    bytes32 name;
+    constructor(bytes32 _name)public{
+        owner = msg.sender;
+        name = _name;
+        a=20;
+    }
+    function print() public returns(uint b){
+        b=a;
+
+    }
+}

--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -13,3 +13,4 @@ from .summary.variable_order import VariableOrder
 from .summary.data_depenency import DataDependency
 from .summary.modifier_calls import Modifiers
 from .summary.require_calls import RequireOrAssert
+from .summary.constructor_calls import ConstructorPrinter

--- a/slither/printers/summary/constructor_calls.py
+++ b/slither/printers/summary/constructor_calls.py
@@ -1,0 +1,47 @@
+"""
+    Module printing summary of the contract
+"""
+from slither.printers.abstract_printer import AbstractPrinter
+
+
+
+class ConstructorPrinter(AbstractPrinter):
+	WIKI = 'https://github.com/crytic/slither/wiki/Printer-documentation#constructor-calls'
+	ARGUMENT = 'constructor-calls'	
+	HELP = 'Print the constructors executed'
+	
+	def _get_soruce_code(self,cst):
+		src_mapping = cst.source_mapping	
+		content= self.slither.source_code[src_mapping['filename_absolute']]
+		start = src_mapping['start']
+		end = src_mapping['start'] + src_mapping['length']
+		initial_space = src_mapping['starting_column']
+		return ' ' * initial_space + content[start:end]
+
+	def output(self,_filename):
+		for contract in self.contracts:
+			stack_name = []
+			stack_definition = []
+			print("\n\nContact Name:",contract.name)
+			print("	Constructor Call Sequence: ", sep=' ', end='', flush=True)
+			cst = contract.constructors_declared
+			if cst:
+				stack_name.append(contract.name)
+				stack_definition.append(self._get_soruce_code(cst))
+			for inherited_contract in contract.inheritance:
+				cst = inherited_contract.constructors_declared
+				if cst:
+					stack_name.append(inherited_contract.name)
+					stack_definition.append(self._get_soruce_code(cst))
+			if len(stack_name)>0:
+				print(" ",stack_name[len(stack_name)-1], sep=' ', end='', flush=True)
+				count = len(stack_name)-2;
+				while count>=0:
+					print("-->",stack_name[count], sep=' ', end='', flush=True)
+					count= count-1;
+				print("\n Constructor Definitions:")
+				count = len(stack_definition)-1
+				while count>=0:
+					print("\n Contract name:", stack_name[count])
+					print ("\n", stack_definition[count])
+					count = count-1;


### PR DESCRIPTION
Till now it gets an instance of constructors from all the contract following c3 linearization and prints internal call instead of the inline version of the constructor.
Also, I have a question, is there something pre-written to get the inline form of function (that i am not able to find) or do I have to write it?
Please point me in the right direction.

This pr is for issue #271 