### PR TITLE
Add ID to result

### DIFF
--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -1,6 +1,6 @@
 import abc
 import re
-
+import hashlib
 from slither.utils.colors import green, yellow, red
 from slither.core.source_mapping.source_mapping import SourceMapping
 from collections import OrderedDict
@@ -145,6 +145,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         d['impact'] = classification_txt[self.IMPACT]
         d['confidence'] = classification_txt[self.CONFIDENCE]
         d['description'] = info
+        d['id'] = hashlib.sha3_256(info.encode('utf-8')).hexdigest()
         d['elements'] = []
         if additional_fields:
             d['additional_fields'] = additional_fields

--- a/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.json
+++ b/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Test.direct() (tests/arbitrary_send-0.5.1.sol#11-13) sends eth to arbitrary user\n\tDangerous calls:\n\t- msg.sender.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#12)\n",
+        "id": "3b375111b21cd2d954cf4a0a640981026a98f899e0b5b149f9aedfe5393bb2b7",
         "elements": [
           {
             "type": "function",
@@ -198,6 +199,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Test.indirect() (tests/arbitrary_send-0.5.1.sol#19-21) sends eth to arbitrary user\n\tDangerous calls:\n\t- destination.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#20)\n",
+        "id": "35106a86d6fd08e7c63c8a0c03fa82c804a169cb1f82a83e339d668342b6dd1a",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.txt
+++ b/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Test.direct() (tests/arbitrary_send-0.5.1.sol#11-13) sends eth to arbitrary user
 	Dangerous calls:
 	- msg.sender.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#12)
@@ -6,4 +6,4 @@ Test.indirect() (tests/arbitrary_send-0.5.1.sol#19-21) sends eth to arbitrary us
 	Dangerous calls:
 	- destination.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#20)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#functions-that-send-ether-to-arbitrary-destinations[0m
-INFO:Slither:tests/arbitrary_send-0.5.1.sol analyzed (1 contracts), 2 result(s) found
+tests/arbitrary_send-0.5.1.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/arbitrary_send.arbitrary-send.json
+++ b/tests/expected_json/arbitrary_send.arbitrary-send.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Test.direct() (tests/arbitrary_send.sol#11-13) sends eth to arbitrary user\n\tDangerous calls:\n\t- msg.sender.send(address(this).balance) (tests/arbitrary_send.sol#12)\n",
+        "id": "9aea825c9ddcff49049b63948ac53375be9c799a0b850d4b0633257c68404a75",
         "elements": [
           {
             "type": "function",
@@ -198,6 +199,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Test.indirect() (tests/arbitrary_send.sol#19-21) sends eth to arbitrary user\n\tDangerous calls:\n\t- destination.send(address(this).balance) (tests/arbitrary_send.sol#20)\n",
+        "id": "60297dad9b02f0c918fdb7caa0a76a1865ddbd1f32ad360918ac1e5a6f06e634",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/arbitrary_send.arbitrary-send.txt
+++ b/tests/expected_json/arbitrary_send.arbitrary-send.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Test.direct() (tests/arbitrary_send.sol#11-13) sends eth to arbitrary user
 	Dangerous calls:
 	- msg.sender.send(address(this).balance) (tests/arbitrary_send.sol#12)
@@ -6,4 +6,4 @@ Test.indirect() (tests/arbitrary_send.sol#19-21) sends eth to arbitrary user
 	Dangerous calls:
 	- destination.send(address(this).balance) (tests/arbitrary_send.sol#20)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#functions-that-send-ether-to-arbitrary-destinations[0m
-INFO:Slither:tests/arbitrary_send.sol analyzed (1 contracts), 2 result(s) found
+tests/arbitrary_send.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/backdoor.backdoor.json
+++ b/tests/expected_json/backdoor.backdoor.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Backdoor function found in C.i_am_a_backdoor (tests/backdoor.sol#4-6)\n",
+        "id": "64424db57d23e5486f22aebc453ca8e4f66923f73a1334e2cd9cf68e16a28df4",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/backdoor.backdoor.txt
+++ b/tests/expected_json/backdoor.backdoor.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[91m
+[91m
 Backdoor function found in C.i_am_a_backdoor (tests/backdoor.sol#4-6)
 Reference: https://github.com/trailofbits/slither/wiki/Adding-a-new-detector[0m
+tests/backdoor.sol analyzed (1 contracts with 1 detectors), 1 result(s) found
 INFO:Slither:[93m/home/travis/build/crytic/slither/scripts/../tests/expected_json/backdoor.backdoor.json exists already, the overwrite is prevented[0m
-INFO:Slither:tests/backdoor.sol analyzed (1 contracts), 1 result(s) found

--- a/tests/expected_json/backdoor.suicidal.json
+++ b/tests/expected_json/backdoor.suicidal.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "C.i_am_a_backdoor() (tests/backdoor.sol#4-6) allows anyone to destruct the contract\n",
+        "id": "d9be2dd6f026802003d72fda6bef529c7c822fd485d6e8f17f3e3dcff09692db",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/backdoor.suicidal.txt
+++ b/tests/expected_json/backdoor.suicidal.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[91m
+[91m
 C.i_am_a_backdoor() (tests/backdoor.sol#4-6) allows anyone to destruct the contract
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#suicidal[0m
+tests/backdoor.sol analyzed (1 contracts with 1 detectors), 1 result(s) found
 INFO:Slither:[93m/home/travis/build/crytic/slither/scripts/../tests/expected_json/backdoor.suicidal.json exists already, the overwrite is prevented[0m
-INFO:Slither:tests/backdoor.sol analyzed (1 contracts), 1 result(s) found

--- a/tests/expected_json/const_state_variables.constable-states.json
+++ b/tests/expected_json/const_state_variables.constable-states.json
@@ -8,6 +8,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "A.myFriendsAddress should be constant (tests/const_state_variables.sol#7)\n",
+        "id": "1a4c092820648dc42cc363ed243103df2ed0e0ecbb5c3ca9b0f9913b2807bf7f",
         "elements": [
           {
             "type": "variable",
@@ -71,6 +72,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "A.test should be constant (tests/const_state_variables.sol#10)\n",
+        "id": "975bd46f17739b37cf8a8fc7ad9d0c13f24cff34f51da57a2b270cf65bdf96d8",
         "elements": [
           {
             "type": "variable",
@@ -134,6 +136,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "A.text2 should be constant (tests/const_state_variables.sol#14)\n",
+        "id": "92938db1d8d7251741c6102cadbd5f5fd51adf45437243ea0f03e48a381f44fe",
         "elements": [
           {
             "type": "variable",
@@ -197,6 +200,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "B.mySistersAddress should be constant (tests/const_state_variables.sol#26)\n",
+        "id": "f3bf2450f5d8b97fb4adf6a12474392a9597664c77eaf47f4b1bcac14119aa9f",
         "elements": [
           {
             "type": "variable",
@@ -256,6 +260,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "MyConc.should_be_constant should be constant (tests/const_state_variables.sol#42)\n",
+        "id": "ef5c9c1bbfbd5d5db45431109b6c6155b734715b9fc5b7de716f8b3e016d7c8f",
         "elements": [
           {
             "type": "variable",
@@ -315,6 +320,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "MyConc.should_be_constant_2 should be constant (tests/const_state_variables.sol#43)\n",
+        "id": "3bf4fb0466420ac74a39c40e095663fd0868366202421b6bb82f52fb72a75438",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/const_state_variables.constable-states.txt
+++ b/tests/expected_json/const_state_variables.constable-states.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 A.myFriendsAddress should be constant (tests/const_state_variables.sol#7)
 A.test should be constant (tests/const_state_variables.sol#10)
 A.text2 should be constant (tests/const_state_variables.sol#14)
@@ -6,4 +6,4 @@ B.mySistersAddress should be constant (tests/const_state_variables.sol#26)
 MyConc.should_be_constant should be constant (tests/const_state_variables.sol#42)
 MyConc.should_be_constant_2 should be constant (tests/const_state_variables.sol#43)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#state-variables-that-could-be-declared-constant[0m
-INFO:Slither:tests/const_state_variables.sol analyzed (3 contracts), 6 result(s) found
+tests/const_state_variables.sol analyzed (3 contracts with 1 detectors), 6 result(s) found

--- a/tests/expected_json/constant-0.5.1.constant-function.json
+++ b/tests/expected_json/constant-0.5.1.constant-function.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "Constant.test_assembly_bug() (tests/constant-0.5.1.sol#15-17) is declared view but contains assembly code\n",
+        "id": "d236e087130bf825b0e459ba72c8781d4ddd72c1041b3b673dc25e7e73cbfefa",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/constant-0.5.1.constant-function.txt
+++ b/tests/expected_json/constant-0.5.1.constant-function.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 Constant.test_assembly_bug() (tests/constant-0.5.1.sol#15-17) is declared view but contains assembly code
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#constant-functions-changing-the-state[0m
-INFO:Slither:tests/constant-0.5.1.sol analyzed (1 contracts), 1 result(s) found
+tests/constant-0.5.1.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/constant.constant-function.json
+++ b/tests/expected_json/constant.constant-function.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "Constant.test_view_bug() (tests/constant.sol#5-7) is declared view but changes state variables:\n\t- Constant.a\n",
+        "id": "e853a0910b549fd363941ecf228d93901ddfd2c06e47d320077dc1484f8dfcc6",
         "elements": [
           {
             "type": "function",
@@ -146,6 +147,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "Constant.test_constant_bug() (tests/constant.sol#9-11) is declared view but changes state variables:\n\t- Constant.a\n",
+        "id": "cf043b93a82439d650956ef7b36f0e2fb650d1a5490e339c4373921266fd316d",
         "elements": [
           {
             "type": "function",
@@ -284,6 +286,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "Constant.test_assembly_bug() (tests/constant.sol#22-24) is declared view but contains assembly code\n",
+        "id": "d06d0afaaa673fad61cd4d66c43f957eb6ae007394298c4405459d161e8f8e6f",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/constant.constant-function.txt
+++ b/tests/expected_json/constant.constant-function.txt
@@ -1,8 +1,8 @@
-INFO:Detectors:[93m
+[93m
 Constant.test_view_bug() (tests/constant.sol#5-7) is declared view but changes state variables:
 	- Constant.a
 Constant.test_constant_bug() (tests/constant.sol#9-11) is declared view but changes state variables:
 	- Constant.a
 Constant.test_assembly_bug() (tests/constant.sol#22-24) is declared view but contains assembly code
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#constant-functions-changing-the-state[0m
-INFO:Slither:tests/constant.sol analyzed (1 contracts), 3 result(s) found
+tests/constant.sol analyzed (1 contracts with 1 detectors), 3 result(s) found

--- a/tests/expected_json/controlled_delegatecall.controlled-delegatecall.json
+++ b/tests/expected_json/controlled_delegatecall.controlled-delegatecall.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "C.bad_delegate_call (tests/controlled_delegatecall.sol#8-11) uses delegatecall to a input-controlled function id\n\t- addr_bad.delegatecall(data) (tests/controlled_delegatecall.sol#10)\n",
+        "id": "ae344f39154de3bf3a8248876f20cf02b98890de8dd35ffce1236a3cdeafabd0",
         "elements": [
           {
             "type": "node",
@@ -168,6 +169,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "C.bad_delegate_call2 (tests/controlled_delegatecall.sol#18-20) uses delegatecall to a input-controlled function id\n\t- addr_bad.delegatecall(abi.encode(func_id,data)) (tests/controlled_delegatecall.sol#19)\n",
+        "id": "de4d6d4efba2bdd2007f3750379a7ee977135fb62122be091db05cdc127c66dc",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/controlled_delegatecall.controlled-delegatecall.txt
+++ b/tests/expected_json/controlled_delegatecall.controlled-delegatecall.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[91m
+[91m
 C.bad_delegate_call (tests/controlled_delegatecall.sol#8-11) uses delegatecall to a input-controlled function id
 	- addr_bad.delegatecall(data) (tests/controlled_delegatecall.sol#10)
 C.bad_delegate_call2 (tests/controlled_delegatecall.sol#18-20) uses delegatecall to a input-controlled function id
 	- addr_bad.delegatecall(abi.encode(func_id,data)) (tests/controlled_delegatecall.sol#19)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#controlled-delegatecall[0m
-INFO:Slither:tests/controlled_delegatecall.sol analyzed (1 contracts), 2 result(s) found
+tests/controlled_delegatecall.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/deprecated_calls.deprecated-standards.json
+++ b/tests/expected_json/deprecated_calls.deprecated-standards.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#2:\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "00e5d4c65c1493bfdf0c9be0dca5c7ce3506420857104037302494df21a27a54",
         "elements": [
           {
             "type": "variable",
@@ -80,6 +81,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#7:\n\t- Usage of \"msg.gas\" should be replaced with \"gasleft()\"\n",
+        "id": "89a0c4ed3b19342f586e2b01b888d85d46f014666c0dd363f98d2dbaee21e704",
         "elements": [
           {
             "type": "node",
@@ -179,6 +181,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#9:\n\t- Usage of \"throw\" should be replaced with \"revert()\"\n",
+        "id": "f596c5e1437dd68c3006885439809116317c0c430f84848217befc0e7b08cb64",
         "elements": [
           {
             "type": "node",
@@ -278,6 +281,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#16:\n\t- Usage of \"sha3()\" should be replaced with \"keccak256()\"\n",
+        "id": "2e37f09c18adbe1b38887578cb1353aed05b09f1d505c6fd57af5b9198e62b2b",
         "elements": [
           {
             "type": "node",
@@ -383,6 +387,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#19:\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "d11fc399439127b2f2566865a588c8b8bdf610bc12a3e051992946a91b991ba8",
         "elements": [
           {
             "type": "node",
@@ -488,6 +493,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#22:\n\t- Usage of \"callcode\" should be replaced with \"delegatecall\"\n",
+        "id": "b931ee9bc5f8601df6805f37dab44a193a68271d1e4566b4dc54e2b44d14e233",
         "elements": [
           {
             "type": "node",
@@ -593,6 +599,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#25:\n\t- Usage of \"suicide()\" should be replaced with \"selfdestruct()\"\n",
+        "id": "0090eb0b9539af6f858e7a671ccd71d4f552f2f636e64dc5554fd5c2b5a1b6b4",
         "elements": [
           {
             "type": "node",
@@ -698,6 +705,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Deprecated standard detected @ tests/deprecated_calls.sol#2:\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "00e5d4c65c1493bfdf0c9be0dca5c7ce3506420857104037302494df21a27a54",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/deprecated_calls.deprecated-standards.txt
+++ b/tests/expected_json/deprecated_calls.deprecated-standards.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 Deprecated standard detected @ tests/deprecated_calls.sol#2:
 	- Usage of "block.blockhash()" should be replaced with "blockhash()"
 Deprecated standard detected @ tests/deprecated_calls.sol#7:
@@ -16,4 +16,4 @@ Deprecated standard detected @ tests/deprecated_calls.sol#25:
 Deprecated standard detected @ tests/deprecated_calls.sol#2:
 	- Usage of "block.blockhash()" should be replaced with "blockhash()"
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#deprecated-standards[0m
-INFO:Slither:tests/deprecated_calls.sol analyzed (1 contracts), 8 result(s) found
+tests/deprecated_calls.sol analyzed (1 contracts with 1 detectors), 8 result(s) found

--- a/tests/expected_json/erc20_indexed.erc20-indexed.json
+++ b/tests/expected_json/erc20_indexed.erc20-indexed.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "ERC20 event IERC20Bad.Transfer (tests/erc20_indexed.sol#19) does not index parameter 'from'\n",
+        "id": "2f96b334aa58d2ad33e95425f2da4d9fbd5a6bee97ba8878fc3282b3ea3c2a78",
         "elements": [
           {
             "type": "event",
@@ -67,6 +68,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "ERC20 event IERC20Bad.Transfer (tests/erc20_indexed.sol#19) does not index parameter 'to'\n",
+        "id": "155f98b1b4b7a0c3de451cbe8d4e849aff012a380123fb9427b83b6e22b2dd5a",
         "elements": [
           {
             "type": "event",
@@ -126,6 +128,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "ERC20 event IERC20Bad.Approval (tests/erc20_indexed.sol#20) does not index parameter 'owner'\n",
+        "id": "90d2722a1ceeee85bde7460f35a11b393bf80676a0b74d62c6924a416b4b90b3",
         "elements": [
           {
             "type": "event",
@@ -185,6 +188,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "ERC20 event IERC20Bad.Approval (tests/erc20_indexed.sol#20) does not index parameter 'spender'\n",
+        "id": "39e4819f04f95b815c4f51eb1c392313635a0cbb0fd7e6337bf8c436e395b90c",
         "elements": [
           {
             "type": "event",

--- a/tests/expected_json/erc20_indexed.erc20-indexed.txt
+++ b/tests/expected_json/erc20_indexed.erc20-indexed.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[92m
+[92m
 ERC20 event IERC20Bad.Transfer (tests/erc20_indexed.sol#19) does not index parameter 'from'
 ERC20 event IERC20Bad.Transfer (tests/erc20_indexed.sol#19) does not index parameter 'to'
 ERC20 event IERC20Bad.Approval (tests/erc20_indexed.sol#20) does not index parameter 'owner'
 ERC20 event IERC20Bad.Approval (tests/erc20_indexed.sol#20) does not index parameter 'spender'
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unindexed-erc20-event-parameters[0m
-INFO:Slither:tests/erc20_indexed.sol analyzed (3 contracts), 4 result(s) found
+tests/erc20_indexed.sol analyzed (3 contracts with 1 detectors), 4 result(s) found

--- a/tests/expected_json/external_function.external-function.json
+++ b/tests/expected_json/external_function.external-function.json
@@ -8,6 +8,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15) should be declared external\n",
+        "id": "dd35cb62b6abb436ad5e8278e3090147644cd3b844db7ab4894b84fb7c161753",
         "elements": [
           {
             "type": "function",
@@ -75,6 +76,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19) should be declared external\n",
+        "id": "ac83cce7722a702357d0222107758b97c16f20457a1f0e421b26c6fa52522e6e",
         "elements": [
           {
             "type": "function",
@@ -142,6 +144,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23) should be declared external\n",
+        "id": "6841be19041b6a9fbf82aafd165dc041f9c3b78ae89d9f70a46767679d56ed46",
         "elements": [
           {
             "type": "function",
@@ -209,6 +212,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39) should be declared external\n",
+        "id": "805a9726b2f8bea6c529e32823c64de1626915020827675a4a1671b8f1f36002",
         "elements": [
           {
             "type": "function",
@@ -272,6 +276,7 @@
         "impact": "Optimization",
         "confidence": "High",
         "description": "FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76) should be declared external\n",
+        "id": "784919e6078665bcbffacda08fd2e733c1eeed72f949820cb4e18c21e4d0425d",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/external_function.external-function.txt
+++ b/tests/expected_json/external_function.external-function.txt
@@ -1,8 +1,8 @@
-INFO:Detectors:[92m
+[92m
 ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15) should be declared external
 ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19) should be declared external
 ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23) should be declared external
 ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39) should be declared external
 FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76) should be declared external
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#public-function-that-could-be-declared-as-external[0m
-INFO:Slither:tests/external_function.sol analyzed (6 contracts), 5 result(s) found
+tests/external_function.sol analyzed (6 contracts with 1 detectors), 5 result(s) found

--- a/tests/expected_json/external_function_2.external-function.txt
+++ b/tests/expected_json/external_function_2.external-function.txt
@@ -1,1 +1,1 @@
-INFO:Slither:tests/external_function_2.sol analyzed (4 contracts), 0 result(s) found
+tests/external_function_2.sol analyzed (4 contracts with 1 detectors), 0 result(s) found

--- a/tests/expected_json/incorrect_equality.incorrect-equality.json
+++ b/tests/expected_json/incorrect_equality.incorrect-equality.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "ERC20TestBalance.bad0(ERC20Function) (tests/incorrect_equality.sol#21-23) uses a dangerous strict equality:\n\t- require(bool)(erc.balanceOf(address(this)) == 10)\n",
+        "id": "61d72cda908d4aa7deedcbd6de0d51b990c03b75a46b7e0e427c609fe30473d5",
         "elements": [
           {
             "type": "node",
@@ -154,6 +155,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "ERC20TestBalance.bad1(ERC20Variable) (tests/incorrect_equality.sol#25-27) uses a dangerous strict equality:\n\t- require(bool)(erc.balanceOf(msg.sender) == 10)\n",
+        "id": "afca5d2731323286bc786540c17868632976f7194ed88316873ba12fa26a1bb4",
         "elements": [
           {
             "type": "node",
@@ -300,6 +302,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad0() (tests/incorrect_equality.sol#32-35) uses a dangerous strict equality:\n\t- require(bool)(address(address(this)).balance == 10000000000000000000)\n",
+        "id": "5788b50b1890265c2bcca1508aa44e460bcc8c141fbcc7792ea8c3f39fd414b7",
         "elements": [
           {
             "type": "node",
@@ -546,6 +549,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad1() (tests/incorrect_equality.sol#37-40) uses a dangerous strict equality:\n\t- require(bool)(10000000000000000000 == address(address(this)).balance)\n",
+        "id": "6716f558bdb9f992e50930444d709406d3143389867c1cc942df5f757a26a85a",
         "elements": [
           {
             "type": "node",
@@ -792,6 +796,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad2() (tests/incorrect_equality.sol#42-45) uses a dangerous strict equality:\n\t- require(bool)(address(this).balance == 10000000000000000000)\n",
+        "id": "2043ef0997412319727d45f00a594031284f9636338b73f2c67afd56a5d28189",
         "elements": [
           {
             "type": "node",
@@ -1038,6 +1043,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad3() (tests/incorrect_equality.sol#47-50) uses a dangerous strict equality:\n\t- require(bool)(10000000000000000000 == address(this).balance)\n",
+        "id": "db5232f7e3da871dc3151383de21a0d7ceb6cdd8e5da49c9318a831c80a38b61",
         "elements": [
           {
             "type": "node",
@@ -1284,6 +1290,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad4() (tests/incorrect_equality.sol#52-57) uses a dangerous strict equality:\n\t- balance == 10000000000000000000\n",
+        "id": "bfbadf7cea95cfd6a7c9aa9389b921282e3bd9fc4727fa89d13a00e3ab6bcc82",
         "elements": [
           {
             "type": "node",
@@ -1534,6 +1541,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad5() (tests/incorrect_equality.sol#59-64) uses a dangerous strict equality:\n\t- 10000000000000000000 == balance\n",
+        "id": "0907b87110f2dac94fb53a9955bc386dbfd1f2374d97457e81ac1595b90b25ee",
         "elements": [
           {
             "type": "node",
@@ -1784,6 +1792,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestContractBalance.bad6() (tests/incorrect_equality.sol#66-71) uses a dangerous strict equality:\n\t- balance == 10000000000000000000\n",
+        "id": "3200426d9494286409c77618a52787fc0f1c8d0e62e26a2590f71752ca82641d",
         "elements": [
           {
             "type": "node",
@@ -2034,6 +2043,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestSolidityKeyword.bad0() (tests/incorrect_equality.sol#123-125) uses a dangerous strict equality:\n\t- require(bool)(now == 0)\n",
+        "id": "24cf9b51508e0084091030b281c4bedde701ad9f5de51d510f649d03bc7d6e4f",
         "elements": [
           {
             "type": "node",
@@ -2216,6 +2226,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestSolidityKeyword.bad1() (tests/incorrect_equality.sol#127-129) uses a dangerous strict equality:\n\t- require(bool)(block.number == 0)\n",
+        "id": "416a40ba494c89aacf4682f6f77b1bb9a4a674fd61098c6a4d71cfbf7cc289a6",
         "elements": [
           {
             "type": "node",
@@ -2398,6 +2409,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "TestSolidityKeyword.bad2() (tests/incorrect_equality.sol#131-133) uses a dangerous strict equality:\n\t- require(bool)(block.number == 0)\n",
+        "id": "7d6bf3f3788aa1c874b032aa8c02137eb092127062fbd5cb1b4fd39847830e5e",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/incorrect_equality.incorrect-equality.txt
+++ b/tests/expected_json/incorrect_equality.incorrect-equality.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 ERC20TestBalance.bad0(ERC20Function) (tests/incorrect_equality.sol#21-23) uses a dangerous strict equality:
 	- require(bool)(erc.balanceOf(address(this)) == 10)
 ERC20TestBalance.bad1(ERC20Variable) (tests/incorrect_equality.sol#25-27) uses a dangerous strict equality:
@@ -24,4 +24,4 @@ TestSolidityKeyword.bad1() (tests/incorrect_equality.sol#127-129) uses a dangero
 TestSolidityKeyword.bad2() (tests/incorrect_equality.sol#131-133) uses a dangerous strict equality:
 	- require(bool)(block.number == 0)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#dangerous-strict-equalities[0m
-INFO:Slither:tests/incorrect_equality.sol analyzed (5 contracts), 12 result(s) found
+tests/incorrect_equality.sol analyzed (5 contracts with 1 detectors), 12 result(s) found

--- a/tests/expected_json/incorrect_erc20_interface.erc20-interface.json
+++ b/tests/expected_json/incorrect_erc20_interface.erc20-interface.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: transfer(address,uint256) (tests/incorrect_erc20_interface.sol#4)\n",
+        "id": "445a089ab92bbaf3e729d444bce6e5886ceee3990a909418fc54ea67d04f57ae",
         "elements": [
           {
             "type": "function",
@@ -62,6 +63,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: approve(address,uint256) (tests/incorrect_erc20_interface.sol#5)\n",
+        "id": "8ad0488d3feb262e2f7bc3270b6b2d7bed302b3ff5662219269d63665025cb61",
         "elements": [
           {
             "type": "function",
@@ -116,6 +118,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: transferFrom(address,address,uint256) (tests/incorrect_erc20_interface.sol#6)\n",
+        "id": "a5d542b3a79d1d51806d352d635f1de5fa48f7183c0b9c8fa2fc89e631911681",
         "elements": [
           {
             "type": "function",
@@ -170,6 +173,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: totalSupply() (tests/incorrect_erc20_interface.sol#7)\n",
+        "id": "883433ab0e3beefb53425bd731d33b109d94823ea4cecc648017acc236cacbd2",
         "elements": [
           {
             "type": "function",
@@ -224,6 +228,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: balanceOf(address) (tests/incorrect_erc20_interface.sol#8)\n",
+        "id": "f15d80247c0ea040205495e93690f973d0fc6bb8571c90f408e991171e407284",
         "elements": [
           {
             "type": "function",
@@ -278,6 +283,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: allowance(address,address) (tests/incorrect_erc20_interface.sol#9)\n",
+        "id": "66fc5bafed58dcc4d91bcc262890ef994e948e6525691910242d6df5b695ae58",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/incorrect_erc20_interface.erc20-interface.txt
+++ b/tests/expected_json/incorrect_erc20_interface.erc20-interface.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: transfer(address,uint256) (tests/incorrect_erc20_interface.sol#4)
 Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: approve(address,uint256) (tests/incorrect_erc20_interface.sol#5)
 Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: transferFrom(address,address,uint256) (tests/incorrect_erc20_interface.sol#6)
@@ -6,4 +6,4 @@ Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function in
 Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: balanceOf(address) (tests/incorrect_erc20_interface.sol#8)
 Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface: allowance(address,address) (tests/incorrect_erc20_interface.sol#9)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-erc20-interface[0m
-INFO:Slither:tests/incorrect_erc20_interface.sol analyzed (1 contracts), 6 result(s) found
+tests/incorrect_erc20_interface.sol analyzed (1 contracts with 1 detectors), 6 result(s) found

--- a/tests/expected_json/incorrect_erc721_interface.erc721-interface.json
+++ b/tests/expected_json/incorrect_erc721_interface.erc721-interface.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: supportsInterface(bytes4) (tests/incorrect_erc721_interface.sol#4)\n",
+        "id": "bf1617a4add9e4be6968bf623738b226f82980922641b7bddca2ccb14b975c04",
         "elements": [
           {
             "type": "function",
@@ -57,6 +58,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: balanceOf(address) (tests/incorrect_erc721_interface.sol#7)\n",
+        "id": "cdcef4ee0d5d33d99f07375e58e8cc4263abd3993883401f88ceecdf5f657248",
         "elements": [
           {
             "type": "function",
@@ -114,6 +116,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: ownerOf(uint256) (tests/incorrect_erc721_interface.sol#8)\n",
+        "id": "a0fc9eee535afda76a7fc41fb532137ce16ef2b2b50c4b75013d01d1e5734213",
         "elements": [
           {
             "type": "function",
@@ -171,6 +174,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: safeTransferFrom(address,address,uint256,bytes) (tests/incorrect_erc721_interface.sol#9)\n",
+        "id": "98a952e9f4d228b2ea64fa6d5c84fe5e777a6b76e278c38341dd5546f49bb6b7",
         "elements": [
           {
             "type": "function",
@@ -228,6 +232,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: safeTransferFrom(address,address,uint256) (tests/incorrect_erc721_interface.sol#10)\n",
+        "id": "ca108f1d450221d33944db597df1176982a0d87f37a27b3499b915fa2031bb1f",
         "elements": [
           {
             "type": "function",
@@ -285,6 +290,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: transferFrom(address,address,uint256) (tests/incorrect_erc721_interface.sol#11)\n",
+        "id": "a86e9f59d523636d4b33c271ba904f03de235ed973e3f2471aaca7d583fd5ad6",
         "elements": [
           {
             "type": "function",
@@ -342,6 +348,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: approve(address,uint256) (tests/incorrect_erc721_interface.sol#12)\n",
+        "id": "20f85943e3082591f4d7c615867fb8918e31de6fe458e218f74991723214f169",
         "elements": [
           {
             "type": "function",
@@ -399,6 +406,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: setApprovalForAll(address,bool) (tests/incorrect_erc721_interface.sol#13)\n",
+        "id": "ad405be29301c17206bc8cc7ae20cc7434f407ed5e79ae8e8656650af404fd61",
         "elements": [
           {
             "type": "function",
@@ -456,6 +464,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: getApproved(uint256) (tests/incorrect_erc721_interface.sol#14)\n",
+        "id": "ddb2ede5c011e524cf73b3b5aae23289f1d0338c179a5b7036632f770fee25b3",
         "elements": [
           {
             "type": "function",
@@ -513,6 +522,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: isApprovedForAll(address,address) (tests/incorrect_erc721_interface.sol#15)\n",
+        "id": "84395338fbebb5bacb5348c52bee0f4c7c930c59b362dc76bd77b54110115a5c",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/incorrect_erc721_interface.erc721-interface.txt
+++ b/tests/expected_json/incorrect_erc721_interface.erc721-interface.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: supportsInterface(bytes4) (tests/incorrect_erc721_interface.sol#4)
 Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: balanceOf(address) (tests/incorrect_erc721_interface.sol#7)
 Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: ownerOf(uint256) (tests/incorrect_erc721_interface.sol#8)
@@ -10,4 +10,4 @@ Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function 
 Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: getApproved(uint256) (tests/incorrect_erc721_interface.sol#14)
 Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface: isApprovedForAll(address,address) (tests/incorrect_erc721_interface.sol#15)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-erc721-interface[0m
-INFO:Slither:tests/incorrect_erc721_interface.sol analyzed (2 contracts), 10 result(s) found
+tests/incorrect_erc721_interface.sol analyzed (2 contracts with 1 detectors), 10 result(s) found

--- a/tests/expected_json/inline_assembly_contract-0.5.1.assembly.json
+++ b/tests/expected_json/inline_assembly_contract-0.5.1.assembly.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "GetCode.at(address) uses assembly (tests/inline_assembly_contract-0.5.1.sol#6-20)\n\t- tests/inline_assembly_contract-0.5.1.sol#7-20\n",
+        "id": "4cb0585a1be0e7e4c256a51fe543ade60981b411da324b2754d6dc15dc02d351",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/inline_assembly_contract-0.5.1.assembly.txt
+++ b/tests/expected_json/inline_assembly_contract-0.5.1.assembly.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 GetCode.at(address) uses assembly (tests/inline_assembly_contract-0.5.1.sol#6-20)
 	- tests/inline_assembly_contract-0.5.1.sol#7-20
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#assembly-usage[0m
-INFO:Slither:tests/inline_assembly_contract-0.5.1.sol analyzed (1 contracts), 1 result(s) found
+tests/inline_assembly_contract-0.5.1.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/inline_assembly_contract.assembly.json
+++ b/tests/expected_json/inline_assembly_contract.assembly.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "GetCode.at(address) uses assembly (tests/inline_assembly_contract.sol#6-20)\n\t- tests/inline_assembly_contract.sol#7-20\n",
+        "id": "1c2bd1610eb9f8b63c5c4a35f6b3d894d6691d37cf98221ea52b7106e8083842",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/inline_assembly_contract.assembly.txt
+++ b/tests/expected_json/inline_assembly_contract.assembly.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 GetCode.at(address) uses assembly (tests/inline_assembly_contract.sol#6-20)
 	- tests/inline_assembly_contract.sol#7-20
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#assembly-usage[0m
-INFO:Slither:tests/inline_assembly_contract.sol analyzed (1 contracts), 1 result(s) found
+tests/inline_assembly_contract.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/inline_assembly_library-0.5.1.assembly.json
+++ b/tests/expected_json/inline_assembly_library-0.5.1.assembly.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "VectorSum.sumAsm(uint256[]) uses assembly (tests/inline_assembly_library-0.5.1.sol#16-22)\n\t- tests/inline_assembly_library-0.5.1.sol#18-21\n",
+        "id": "933695cc376038ba8d59ee9939950a333d15585299fcca18ef37038c5b606cb0",
         "elements": [
           {
             "type": "function",
@@ -215,6 +216,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "VectorSum.sumPureAsm(uint256[]) uses assembly (tests/inline_assembly_library-0.5.1.sol#25-47)\n\t- tests/inline_assembly_library-0.5.1.sol#26-47\n",
+        "id": "af7c8fceb78cbcb9e8ddcebed28d1e57a70841dfaf8beebcd61fb6a248558c26",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/inline_assembly_library-0.5.1.assembly.txt
+++ b/tests/expected_json/inline_assembly_library-0.5.1.assembly.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[92m
+[92m
 VectorSum.sumAsm(uint256[]) uses assembly (tests/inline_assembly_library-0.5.1.sol#16-22)
 	- tests/inline_assembly_library-0.5.1.sol#18-21
 VectorSum.sumPureAsm(uint256[]) uses assembly (tests/inline_assembly_library-0.5.1.sol#25-47)
 	- tests/inline_assembly_library-0.5.1.sol#26-47
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#assembly-usage[0m
-INFO:Slither:tests/inline_assembly_library-0.5.1.sol analyzed (1 contracts), 2 result(s) found
+tests/inline_assembly_library-0.5.1.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/inline_assembly_library.assembly.json
+++ b/tests/expected_json/inline_assembly_library.assembly.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "VectorSum.sumAsm(uint256[]) uses assembly (tests/inline_assembly_library.sol#16-22)\n\t- tests/inline_assembly_library.sol#18-21\n",
+        "id": "c4d15e0bb48da142b998b3479bcde43ad0b9b7d8329d3bc6d48e707162936c8d",
         "elements": [
           {
             "type": "function",
@@ -215,6 +216,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "VectorSum.sumPureAsm(uint256[]) uses assembly (tests/inline_assembly_library.sol#25-47)\n\t- tests/inline_assembly_library.sol#26-47\n",
+        "id": "4cfbe1ee82597d2e01cff4e14349a2e2987e8e6533b6cf0f2eea468536bc073c",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/inline_assembly_library.assembly.txt
+++ b/tests/expected_json/inline_assembly_library.assembly.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[92m
+[92m
 VectorSum.sumAsm(uint256[]) uses assembly (tests/inline_assembly_library.sol#16-22)
 	- tests/inline_assembly_library.sol#18-21
 VectorSum.sumPureAsm(uint256[]) uses assembly (tests/inline_assembly_library.sol#25-47)
 	- tests/inline_assembly_library.sol#26-47
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#assembly-usage[0m
-INFO:Slither:tests/inline_assembly_library.sol analyzed (1 contracts), 2 result(s) found
+tests/inline_assembly_library.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/locked_ether-0.5.1.locked-ether.json
+++ b/tests/expected_json/locked_ether-0.5.1.locked-ether.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Contract locking ether found in :\n\tContract OnlyLocked has payable functions:\n\t - receive (tests/locked_ether-0.5.1.sol#4-6)\n\tBut does not have a function to withdraw the ether\n",
+        "id": "e6b4a196a2feae0e0f684414d4b0e005560a9bdcede4e7812b2be398c9742ec6",
         "elements": [
           {
             "type": "contract",

--- a/tests/expected_json/locked_ether-0.5.1.locked-ether.txt
+++ b/tests/expected_json/locked_ether-0.5.1.locked-ether.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[93m
+[93m
 Contract locking ether found in :
 	Contract OnlyLocked has payable functions:
 	 - receive (tests/locked_ether-0.5.1.sol#4-6)
 	But does not have a function to withdraw the ether
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#contracts-that-lock-ether[0m
-INFO:Slither:tests/locked_ether-0.5.1.sol analyzed (4 contracts), 1 result(s) found
+tests/locked_ether-0.5.1.sol analyzed (4 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/locked_ether.locked-ether.json
+++ b/tests/expected_json/locked_ether.locked-ether.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "Contract locking ether found in :\n\tContract OnlyLocked has payable functions:\n\t - receive (tests/locked_ether.sol#4-6)\n\tBut does not have a function to withdraw the ether\n",
+        "id": "30894d690ad391f45cd9510309974eeb7dc14877735fed8d7aa6cfc9417f69dc",
         "elements": [
           {
             "type": "contract",

--- a/tests/expected_json/locked_ether.locked-ether.txt
+++ b/tests/expected_json/locked_ether.locked-ether.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[93m
+[93m
 Contract locking ether found in :
 	Contract OnlyLocked has payable functions:
 	 - receive (tests/locked_ether.sol#4-6)
 	But does not have a function to withdraw the ether
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#contracts-that-lock-ether[0m
-INFO:Slither:tests/locked_ether.sol analyzed (4 contracts), 1 result(s) found
+tests/locked_ether.sol analyzed (4 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/low_level_calls.low-level-calls.json
+++ b/tests/expected_json/low_level_calls.low-level-calls.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Low level call in Sender.send(address) (tests/low_level_calls.sol#5-7):\n\t-_receiver.call.value(msg.value).gas(7777)() tests/low_level_calls.sol#6\n",
+        "id": "eccb51ad66e431c71796b79e26e62201a67638be6b243a059c133d2fc23cbdb8",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/low_level_calls.low-level-calls.txt
+++ b/tests/expected_json/low_level_calls.low-level-calls.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 Low level call in Sender.send(address) (tests/low_level_calls.sol#5-7):
 	-_receiver.call.value(msg.value).gas(7777)() tests/low_level_calls.sol#6
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#low-level-calls[0m
-INFO:Slither:tests/low_level_calls.sol analyzed (2 contracts), 1 result(s) found
+tests/low_level_calls.sol analyzed (2 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/multiple_calls_in_loop.calls-loop.json
+++ b/tests/expected_json/multiple_calls_in_loop.calls-loop.json
@@ -8,6 +8,7 @@
         "impact": "Low",
         "confidence": "Medium",
         "description": "CallInLoop.bad() has external calls inside a loop: \"destinations[i].transfer(i)\" (tests/multiple_calls_in_loop.sol#11)\n",
+        "id": "fcb7ae9e99c05561b205b83f184e6a1ba8f3f50881cbcb5cf672feb6c1675f22",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/multiple_calls_in_loop.calls-loop.txt
+++ b/tests/expected_json/multiple_calls_in_loop.calls-loop.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 CallInLoop.bad() has external calls inside a loop: "destinations[i].transfer(i)" (tests/multiple_calls_in_loop.sol#11)
-Reference: https://github.com/crytic/slither/wiki/Detector-Documentation/_edit#calls-inside-a-loop[0m
-INFO:Slither:tests/multiple_calls_in_loop.sol analyzed (1 contracts), 1 result(s) found
+Reference: https://github.com/crytic/slither/wiki/Detector-Documentation/#calls-inside-a-loop[0m
+tests/multiple_calls_in_loop.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/naming_convention.naming-convention.json
+++ b/tests/expected_json/naming_convention.naming-convention.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Contract 'naming' (tests/naming_convention.sol#3-48) is not in CapWords\n",
+        "id": "61a54b2aef3574debe665bea37bd863f84f548545e7aeedafc6271f80182899a",
         "elements": [
           {
             "type": "contract",
@@ -83,6 +84,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Struct 'naming.test' (tests/naming_convention.sol#14-16) is not in CapWords\n",
+        "id": "fd4706641db9ca2b244c0ae7e5316cdf30ce7dc19027f7b1e01637573d9011cd",
         "elements": [
           {
             "type": "struct",
@@ -180,6 +182,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Event 'namingevent_(uint256)' (tests/naming_convention.sol#23) is not in CapWords\n",
+        "id": "88a22ba5e7ed5b0f8fb62561573c7a75578bd8a216eea2252417895174d6793c",
         "elements": [
           {
             "type": "event",
@@ -276,6 +279,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Function 'naming.GetOne()' (tests/naming_convention.sol#30-33) is not in mixedCase\n",
+        "id": "e442cdd3fe0c8aea1d655c59b81a88220cbebeefdc1dbcd2616f49b329d08608",
         "elements": [
           {
             "type": "function",
@@ -375,6 +379,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Parameter 'Number2' of Number2 (tests/naming_convention.sol#35) is not in mixedCase\n",
+        "id": "58bed6a50a1d7587ba23761c68bc2b6967e25b0507003bf77529bf818fa45a57",
         "elements": [
           {
             "type": "variable",
@@ -494,6 +499,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Constant 'naming.MY_other_CONSTANT' (tests/naming_convention.sol#9) is not in UPPER_CASE_WITH_UNDERSCORES\n",
+        "id": "baa9f605d53e592277a1523d0de9904b2b68fc838be3e9a35674c7f2e8bd8707",
         "elements": [
           {
             "type": "variable",
@@ -589,6 +595,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Variable 'naming.Var_One' (tests/naming_convention.sol#11) is not in mixedCase\n",
+        "id": "e540d006cbfb72b703edaf7655ffc4431681298dd78565d6d91a7d3295254a9d",
         "elements": [
           {
             "type": "variable",
@@ -684,6 +691,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Enum 'naming.numbers' (tests/naming_convention.sol#6) is not in CapWords\n",
+        "id": "def0f6ae2024936db6131001c338948cc036266ea6da7bc5f56da89d5675f701",
         "elements": [
           {
             "type": "enum",
@@ -779,6 +787,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Modifier 'naming.CantDo()' (tests/naming_convention.sol#41-43) is not in mixedCase\n",
+        "id": "26bc52267e81626821d08eda3c3b6db674fcc38adffb4dacd70969855b3d1c34",
         "elements": [
           {
             "type": "function",
@@ -877,6 +886,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Parameter '_used' of _used (tests/naming_convention.sol#59) is not in mixedCase\n",
+        "id": "82e3b1f267546d2f12d77695266b29a8c5da53d961d6a573eba9882770bc4961",
         "elements": [
           {
             "type": "variable",
@@ -963,6 +973,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Variable 'T._myPublicVar' (tests/naming_convention.sol#56) is not in mixedCase\n",
+        "id": "48e743a85d1e3d3a7873d7d2e2efbe272c578abef9c7b7546c77556eb4cd8468",
         "elements": [
           {
             "type": "variable",
@@ -1027,6 +1038,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Variable 'T.l' (tests/naming_convention.sol#67) used l, O, I, which should not be used\n",
+        "id": "15393f63e671c1e02e170814700f83c93603cbba99f19153b2497f6026dc7597",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/naming_convention.naming-convention.txt
+++ b/tests/expected_json/naming_convention.naming-convention.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 Contract 'naming' (tests/naming_convention.sol#3-48) is not in CapWords
 Struct 'naming.test' (tests/naming_convention.sol#14-16) is not in CapWords
 Event 'namingevent_(uint256)' (tests/naming_convention.sol#23) is not in CapWords
@@ -12,4 +12,4 @@ Parameter '_used' of _used (tests/naming_convention.sol#59) is not in mixedCase
 Variable 'T._myPublicVar' (tests/naming_convention.sol#56) is not in mixedCase
 Variable 'T.l' (tests/naming_convention.sol#67) used l, O, I, which should not be used
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions[0m
-INFO:Slither:tests/naming_convention.sol analyzed (4 contracts), 12 result(s) found
+tests/naming_convention.sol analyzed (4 contracts with 1 detectors), 12 result(s) found

--- a/tests/expected_json/old_solc.sol.json.solc-version.json
+++ b/tests/expected_json/old_solc.sol.json.solc-version.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Pragma version \"0.4.21\" allows old versions (None)\n",
+        "id": "a7b6bf8c3231da7d72745d7268e59d7f2e98c4f2d2c40b2a623579f6e1d1c2b0",
         "elements": [
           {
             "type": "pragma",

--- a/tests/expected_json/old_solc.sol.json.solc-version.txt
+++ b/tests/expected_json/old_solc.sol.json.solc-version.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 Pragma version "0.4.21" allows old versions (None)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
+tests/old_solc.sol.json analyzed (1 contracts with 1 detectors), 1 result(s) found
 INFO:Slither:[93m/home/travis/build/crytic/slither/scripts/../tests/expected_json/old_solc.sol.json.solc-version.json exists already, the overwrite is prevented[0m
-INFO:Slither:tests/old_solc.sol.json analyzed (1 contracts), 1 result(s) found

--- a/tests/expected_json/pragma.0.4.24.pragma.json
+++ b/tests/expected_json/pragma.0.4.24.pragma.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Different versions of Solidity is used in :\n\t- Version used: ['^0.4.23', '^0.4.24']\n\t- tests/pragma.0.4.23.sol#1 declares pragma solidity^0.4.23\n\t- tests/pragma.0.4.24.sol#1 declares pragma solidity^0.4.24\n",
+        "id": "1b213c827c720014104a57dee21e848ca2463209718b766f9457cf9a7da864b5",
         "elements": [
           {
             "type": "pragma",

--- a/tests/expected_json/pragma.0.4.24.pragma.txt
+++ b/tests/expected_json/pragma.0.4.24.pragma.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[92m
+[92m
 Different versions of Solidity is used in :
 	- Version used: ['^0.4.23', '^0.4.24']
 	- tests/pragma.0.4.23.sol#1 declares pragma solidity^0.4.23
 	- tests/pragma.0.4.24.sol#1 declares pragma solidity^0.4.24
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#different-pragma-directives-are-used[0m
-INFO:Slither:tests/pragma.0.4.24.sol analyzed (1 contracts), 1 result(s) found
+tests/pragma.0.4.24.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)\n\tState variables written after the call(s):\n\t- userBalance (tests/reentrancy-0.5.1.sol#21)\n",
+        "id": "ca1f268bd5fc31807e3fe6b2690b03223abf8489495dd4c0a75c8ccb011efaf4",
         "elements": [
           {
             "type": "function",
@@ -357,6 +358,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#44-53):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(amount)() (tests/reentrancy-0.5.1.sol#49)\n\tState variables written after the call(s):\n\t- userBalance (tests/reentrancy-0.5.1.sol#51)\n",
+        "id": "c3d50c2c79cdba4c97e465911b51953774108f056880326903829f96991b838d",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.txt
+++ b/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):
 	External calls:
 	- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)
@@ -10,4 +10,4 @@ Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#4
 	State variables written after the call(s):
 	- userBalance (tests/reentrancy-0.5.1.sol#51)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities[0m
-INFO:Slither:tests/reentrancy-0.5.1.sol analyzed (1 contracts), 2 result(s) found
+tests/reentrancy-0.5.1.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/reentrancy.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy.reentrancy-eth.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):\n\tExternal calls:\n\t- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)\n\tState variables written after the call(s):\n\t- userBalance (tests/reentrancy.sol#20)\n",
+        "id": "83e76a02ab726f209a4492f3edadbd6cc8d47a44f3adbcd2bf85e24ea0146831",
         "elements": [
           {
             "type": "function",
@@ -408,6 +409,7 @@
         "impact": "High",
         "confidence": "Medium",
         "description": "Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):\n\tExternal calls:\n\t- msg.sender.call.value(amount / 2)() (tests/reentrancy.sol#67)\n\tState variables written after the call(s):\n\t- userBalance (tests/reentrancy.sol#68)\n",
+        "id": "6088fcc84061d99d41aa18737df272778b368797dbca8c0a0b8daaa5a29f987b",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/reentrancy.reentrancy-eth.txt
+++ b/tests/expected_json/reentrancy.reentrancy-eth.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):
 	External calls:
 	- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)
@@ -10,4 +10,4 @@ Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):
 	State variables written after the call(s):
 	- userBalance (tests/reentrancy.sol#68)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities[0m
-INFO:Slither:tests/reentrancy.sol analyzed (1 contracts), 2 result(s) found
+tests/reentrancy.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/right_to_left_override.rtlo.json
+++ b/tests/expected_json/right_to_left_override.rtlo.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
+        "id": "a6c8caf0e8d2182254c7b66c9808b999315b14fe10087f12bdc0afa72a43c223",
         "elements": [
           {
             "type": "other",

--- a/tests/expected_json/right_to_left_override.rtlo.txt
+++ b/tests/expected_json/right_to_left_override.rtlo.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[91m
+[91m
 /home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:
 	- b'        test1(/*A\xe2\x80\xae/*B*/2 , 1/*\xe2\x80\xad'
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#right-to-left-override-character[0m
-INFO:Slither:tests/right_to_left_override.sol analyzed (1 contracts), 1 result(s) found
+tests/right_to_left_override.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/shadowing_abstract.shadowing-abstract.json
+++ b/tests/expected_json/shadowing_abstract.shadowing-abstract.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "High",
         "description": "DerivedContract.owner (tests/shadowing_abstract.sol#7) shadows:\n\t- BaseContract.owner (tests/shadowing_abstract.sol#2)\n",
+        "id": "956a405b92b83b3edc7ac9fcc2b00c68f7956a87e7108e9f4ff6598e0dd332ce",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/shadowing_abstract.shadowing-abstract.txt
+++ b/tests/expected_json/shadowing_abstract.shadowing-abstract.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[93m
+[93m
 DerivedContract.owner (tests/shadowing_abstract.sol#7) shadows:
 	- BaseContract.owner (tests/shadowing_abstract.sol#2)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#state-variable-shadowing-from-abstract-contracts[0m
-INFO:Slither:tests/shadowing_abstract.sol analyzed (2 contracts), 1 result(s) found
+tests/shadowing_abstract.sol analyzed (2 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.json
+++ b/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.json
@@ -8,6 +8,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "BaseContract.blockhash (state variable @ tests/shadowing_builtin_symbols.sol#4) shadows built-in symbol \"blockhash\"\n",
+        "id": "f1992708a9325247cef96b16829fa02c2d80d07afbeb3882b71d6f0a9e899b9a",
         "elements": [
           {
             "type": "variable",
@@ -59,6 +60,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "BaseContract.now (state variable @ tests/shadowing_builtin_symbols.sol#5) shadows built-in symbol \"now\"\n",
+        "id": "268ae76c67a957e59d12364c797d825f662f33cff0d5e71e2f1c9b749c9316b4",
         "elements": [
           {
             "type": "variable",
@@ -110,6 +112,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "BaseContract.revert (event @ tests/shadowing_builtin_symbols.sol#7) shadows built-in symbol \"revert\"\n",
+        "id": "7340fda6516803985c49e6405f4c6e3dd1dba46eeb0fe0dad1e45fe80a2491db",
         "elements": [
           {
             "type": "event",
@@ -162,6 +165,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "ExtendedContract.assert (function @ tests/shadowing_builtin_symbols.sol#13-15) shadows built-in symbol \"assert\"\n",
+        "id": "e1cb5b2c90831eda757fb46a7f109adc3f090fd793cd9d084c07c1b7391e3d24",
         "elements": [
           {
             "type": "function",
@@ -217,6 +221,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "ExtendedContract.assert.msg (local variable @ tests/shadowing_builtin_symbols.sol#14) shadows built-in symbol \"msg\"\n",
+        "id": "57b2ef10e03c5d520fe9706499cf200eebcd1711432e2d9f8363794ddd6a7532",
         "elements": [
           {
             "type": "variable",
@@ -292,6 +297,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "ExtendedContract.ecrecover (state variable @ tests/shadowing_builtin_symbols.sol#11) shadows built-in symbol \"ecrecover\"\n",
+        "id": "8924a627f869a25833cb123f4472b7385e908a4f5b20bbf4547d29e6d7f860dd",
         "elements": [
           {
             "type": "variable",
@@ -344,6 +350,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.require (modifier @ tests/shadowing_builtin_symbols.sol#23-28) shadows built-in symbol \"require\"\n",
+        "id": "7a5ee056a2374102e534b3d948c26314b0b1d8a39700616575c65c4db2eccd80",
         "elements": [
           {
             "type": "function",
@@ -407,6 +414,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.require.keccak256 (local variable @ tests/shadowing_builtin_symbols.sol#25) shadows built-in symbol \"keccak256\"\n",
+        "id": "b282054d4ccba468784148f47c4eef34219e755aeb4627498b5dfdf940a6483a",
         "elements": [
           {
             "type": "variable",
@@ -490,6 +498,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.require.sha3 (local variable @ tests/shadowing_builtin_symbols.sol#26) shadows built-in symbol \"sha3\"\n",
+        "id": "db014f63c1d2072d04e1c7b91f069d02ced0c91ac2741c44472a854d85556d01",
         "elements": [
           {
             "type": "variable",
@@ -573,6 +582,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.blockhash (state variable @ tests/shadowing_builtin_symbols.sol#19) shadows built-in symbol \"blockhash\"\n",
+        "id": "e6ba7969d049eaaeb526d1a74c19104efb6262d3bf18cf678e29c537827b252f",
         "elements": [
           {
             "type": "variable",
@@ -630,6 +640,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.this (state variable @ tests/shadowing_builtin_symbols.sol#20) shadows built-in symbol \"this\"\n",
+        "id": "29023a555b71e80869c0f1a1bfe7b21591a761c4157976ffa319eca56259b71a",
         "elements": [
           {
             "type": "variable",
@@ -687,6 +698,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.abi (state variable @ tests/shadowing_builtin_symbols.sol#21) shadows built-in symbol \"abi\"\n",
+        "id": "c06268afd2843d5c652bf000d5e8e9e5a31f73aee9f1ce8943c8c990e385af8a",
         "elements": [
           {
             "type": "variable",
@@ -744,6 +756,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "Reserved.mutable (state variable @ tests/shadowing_builtin_symbols.sol#32) shadows built-in symbol \"mutable\"\n",
+        "id": "fb57f49a9bc9aba81389857944d735543ab5e9ac52b99d872249a918d9933e1c",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.txt
+++ b/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 BaseContract.blockhash (state variable @ tests/shadowing_builtin_symbols.sol#4) shadows built-in symbol "blockhash"
 BaseContract.now (state variable @ tests/shadowing_builtin_symbols.sol#5) shadows built-in symbol "now"
 BaseContract.revert (event @ tests/shadowing_builtin_symbols.sol#7) shadows built-in symbol "revert"
@@ -13,4 +13,4 @@ FurtherExtendedContract.this (state variable @ tests/shadowing_builtin_symbols.s
 FurtherExtendedContract.abi (state variable @ tests/shadowing_builtin_symbols.sol#21) shadows built-in symbol "abi"
 Reserved.mutable (state variable @ tests/shadowing_builtin_symbols.sol#32) shadows built-in symbol "mutable"
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#builtin-symbol-shadowing[0m
-INFO:Slither:tests/shadowing_builtin_symbols.sol analyzed (4 contracts), 13 result(s) found
+tests/shadowing_builtin_symbols.sol analyzed (4 contracts with 1 detectors), 13 result(s) found

--- a/tests/expected_json/shadowing_local_variable.shadowing-local.json
+++ b/tests/expected_json/shadowing_local_variable.shadowing-local.json
@@ -8,6 +8,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.shadowingParent.x (local variable @ tests/shadowing_local_variable.sol#25) shadows:\n\t- FurtherExtendedContract.x (state variable @ tests/shadowing_local_variable.sol#17)\n\t- ExtendedContract.x (state variable @ tests/shadowing_local_variable.sol#9)\n\t- BaseContract.x (state variable @ tests/shadowing_local_variable.sol#4)\n",
+        "id": "5e38717a1c23eab1e19f897102a28d874c9b9d0c73b3bdd0034f3176b382fef8",
         "elements": [
           {
             "type": "variable",
@@ -218,6 +219,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.shadowingParent.y (local variable @ tests/shadowing_local_variable.sol#25) shadows:\n\t- BaseContract.y (state variable @ tests/shadowing_local_variable.sol#5)\n",
+        "id": "04f6a4d04525922c8f1020bd0b58a961d4941fda23608f1f4288db9dde1f22bf",
         "elements": [
           {
             "type": "variable",
@@ -336,6 +338,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.shadowingParent.z (local variable @ tests/shadowing_local_variable.sol#25) shadows:\n\t- ExtendedContract.z (function @ tests/shadowing_local_variable.sol#11)\n",
+        "id": "581dcd383b94cd5590dc082b5a9d704495b9fff5db95bf58cfe9b7785ac4f5c8",
         "elements": [
           {
             "type": "variable",
@@ -458,6 +461,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.shadowingParent.w (local variable @ tests/shadowing_local_variable.sol#25) shadows:\n\t- FurtherExtendedContract.w (modifier @ tests/shadowing_local_variable.sol#20-23)\n",
+        "id": "447d65733adf01117b030c140b270da8ecd62195c3fcbc835442ec05c7d0ea29",
         "elements": [
           {
             "type": "variable",
@@ -587,6 +591,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "FurtherExtendedContract.shadowingParent.v (local variable @ tests/shadowing_local_variable.sol#25) shadows:\n\t- ExtendedContract.v (event @ tests/shadowing_local_variable.sol#13)\n",
+        "id": "59e98677340909cd3dd904a8c805bccb1ae763d9391f0fc89eb8b31161827cfe",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/shadowing_local_variable.shadowing-local.txt
+++ b/tests/expected_json/shadowing_local_variable.shadowing-local.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 FurtherExtendedContract.shadowingParent.x (local variable @ tests/shadowing_local_variable.sol#25) shadows:
 	- FurtherExtendedContract.x (state variable @ tests/shadowing_local_variable.sol#17)
 	- ExtendedContract.x (state variable @ tests/shadowing_local_variable.sol#9)
@@ -12,4 +12,4 @@ FurtherExtendedContract.shadowingParent.w (local variable @ tests/shadowing_loca
 FurtherExtendedContract.shadowingParent.v (local variable @ tests/shadowing_local_variable.sol#25) shadows:
 	- ExtendedContract.v (event @ tests/shadowing_local_variable.sol#13)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#local-variable-shadowing[0m
-INFO:Slither:tests/shadowing_local_variable.sol analyzed (3 contracts), 5 result(s) found
+tests/shadowing_local_variable.sol analyzed (3 contracts with 1 detectors), 5 result(s) found

--- a/tests/expected_json/shadowing_state_variable.shadowing-state.json
+++ b/tests/expected_json/shadowing_state_variable.shadowing-state.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "DerivedContract.owner (tests/shadowing_state_variable.sol#12) shadows:\n\t- BaseContract.owner (tests/shadowing_state_variable.sol#2)\n",
+        "id": "cc0ccc1335cd7481b96964251efdb2672129f16a40a718a41ca681a61a680c35",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/shadowing_state_variable.shadowing-state.txt
+++ b/tests/expected_json/shadowing_state_variable.shadowing-state.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[91m
+[91m
 DerivedContract.owner (tests/shadowing_state_variable.sol#12) shadows:
 	- BaseContract.owner (tests/shadowing_state_variable.sol#2)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#state-variable-shadowing[0m
-INFO:Slither:tests/shadowing_state_variable.sol analyzed (2 contracts), 1 result(s) found
+tests/shadowing_state_variable.sol analyzed (2 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/solc_version_incorrect.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect.solc-version.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Pragma version \"^0.4.23\" allows old versions (tests/solc_version_incorrect.sol#2)\n",
+        "id": "8e23bbb42d580b86288abb89f46c9cdf11abf1fe2903bb510dcf33477695a066",
         "elements": [
           {
             "type": "pragma",
@@ -42,6 +43,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Pragma version \">=0.4.0<0.6.0\" allows old versions (tests/solc_version_incorrect.sol#3)\n",
+        "id": "e24c9b9db39b5463c8cf6c681a260bebad2d25d69cd501a4733dba0fd2cf1a3a",
         "elements": [
           {
             "type": "pragma",

--- a/tests/expected_json/solc_version_incorrect.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect.solc-version.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 Pragma version "^0.4.23" allows old versions (tests/solc_version_incorrect.sol#2)
 Pragma version ">=0.4.0<0.6.0" allows old versions (tests/solc_version_incorrect.sol#3)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
-INFO:Slither:tests/solc_version_incorrect.sol analyzed (1 contracts), 2 result(s) found
+tests/solc_version_incorrect.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Pragma version \"^0.5.5\" is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html) (None)\n",
+        "id": "6f28caaaacadda034fc52a17ed74637e1485088835fb84e27301cb18bf398663",
         "elements": [
           {
             "type": "pragma",
@@ -40,6 +41,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "Pragma version \"0.5.7\" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (None)\n",
+        "id": "a6157d2a463a0628d1adfbbc12f1b4e8519b8a99bfdf310513817ed125d2a92c",
         "elements": [
           {
             "type": "pragma",

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 Pragma version "^0.5.5" is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html) (None)
 Pragma version "0.5.7" necessitates versions too recent to be trusted. Consider deploying with 0.5.3 (None)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
-INFO:Slither:tests/solc_version_incorrect_05.ast.json analyzed (1 contracts), 2 result(s) found
+tests/solc_version_incorrect_05.ast.json analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/timestamp.timestamp.json
+++ b/tests/expected_json/timestamp.timestamp.json
@@ -8,6 +8,7 @@
         "impact": "Low",
         "confidence": "Medium",
         "description": "Timestamp.bad0() (tests/timestamp.sol#4-6) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool)(block.timestamp == 0) (tests/timestamp.sol#5)\n",
+        "id": "4aa714b1d7b852f9aca4078a2490d8ef4b7435f0d3b0bccffed485b95a0c426c",
         "elements": [
           {
             "type": "function",
@@ -156,6 +157,7 @@
         "impact": "Low",
         "confidence": "Medium",
         "description": "Timestamp.bad1() (tests/timestamp.sol#8-11) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool)(time == 0) (tests/timestamp.sol#10)\n",
+        "id": "e0a85638c9a5881aec2037f0950b48f20a7e69377379417a3bfbc474d9acbcd1",
         "elements": [
           {
             "type": "function",
@@ -306,6 +308,7 @@
         "impact": "Low",
         "confidence": "Medium",
         "description": "Timestamp.bad2() (tests/timestamp.sol#13-15) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > 0 (tests/timestamp.sol#14)\n",
+        "id": "968de9124952eb3eb1395be0afd6ca9d1538d1196ed05dfdeb6bb45b3a4cfadf",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/timestamp.timestamp.txt
+++ b/tests/expected_json/timestamp.timestamp.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[92m
+[92m
 Timestamp.bad0() (tests/timestamp.sol#4-6) uses timestamp for comparisons
 	Dangerous comparisons:
 	- require(bool)(block.timestamp == 0) (tests/timestamp.sol#5)
@@ -9,4 +9,4 @@ Timestamp.bad2() (tests/timestamp.sol#13-15) uses timestamp for comparisons
 	Dangerous comparisons:
 	- block.timestamp > 0 (tests/timestamp.sol#14)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#block-timestamp[0m
-INFO:Slither:tests/timestamp.sol analyzed (1 contracts), 3 result(s) found
+tests/timestamp.sol analyzed (1 contracts with 1 detectors), 3 result(s) found

--- a/tests/expected_json/too_many_digits.too-many-digits.json
+++ b/tests/expected_json/too_many_digits.too-many-digits.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "Medium",
         "description": "C.f (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x1 = 0x000001\n",
+        "id": "4785fe4858facf0922e6746f44f9daf7188094db6fe1c281eb6e5b53f4f7fb6a",
         "elements": [
           {
             "type": "node",
@@ -118,6 +119,7 @@
         "impact": "Informational",
         "confidence": "Medium",
         "description": "C.f (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x2 = 0x0000000000001\n",
+        "id": "613276b6aa078856167ef9f2b8382fcb447124275f4d57abe509253dfc63e0bc",
         "elements": [
           {
             "type": "node",
@@ -228,6 +230,7 @@
         "impact": "Informational",
         "confidence": "Medium",
         "description": "C.f (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x3 = 1000000000000000000\n",
+        "id": "e36826b868764a07bce92ad3eb9f88acd3a089050403cfb865864ba22f85f399",
         "elements": [
           {
             "type": "node",
@@ -338,6 +341,7 @@
         "impact": "Informational",
         "confidence": "Medium",
         "description": "C.f (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x4 = 100000\n",
+        "id": "682b583114d797b0e85e2cf6dd72a25e32ce54d0a977dcb92584724f7c8874f5",
         "elements": [
           {
             "type": "node",
@@ -448,6 +452,7 @@
         "impact": "Informational",
         "confidence": "Medium",
         "description": "C.h (tests/too_many_digits.sol#20-24) uses literals with too many digits:\n\t- x2 = 100000\n",
+        "id": "06427cedc42fc49c2a7ea6332a9e31fbc1813c9a895155ee75c9f81d5ba99a80",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/too_many_digits.too-many-digits.txt
+++ b/tests/expected_json/too_many_digits.too-many-digits.txt
@@ -10,4 +10,4 @@ C.f (tests/too_many_digits.sol#9-15) uses literals with too many digits:
 C.h (tests/too_many_digits.sol#20-24) uses literals with too many digits:
 	- x2 = 100000
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#too-many-digits[0m
-tests/too_many_digits.sol analyzed (1 contracts), 5 result(s) found
+tests/too_many_digits.sol analyzed (1 contracts with 1 detectors), 5 result(s) found

--- a/tests/expected_json/tx_origin-0.5.1.tx-origin.json
+++ b/tests/expected_json/tx_origin-0.5.1.tx-origin.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "TxOrigin.bug0() uses tx.origin for authorization: \"require(bool)(tx.origin == owner)\" (tests/tx_origin-0.5.1.sol#10)\n",
+        "id": "653a174d6c3079b62b696ff30c34e0ba25c02ab505a9c67696d149ff2b71f436",
         "elements": [
           {
             "type": "node",
@@ -100,6 +101,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "TxOrigin.bug2() uses tx.origin for authorization: \"tx.origin != owner\" (tests/tx_origin-0.5.1.sol#14)\n",
+        "id": "e2f4265f7ec65ebf832d0f82f94db352ac91eb961a55f5967ce2356103ccd5f3",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/tx_origin-0.5.1.tx-origin.txt
+++ b/tests/expected_json/tx_origin-0.5.1.tx-origin.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[93m
+[93m
 TxOrigin.bug0() uses tx.origin for authorization: "require(bool)(tx.origin == owner)" (tests/tx_origin-0.5.1.sol#10)
 TxOrigin.bug2() uses tx.origin for authorization: "tx.origin != owner" (tests/tx_origin-0.5.1.sol#14)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#dangerous-usage-of-txorigin[0m
-INFO:Slither:tests/tx_origin-0.5.1.sol analyzed (1 contracts), 2 result(s) found
+tests/tx_origin-0.5.1.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/tx_origin.tx-origin.json
+++ b/tests/expected_json/tx_origin.tx-origin.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "TxOrigin.bug0() uses tx.origin for authorization: \"require(bool)(tx.origin == owner)\" (tests/tx_origin.sol#10)\n",
+        "id": "4d5b6e8b806b5f103d91ed4c2e757da446a858fee4e678dc92e1d83654b21fa3",
         "elements": [
           {
             "type": "node",
@@ -100,6 +101,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "TxOrigin.bug2() uses tx.origin for authorization: \"tx.origin != owner\" (tests/tx_origin.sol#14)\n",
+        "id": "d591780befebc3af430a4158bf57a4b4ef714fd4def2b1cbe1cd65cdb3c1bb3c",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/tx_origin.tx-origin.txt
+++ b/tests/expected_json/tx_origin.tx-origin.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[93m
+[93m
 TxOrigin.bug0() uses tx.origin for authorization: "require(bool)(tx.origin == owner)" (tests/tx_origin.sol#10)
 TxOrigin.bug2() uses tx.origin for authorization: "tx.origin != owner" (tests/tx_origin.sol#14)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#dangerous-usage-of-txorigin[0m
-INFO:Slither:tests/tx_origin.sol analyzed (1 contracts), 2 result(s) found
+tests/tx_origin.sol analyzed (1 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.json
+++ b/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "MyConc.bad(address) (tests/unchecked_lowlevel-0.5.1.sol#2-4) ignores return value by low-level calls \"dst.call.value(msg.value)()\" (tests/unchecked_lowlevel-0.5.1.sol#3)\n",
+        "id": "32c39a25403214ff189e81d5fdfb358812bbab7b9de8bcc1b3d1e25252206859",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.txt
+++ b/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 MyConc.bad(address) (tests/unchecked_lowlevel-0.5.1.sol#2-4) ignores return value by low-level calls "dst.call.value(msg.value)()" (tests/unchecked_lowlevel-0.5.1.sol#3)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unchecked-low-level-calls[0m
-INFO:Slither:tests/unchecked_lowlevel-0.5.1.sol analyzed (1 contracts), 1 result(s) found
+tests/unchecked_lowlevel-0.5.1.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.json
+++ b/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "MyConc.bad(address) (tests/unchecked_lowlevel.sol#2-4) ignores return value by low-level calls \"dst.call.value(msg.value)()\" (tests/unchecked_lowlevel.sol#3)\n",
+        "id": "7e57597ad883cef906e3d992dbe66c95dce23f2e7b7f609fe33fc9b8056a5916",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.txt
+++ b/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 MyConc.bad(address) (tests/unchecked_lowlevel.sol#2-4) ignores return value by low-level calls "dst.call.value(msg.value)()" (tests/unchecked_lowlevel.sol#3)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unchecked-low-level-calls[0m
-INFO:Slither:tests/unchecked_lowlevel.sol analyzed (1 contracts), 1 result(s) found
+tests/unchecked_lowlevel.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/unchecked_send-0.5.1.unchecked-send.json
+++ b/tests/expected_json/unchecked_send-0.5.1.unchecked-send.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "MyConc.bad(address) (tests/unchecked_send-0.5.1.sol#2-4) ignores return value by send calls \"dst.send(msg.value)\" (tests/unchecked_send-0.5.1.sol#3)\n",
+        "id": "01da42ad0627149899610e0343686fa92977a820e7e0683e5c82f7af85808d01",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/unchecked_send-0.5.1.unchecked-send.txt
+++ b/tests/expected_json/unchecked_send-0.5.1.unchecked-send.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 MyConc.bad(address) (tests/unchecked_send-0.5.1.sol#2-4) ignores return value by send calls "dst.send(msg.value)" (tests/unchecked_send-0.5.1.sol#3)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unchecked-send[0m
-INFO:Slither:tests/unchecked_send-0.5.1.sol analyzed (1 contracts), 1 result(s) found
+tests/unchecked_send-0.5.1.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/uninitialized-0.5.1.uninitialized-state.json
+++ b/tests/expected_json/uninitialized-0.5.1.uninitialized-state.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Uninitialized.destination (tests/uninitialized-0.5.1.sol#5) is never initialized. It is used in:\n\t- transfer (tests/uninitialized-0.5.1.sol#7-9)\n",
+        "id": "f8355a5d64234287a98045d062f62ae3af3d551c9389f99780892d2fbf5e2e6f",
         "elements": [
           {
             "type": "variable",
@@ -111,6 +112,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test.balances (tests/uninitialized-0.5.1.sol#15) is never initialized. It is used in:\n\t- use (tests/uninitialized-0.5.1.sol#23-26)\n",
+        "id": "d049f0ff5e0b9d18de6b1b5f0e849d6fe332ff59cf5738f488a23ae9d3c20b01",
         "elements": [
           {
             "type": "variable",
@@ -225,6 +227,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test2.st (tests/uninitialized-0.5.1.sol#45) is never initialized. It is used in:\n\t- use (tests/uninitialized-0.5.1.sol#53-56)\n",
+        "id": "6167525254a02e75a53a7c2617869600032475f208a4f82e27d69a0f124cbfeb",
         "elements": [
           {
             "type": "variable",
@@ -345,6 +348,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test2.v (tests/uninitialized-0.5.1.sol#47) is never initialized. It is used in:\n\t- init (tests/uninitialized-0.5.1.sol#49-51)\n",
+        "id": "daf1a884414844b763bea119bb474f424b24005bf922c54b72b3adf1b89b2a68",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/uninitialized-0.5.1.uninitialized-state.txt
+++ b/tests/expected_json/uninitialized-0.5.1.uninitialized-state.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Uninitialized.destination (tests/uninitialized-0.5.1.sol#5) is never initialized. It is used in:
 	- transfer (tests/uninitialized-0.5.1.sol#7-9)
 Test.balances (tests/uninitialized-0.5.1.sol#15) is never initialized. It is used in:
@@ -8,4 +8,4 @@ Test2.st (tests/uninitialized-0.5.1.sol#45) is never initialized. It is used in:
 Test2.v (tests/uninitialized-0.5.1.sol#47) is never initialized. It is used in:
 	- init (tests/uninitialized-0.5.1.sol#49-51)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-state-variables[0m
-INFO:Slither:tests/uninitialized-0.5.1.sol analyzed (4 contracts), 4 result(s) found
+tests/uninitialized-0.5.1.sol analyzed (4 contracts with 1 detectors), 4 result(s) found

--- a/tests/expected_json/uninitialized.uninitialized-state.json
+++ b/tests/expected_json/uninitialized.uninitialized-state.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Uninitialized.destination (tests/uninitialized.sol#5) is never initialized. It is used in:\n\t- transfer (tests/uninitialized.sol#7-9)\n",
+        "id": "b9d72c064240304f637c582907af558061621676b6c15799fec3e941ecfe2899",
         "elements": [
           {
             "type": "variable",
@@ -111,6 +112,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test.balances (tests/uninitialized.sol#15) is never initialized. It is used in:\n\t- use (tests/uninitialized.sol#23-26)\n",
+        "id": "19fec3e281dbd48a9c7969b559ca1fc3998cd74800493ba553c234d80f4bfa3a",
         "elements": [
           {
             "type": "variable",
@@ -225,6 +227,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test2.st (tests/uninitialized.sol#45) is never initialized. It is used in:\n\t- use (tests/uninitialized.sol#53-56)\n",
+        "id": "a1b152d139584b017fe00b3b319a5d917798f5c2ec352e35fddfd55ad3a43c63",
         "elements": [
           {
             "type": "variable",
@@ -345,6 +348,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "Test2.v (tests/uninitialized.sol#47) is never initialized. It is used in:\n\t- init (tests/uninitialized.sol#49-51)\n",
+        "id": "bda10ca462e351d03d31f9454cd4d69abbf4140835db77932fb913cdd0ee030d",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/uninitialized.uninitialized-state.txt
+++ b/tests/expected_json/uninitialized.uninitialized-state.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 Uninitialized.destination (tests/uninitialized.sol#5) is never initialized. It is used in:
 	- transfer (tests/uninitialized.sol#7-9)
 Test.balances (tests/uninitialized.sol#15) is never initialized. It is used in:
@@ -8,4 +8,4 @@ Test2.st (tests/uninitialized.sol#45) is never initialized. It is used in:
 Test2.v (tests/uninitialized.sol#47) is never initialized. It is used in:
 	- init (tests/uninitialized.sol#49-51)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-state-variables[0m
-INFO:Slither:tests/uninitialized.sol analyzed (4 contracts), 4 result(s) found
+tests/uninitialized.sol analyzed (4 contracts with 1 detectors), 4 result(s) found

--- a/tests/expected_json/uninitialized_local_variable.uninitialized-local.json
+++ b/tests/expected_json/uninitialized_local_variable.uninitialized-local.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "uint_not_init in Uninitialized.func() (tests/uninitialized_local_variable.sol#4) is a local variable never initialiazed\n",
+        "id": "2c664905bce7e30b69220815bcf4d0731d29c705692a0d8cf19dd43dc687baeb",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/uninitialized_local_variable.uninitialized-local.txt
+++ b/tests/expected_json/uninitialized_local_variable.uninitialized-local.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[93m
+[93m
 uint_not_init in Uninitialized.func() (tests/uninitialized_local_variable.sol#4) is a local variable never initialiazed
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-local-variables[0m
-INFO:Slither:tests/uninitialized_local_variable.sol analyzed (1 contracts), 1 result(s) found
+tests/uninitialized_local_variable.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.json
+++ b/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.json
@@ -8,6 +8,7 @@
         "impact": "High",
         "confidence": "High",
         "description": "st_bug in Uninitialized.func() (tests/uninitialized_storage_pointer.sol#10) is a storage variable never initialiazed\n",
+        "id": "9800addcf9196886a8297c61a4bdb8e33cf32e72e71cc2930a08585ab429a0ee",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.txt
+++ b/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.txt
@@ -1,4 +1,4 @@
-INFO:Detectors:[91m
+[91m
 st_bug in Uninitialized.func() (tests/uninitialized_storage_pointer.sol#10) is a storage variable never initialiazed
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-storage-variables[0m
-INFO:Slither:tests/uninitialized_storage_pointer.sol analyzed (1 contracts), 1 result(s) found
+tests/uninitialized_storage_pointer.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/unused_return.unused-return.json
+++ b/tests/expected_json/unused_return.unused-return.json
@@ -8,6 +8,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "User.test(Target) (tests/unused_return.sol#17-29) ignores return value by external calls \"t.f()\" (tests/unused_return.sol#18)\n",
+        "id": "691bdea4b639ba261571a61982063a0040c1c4990a9573c160fa5c39741271a0",
         "elements": [
           {
             "type": "node",
@@ -172,6 +173,7 @@
         "impact": "Medium",
         "confidence": "Medium",
         "description": "User.test(Target) (tests/unused_return.sol#17-29) ignores return value by external calls \"a.add(0)\" (tests/unused_return.sol#22)\n",
+        "id": "006cf638a8481a96dcadfb16ced8b99a13be326f11389429596b476a340d55fa",
         "elements": [
           {
             "type": "node",

--- a/tests/expected_json/unused_return.unused-return.txt
+++ b/tests/expected_json/unused_return.unused-return.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[93m
+[93m
 User.test(Target) (tests/unused_return.sol#17-29) ignores return value by external calls "t.f()" (tests/unused_return.sol#18)
 User.test(Target) (tests/unused_return.sol#17-29) ignores return value by external calls "a.add(0)" (tests/unused_return.sol#22)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-return[0m
-INFO:Slither:tests/unused_return.sol analyzed (3 contracts), 2 result(s) found
+tests/unused_return.sol analyzed (3 contracts with 1 detectors), 2 result(s) found

--- a/tests/expected_json/unused_state.unused-state.json
+++ b/tests/expected_json/unused_state.unused-state.json
@@ -8,6 +8,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "A.unused (tests/unused_state.sol#4) is never used in B\n",
+        "id": "6b1b08cab892baa51985a3d40d04203e7e6bbf361632ab3195e1b92d97c010c2",
         "elements": [
           {
             "type": "variable",
@@ -83,6 +84,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "A.unused2 (tests/unused_state.sol#5) is never used in B\n",
+        "id": "5d87257d7c56740f7282f66539f70e154e25076fa6610911f398344f4a1772a5",
         "elements": [
           {
             "type": "variable",
@@ -158,6 +160,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "A.unused3 (tests/unused_state.sol#6) is never used in B\n",
+        "id": "bb310e30a742e7c220aff30660795c31cc913359bc0c155cdad7e49117ee6a6d",
         "elements": [
           {
             "type": "variable",
@@ -233,6 +236,7 @@
         "impact": "Informational",
         "confidence": "High",
         "description": "A.unused4 (tests/unused_state.sol#7) is never used in B\n",
+        "id": "2d63629439c2c23af2ce6bd86d283cbfe6bad3ea38a89dfcf35cbfce8244525e",
         "elements": [
           {
             "type": "variable",

--- a/tests/expected_json/unused_state.unused-state.txt
+++ b/tests/expected_json/unused_state.unused-state.txt
@@ -1,7 +1,7 @@
-INFO:Detectors:[92m
+[92m
 A.unused (tests/unused_state.sol#4) is never used in B
 A.unused2 (tests/unused_state.sol#5) is never used in B
 A.unused3 (tests/unused_state.sol#6) is never used in B
 A.unused4 (tests/unused_state.sol#7) is never used in B
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-state-variables[0m
-INFO:Slither:tests/unused_state.sol analyzed (2 contracts), 4 result(s) found
+tests/unused_state.sol analyzed (2 contracts with 1 detectors), 4 result(s) found

--- a/tests/expected_json/void-cst.void-cst.json
+++ b/tests/expected_json/void-cst.void-cst.json
@@ -8,6 +8,7 @@
         "impact": "Low",
         "confidence": "High",
         "description": "Void constructor called in D.constructor() (tests/void-cst.sol#10-12):\n\t-C() tests/void-cst.sol#10\n",
+        "id": "87b854feb22ef03a7fde0cea7d43eca570c2538fafb530d00075b4cf3c414af2",
         "elements": [
           {
             "type": "function",

--- a/tests/expected_json/void-cst.void-cst.txt
+++ b/tests/expected_json/void-cst.void-cst.txt
@@ -1,5 +1,5 @@
-INFO:Detectors:[92m
+[92m
 Void constructor called in D.constructor() (tests/void-cst.sol#10-12):
 	-C() tests/void-cst.sol#10
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#void-constructor[0m
-INFO:Slither:tests/void-cst.sol analyzed (2 contracts), 1 result(s) found
+tests/void-cst.sol analyzed (2 contracts with 1 detectors), 1 result(s) found


### PR DESCRIPTION
Each json result has an unique Id.

The ID is for now generated as sha3-256(description), but can be improved to simplify the duplicate results triage