### PR TITLE
Added solc-select to installation section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Num | Printer | Description
 
 ## How to install
 
-Slither requires Python 3.6+ and [solc](https://github.com/ethereum/solidity/), the Solidity compiler.
+Slither requires Python 3.6+ and [solc](https://github.com/ethereum/solidity/), the Solidity compiler. 
+
+If your contracts require older versions of solc, [solc-select](https://github.com/crytic/solc-select) will allow you to easily switch between Solidity compiler versions on any platform. It's like NVM, for solc.
 
 ### Using Pip
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Run Slither on a single file:
 $ slither tests/uninitialized.sol 
 ``` 
 
-For additional configuration, see the [usage](https://github.com/trailofbits/slither/wiki/Usage) documentation.
+For additional configuration, see the [usage](https://github.com/trailofbits/slither/wiki/Usage) documentation. 
+
+Use [solc-select](https://github.com/crytic/solc-select) if your contracts require older versions of solc.
 
 ## Detectors
 
@@ -105,8 +107,6 @@ Num | Printer | Description
 ## How to install
 
 Slither requires Python 3.6+ and [solc](https://github.com/ethereum/solidity/), the Solidity compiler. 
-
-If your contracts require older versions of solc, [solc-select](https://github.com/crytic/solc-select) will allow you to easily switch between Solidity compiler versions on any platform. It's like NVM, for solc.
 
 ### Using Pip
 


### PR DESCRIPTION
Banged my head against the wall for hours trying to install older versions of solc to test Slither. Turns out, I could've skipped all that by just using [solc-select](https://github.com/crytic/solc-select). It's an amazing tool. It just works. I love it. Added a few sentences to the README to recommend using solc-select for older contracts.