### PR TITLE
Use cache to speed up dapp travis test

### DIFF
--- a/scripts/travis_test_dapp.sh
+++ b/scripts/travis_test_dapp.sh
@@ -7,6 +7,9 @@ cd test_dapp
 
 curl https://nixos.org/nix/install | sh
 . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+nix-env -iA nixpkgs.cachix
+cachix use dapp
+
 git clone --recursive https://github.com/dapphub/dapptools $HOME/.dapp/dapptools
 nix-env -f $HOME/.dapp/dapptools -iA dapp seth solc hevm ethsign
 


### PR DESCRIPTION
Similar to https://github.com/crytic/crytic-compile/pull/42