### PR TITLE
Refactor reentrancy + API changes

### DIFF
--- a/slither/core/cfg/node.py
+++ b/slither/core/cfg/node.py
@@ -200,6 +200,10 @@ class Node(SourceMapping, ChildFunction):
         self._expression_vars_read = []
         self._expression_calls = []
 
+        # Computed on the fly, can be True of False
+        self._can_reenter = None
+        self._can_send_eth = None
+
     ###################################################################################
     ###################################################################################
     # region General's properties
@@ -401,6 +405,39 @@ class Node(SourceMapping, ChildFunction):
     @property
     def calls_as_expression(self):
         return list(self._expression_calls)
+
+    def can_reenter(self, callstack=None):
+        '''
+        Check if the node can re-enter
+        Do not consider CREATE as potential re-enter, but check if the
+        destination's constructor can contain a call (recurs. follow nested CREATE)
+        For Solidity > 0.5, filter access to public variables and constant/pure/view
+        For call to this. check if the destination can re-enter
+        Do not consider Send/Transfer as there is not enough gas
+        :param callstack: used internally to check for recursion
+        :return bool:
+        '''
+        from slither.slithir.operations import Call
+        if self._can_reenter is None:
+            self._can_reenter = False
+            for ir in self.irs:
+                if isinstance(ir, Call) and ir.can_reenter(callstack):
+                    self._can_reenter = True
+                    return True
+        return self._can_reenter
+
+    def can_send_eth(self):
+        '''
+        Check if the node can send eth
+        :return bool:
+        '''
+        from slither.slithir.operations import Call
+        if self._can_send_eth is None:
+            for ir in self.all_slithir_operations():
+                if isinstance(ir, Call) and ir.can_send_eth():
+                    self._can_send_eth = True
+                    return True
+        return self._can_reenter
 
     # endregion
     ###################################################################################

--- a/slither/core/children/child_node.py
+++ b/slither/core/children/child_node.py
@@ -18,3 +18,7 @@ class ChildNode(object):
     @property
     def contract(self):
         return self.node.function.contract
+
+    @property
+    def slither(self):
+        return self.contract.slither

--- a/slither/slithir/operations/call.py
+++ b/slither/slithir/operations/call.py
@@ -15,3 +15,16 @@ class Call(Operation):
     def arguments(self, v):
         self._arguments = v
 
+    def can_reenter(self, callstack=None):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        return False
+
+    def can_send_eth(self):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        return False

--- a/slither/slithir/operations/library_call.py
+++ b/slither/slithir/operations/library_call.py
@@ -9,6 +9,18 @@ class LibraryCall(HighLevelCall):
     def _check_destination(self, destination):
         assert isinstance(destination, (Contract))
 
+    def can_reenter(self, callstack=None):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        # In case of recursion, return False
+        callstack = [] if callstack is None else callstack
+        if self.function in callstack:
+            return False
+        callstack = callstack + [self.function]
+        return self.function.can_reenter(callstack)
+
     def __str__(self):
         gas = ''
         if self.call_gas:

--- a/slither/slithir/operations/low_level_call.py
+++ b/slither/slithir/operations/low_level_call.py
@@ -54,6 +54,20 @@ class LowLevelCall(Call, OperationWithLValue):
         # remove None
         return self._unroll([x for x in all_read if x])
 
+    def can_reenter(self, callstack=None):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        return True
+
+    def can_send_eth(self):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        return self._call_value is not None
+
     @property
     def destination(self):
         return self._destination

--- a/slither/slithir/operations/new_contract.py
+++ b/slither/slithir/operations/new_contract.py
@@ -31,15 +31,51 @@ class NewContract(Call, OperationWithLValue):
     def call_id(self, c):
         self._callid = c
 
-
     @property
     def contract_name(self):
         return self._contract_name
 
-
     @property
     def read(self):
         return self._unroll(self.arguments)
+
+    @property
+    def contract_created(self):
+        contract_name = self.contract_name
+        contract_instance = self.slither.get_contract_from_name(contract_name)
+        return contract_instance
+
+    ###################################################################################
+    ###################################################################################
+    # region Analyses
+    ###################################################################################
+    ###################################################################################
+
+    def can_reenter(self, callstack=None):
+        '''
+        Must be called after slithIR analysis pass
+        For Solidity > 0.5, filter access to public variables and constant/pure/view
+        For call to this. check if the destination can re-enter
+        :param callstack: check for recursion
+        :return: bool
+        '''
+        callstack = [] if callstack is None else callstack
+        constructor = self.contract_created.constructor
+        if constructor is None:
+            return False
+        if constructor in callstack:
+            return False
+        callstack = callstack + [constructor]
+        return constructor.can_reenter(callstack)
+
+    def can_send_eth(self):
+        '''
+        Must be called after slithIR analysis pass
+        :return: bool
+        '''
+        return self._call_value is not None
+
+    # endregion
 
     def __str__(self):
         value = ''

--- a/slither/utils/function.py
+++ b/slither/utils/function.py
@@ -1,4 +1,3 @@
-import hashlib
 import sha3
 
 def get_function_id(sig):


### PR DESCRIPTION
This PR cleans the reentrancy fix point module by moving part of the logic to the IR level. The reentrancy detector will be easier to read and maintain. Additionally, other modules can benefit from the re-enter and ethers sent information. 

Changes: 

- Create `can_renter` and `can_send_ether` functions for all the `Call` IRs. Additionally, these functions are accessible at the `node` and `function` level.
- Add support for create-based reentrancy (https://github.com/crytic/slither/issues/310)

This PR needs extra testing to ensure that the heuristics are correctly conserved. 