### PR TITLE
Improve external function detector: merge together shadowed function

### DIFF
--- a/scripts/travis_test_dapp.sh
+++ b/scripts/travis_test_dapp.sh
@@ -17,7 +17,7 @@ dapp init
 
 slither .
 
-if [ $? -eq 23 ]
+if [ $? -eq 22 ]
 then  
     exit 0
 fi

--- a/scripts/travis_test_etherscan.sh
+++ b/scripts/travis_test_etherscan.sh
@@ -18,7 +18,7 @@ fi
 
 slither rinkeby:0xFe05820C5A92D9bc906D4A46F662dbeba794d3b7 --solc "./solc-0.4.25"
 
-if [ $? -ne 75 ]
+if [ $? -ne 70 ]
 then
     echo "Etherscan test failed"
     exit -1

--- a/tests/expected_json/external_function.external-function.json
+++ b/tests/expected_json/external_function.external-function.json
@@ -7,7 +7,7 @@
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High",
-        "description": "ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15) should be declared external\n",
+        "description": "funcNotCalled3() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15)\n",
         "elements": [
           {
             "type": "function",
@@ -74,7 +74,7 @@
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High",
-        "description": "ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19) should be declared external\n",
+        "description": "funcNotCalled2() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19)\n",
         "elements": [
           {
             "type": "function",
@@ -141,7 +141,7 @@
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High",
-        "description": "ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23) should be declared external\n",
+        "description": "funcNotCalled() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23)\n",
         "elements": [
           {
             "type": "function",
@@ -208,7 +208,7 @@
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High",
-        "description": "ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39) should be declared external\n",
+        "description": "funcNotCalled() should be declared external:\n\t- ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39)\n",
         "elements": [
           {
             "type": "function",
@@ -271,7 +271,7 @@
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High",
-        "description": "FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76) should be declared external\n",
+        "description": "parameter_read_ok_for_external(uint256) should be declared external:\n\t- FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76)\n",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/external_function.external-function.txt
+++ b/tests/expected_json/external_function.external-function.txt
@@ -1,8 +1,13 @@
-INFO:Detectors:[92m
-ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15) should be declared external
-ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19) should be declared external
-ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23) should be declared external
-ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39) should be declared external
-FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76) should be declared external
+[92m
+funcNotCalled3() should be declared external:
+	- ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15)
+funcNotCalled2() should be declared external:
+	- ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19)
+funcNotCalled() should be declared external:
+	- ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23)
+funcNotCalled() should be declared external:
+	- ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39)
+parameter_read_ok_for_external(uint256) should be declared external:
+	- FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#public-function-that-could-be-declared-as-external[0m
-INFO:Slither:tests/external_function.sol analyzed (6 contracts), 5 result(s) found
+tests/external_function.sol analyzed (6 contracts with 1 detectors), 5 result(s) found

--- a/tests/expected_json/external_function_2.external-function.txt
+++ b/tests/expected_json/external_function_2.external-function.txt
@@ -1,1 +1,1 @@
-INFO:Slither:tests/external_function_2.sol analyzed (4 contracts), 0 result(s) found
+tests/external_function_2.sol analyzed (4 contracts with 1 detectors), 0 result(s) found


### PR DESCRIPTION
For example
```solidity
contract C{
    function f() public{

    }
}

contract D is C{
    function f() public{
        
    }
}

contract E{
    function f() public{
        
    }
}
```

Will result in
```
f() should be declared external:
	- C.f() (a.sol#2-4)
	- D.f() (a.sol#8-10)
f() should be declared external:
	- E.f() (a.sol#14-16)
```

The goal is to facilitate review of the finding. If the visibility is changed in the most derived contract, it must be changed in the base too. It will help the upcoming [slither-format](https://github.com/crytic/slither/pull/238) tool