### PR TITLE
Add JSON output for slither-check-upgradability tool

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -19,6 +19,7 @@ from slither.detectors.abstract_detector import (AbstractDetector,
 from slither.printers import all_printers
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.slither import Slither
+from slither.utils.json_utils import output_json
 from slither.utils.output_capture import StandardOutputCapture
 from slither.utils.colors import red, yellow, set_colorization_enabled
 from slither.utils.command_line import (output_detectors, output_results_to_markdown,
@@ -103,33 +104,6 @@ def process_from_asts(filenames, args, detector_classes, printer_classes):
 
 
 
-# endregion
-###################################################################################
-###################################################################################
-# region Output
-###################################################################################
-###################################################################################
-
-
-def output_json(filename, error, results):
-    # Create our encapsulated JSON result.
-    json_result = {
-        "success": error is None,
-        "error": error,
-        "results": results
-    }
-
-    # Determine if we should output to stdout
-    if filename is None:
-        # Write json to console
-        print(json.dumps(json_result))
-    else:
-        # Write json to file
-        if os.path.isfile(filename):
-            logger.info(yellow(f'{filename} exists already, the overwrite is prevented'))
-        else:
-            with open(filename, 'w', encoding='utf8') as f:
-                json.dump(json_result, f, indent=2)
 
 # endregion
 ###################################################################################

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -59,7 +59,9 @@ def output_json(filename, error, results):
     json_result = {
         "success": error == None,
         "error": error,
-        "results": results
+        "results": {
+            "upgradeability-check": results
+            }
     }
 
     # Determine if we should output to stdout

--- a/slither/tools/upgradeability/check_initialization.py
+++ b/slither/tools/upgradeability/check_initialization.py
@@ -4,8 +4,6 @@ from slither.slithir.operations import InternalCall
 from slither.utils.colors import green,red
 from slither.utils.colors import red, yellow, green
 
-from collections import OrderedDict
-
 logger = logging.getLogger("CheckInitialization")
 logger.setLevel(logging.INFO)
 
@@ -30,7 +28,7 @@ def _get_most_derived_init(contract):
 
 def check_initialization(s):
 
-    results = OrderedDict()
+    results = {}
     
     initializable = s.get_contract_from_name('Initializable')
 
@@ -39,7 +37,7 @@ def check_initialization(s):
     if initializable is None:
         logger.info(yellow('Initializable contract not found, the contract does not follow a standard initalization schema.'))
         results['absent'] = "Initializable contract not found, the contract does not follow a standard initalization schema."
-        return
+        return results
 
     init_info = ''
 
@@ -56,7 +54,7 @@ def check_initialization(s):
                     initializer_modifier_missing = True
                     info = f'{f.canonical_name} does not call initializer'
                     logger.info(red(info))
-                    results['missing_initializer_call'] = info
+                    results['missing-initializer-call'] = info
             most_derived_init = _get_most_derived_init(contract)
             if most_derived_init is None:
                 init_info += f'{contract.name} has no initialize function\n'
@@ -68,13 +66,13 @@ def check_initialization(s):
             for f in missing_calls:
                 info = f'Missing call to {f.canonical_name} in {contract.name}'
                 logger.info(red(info))
-                results['missing_call'] = info
+                results['missing-call'] = info
                 missing_call = True
             double_calls = list(set([f for f in all_init_functions_called if all_init_functions_called.count(f) > 1]))
             for f in double_calls:
-                info = f'{f.canonical_name} is called multiple time in {contract.name}'
+                info = f'{f.canonical_name} is called multiple times in {contract.name}'
                 logger.info(red(info))
-                results['multiple_calls'] = info
+                results['multiple-calls'] = info
                 double_calls_found = True
 
     if not initializer_modifier_missing:

--- a/slither/tools/upgradeability/compare_function_ids.py
+++ b/slither/tools/upgradeability/compare_function_ids.py
@@ -8,8 +8,6 @@ from slither import Slither
 from slither.utils.function import get_function_id
 from slither.utils.colors import red, green
 
-from collections import OrderedDict
-
 logger = logging.getLogger("CompareFunctions")
 logger.setLevel(logging.INFO)
 
@@ -24,7 +22,7 @@ def get_signatures(c):
 
 def compare_function_ids(implem, implem_name, proxy, proxy_name):
 
-    results = OrderedDict()
+    results = {}
     
     logger.info(green('Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)'))
 
@@ -32,13 +30,13 @@ def compare_function_ids(implem, implem_name, proxy, proxy_name):
     if implem_contract is None:
         info = f'{implem_name} not found in {implem.filename}'
         logger.info(red(info))
-        results['implementation_contract_not_found'] = info
+        results['implementation-contract-not-found'] = info
         return results
     proxy_contract = proxy.get_contract_from_name(proxy_name)
     if proxy_contract is None:
         info = f'{proxy_name} not found in {proxy.filename}'
         logger.info(red(info))
-        results['proxy_contract_not_found'] = info
+        results['proxy-contract-not-found'] = info
         return results
 
     signatures_implem = get_signatures(implem_contract)
@@ -54,7 +52,7 @@ def compare_function_ids(implem, implem_name, proxy, proxy_name):
             if signatures_ids_implem[k] != signatures_ids_proxy[k]:
                 info = 'Function id collision found {} {}'.format(signatures_ids_implem[k], signatures_ids_proxy[k])
                 logger.info(red(info))
-                results['function_id_collision'] = info
+                results['function-id-collision'] = info
                 
             else:
                 info = 'Shadowing between proxy and implementation found {}'.format(signatures_ids_implem[k])

--- a/slither/tools/upgradeability/compare_function_ids.py
+++ b/slither/tools/upgradeability/compare_function_ids.py
@@ -8,6 +8,8 @@ from slither import Slither
 from slither.utils.function import get_function_id
 from slither.utils.colors import red, green
 
+from collections import OrderedDict
+
 logger = logging.getLogger("CompareFunctions")
 logger.setLevel(logging.INFO)
 
@@ -22,16 +24,22 @@ def get_signatures(c):
 
 def compare_function_ids(implem, implem_name, proxy, proxy_name):
 
+    results = OrderedDict()
+    
     logger.info(green('Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)'))
 
     implem_contract = implem.get_contract_from_name(implem_name)
     if implem_contract is None:
-        logger.info(red(f'{implem_name} not found in {implem.filename}'))
-        return
+        info = f'{implem_name} not found in {implem.filename}'
+        logger.info(red(info))
+        results['implementation_contract_not_found'] = info
+        return results
     proxy_contract = proxy.get_contract_from_name(proxy_name)
     if proxy_contract is None:
-        logger.info(red(f'{proxy_name} not found in {proxy.filename}'))
-        return
+        info = f'{proxy_name} not found in {proxy.filename}'
+        logger.info(red(info))
+        results['proxy_contract_not_found'] = info
+        return results
 
     signatures_implem = get_signatures(implem_contract)
     signatures_proxy = get_signatures(proxy_contract)
@@ -44,11 +52,16 @@ def compare_function_ids(implem, implem_name, proxy, proxy_name):
         if k in signatures_ids_proxy:
             found = True
             if signatures_ids_implem[k] != signatures_ids_proxy[k]:
-                logger.info(red('Function id collision found {} {}'.format(signatures_ids_implem[k],
-                                                                           signatures_ids_proxy[k])))
+                info = 'Function id collision found {} {}'.format(signatures_ids_implem[k], signatures_ids_proxy[k])
+                logger.info(red(info))
+                results['function_id_collision'] = info
+                
             else:
-                logger.info(red('Shadowing between proxy and implementation found {}'.format(signatures_ids_implem[k])))
+                info = 'Shadowing between proxy and implementation found {}'.format(signatures_ids_implem[k])
+                logger.info(red(info))
+                results['shadowing'] = info
 
     if not found:
         logger.info(green('No function ids collision found'))
 
+    return results

--- a/slither/tools/upgradeability/compare_variables_order.py
+++ b/slither/tools/upgradeability/compare_variables_order.py
@@ -6,11 +6,15 @@ from slither import Slither
 from slither.utils.function import get_function_id
 from slither.utils.colors import red, green, yellow
 
+from collections import OrderedDict
+
 logger = logging.getLogger("VariablesOrder")
 logger.setLevel(logging.INFO)
 
 def compare_variables_order_implementation(v1, contract_name1, v2, contract_name2):
 
+    results = OrderedDict()
+    
     logger.info(green('Run variables order checks between implementations... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)'))
 
     contract_v1 = v1.get_contract_from_name(contract_name1)
@@ -32,16 +36,17 @@ def compare_variables_order_implementation(v1, contract_name1, v2, contract_name
     for idx in range(0, len(order_v1)):
         (v1_name, v1_type) =  order_v1[idx]
         if len(order_v2) < idx:
-            logger.info(red('Missing variable in the new version: {} {}'.format(v1_name, v1_type)))
+            info = 'Missing variable in the new version: {} {}'.format(v1_name, v1_type)
+            logger.info(red(info))
+            results['missing_variable'] = info
             continue
         (v2_name, v2_type) =  order_v2[idx]
 
         if (v1_name != v2_name) or (v1_type != v2_type):
             found = True
-            logger.info(red('Different variables between v1 and v2: {} {} -> {} {}'.format(v1_name,
-                                                                        v1_type,
-                                                                        v2_name,
-                                                                        v2_type)))
+            info = 'Different variables between v1 and v2: {} {} -> {} {}'.format(v1_name, v1_type, v2_name, v2_type)
+            logger.info(red(info))
+            results['different_variables'] = info
 
     if len(order_v2) > len(order_v1):
         new_variables = order_v2[len(order_v1):]
@@ -74,16 +79,20 @@ def compare_variables_order_proxy(implem, implem_name, proxy, proxy_name):
     for idx in range(0, len(order_proxy)):
         (proxy_name, proxy_type) =  order_proxy[idx]
         if len(order_implem) <= idx:
-            logger.info(red('Extra variable in the proxy: {} {}'.format(proxy_name, proxy_type)))
+            info = 'Extra variable in the proxy: {} {}'.format(proxy_name, proxy_type)
+            logger.info(red(info))
+            results['extra_variable'] = info
             continue
         (implem_name, implem_type) =  order_implem[idx]
 
         if (proxy_name != implem_name) or (proxy_type != implem_type):
             found = True
-            logger.info(red('Different variables between proxy and implem: {} {} -> {} {}'.format(proxy_name,
-                                                                        proxy_type,
-                                                                        implem_name,
-                                                                        implem_type)))
+            info = 'Different variables between proxy and implem: {} {} -> {} {}'.format(proxy_name,
+                                                                                         proxy_type,
+                                                                                         implem_name,
+                                                                                         implem_type)
+            logger.info(red(info))
+            results['different_variable'] = info
         else:
             logger.info(yellow('Variable in the proxy: {} {}'.format(proxy_name,
                                                                      proxy_type)))

--- a/slither/tools/upgradeability/compare_variables_order.py
+++ b/slither/tools/upgradeability/compare_variables_order.py
@@ -5,6 +5,7 @@ import logging
 from slither import Slither
 from slither.utils.function import get_function_id
 from slither.utils.colors import red, green, yellow
+from slither.exceptions import SlitherException
 
 logger = logging.getLogger("VariablesOrder")
 logger.setLevel(logging.INFO)
@@ -71,15 +72,13 @@ def compare_variables_order_proxy(implem, implem_name, proxy, proxy_name):
     if contract_implem is None:
         info = 'Contract {} not found in {}'.format(implem_name, implem.filename)
         logger.info(red(info))
-        results['output-error'] = info
-        return results
+        raise SlitherException(info)
 
     contract_proxy = proxy.get_contract_from_name(proxy_name)
     if contract_proxy is None:
         info = 'Contract {} not found in {}'.format(proxy_name, proxy.filename)
         logger.info(red(info))
-        results['output-error'] = info
-        return results
+        raise SlitherException(info)
 
     order_implem = [(variable.name, variable.type) for variable in contract_implem.state_variables if not variable.is_constant]
     order_proxy = [(variable.name, variable.type) for variable in contract_proxy.state_variables if not variable.is_constant]

--- a/slither/tools/upgradeability/compare_variables_order.py
+++ b/slither/tools/upgradeability/compare_variables_order.py
@@ -20,15 +20,13 @@ def compare_variables_order_implementation(v1, contract_name1, v2, contract_name
     if contract_v1 is None:
         info = 'Contract {} not found in {}'.format(contract_name1, v1.filename)
         logger.info(red(info))
-        results['output-error'] = info
-        return results
+        raise SlitherException(info)
 
     contract_v2 = v2.get_contract_from_name(contract_name2)
     if contract_v2 is None:
         info = 'Contract {} not found in {}'.format(contract_name2, v2.filename)
         logger.info(red(info))
-        results['output-error'] = info
-        return results
+        raise SlitherException(info)
 
     order_v1 = [(variable.name, variable.type) for variable in contract_v1.state_variables if not variable.is_constant]
     order_v2 = [(variable.name, variable.type) for variable in contract_v2.state_variables if not variable.is_constant]

--- a/slither/utils/json_utils.py
+++ b/slither/utils/json_utils.py
@@ -1,0 +1,36 @@
+import os
+import json
+import logging
+from slither.utils.colors import yellow
+logger = logging.getLogger("Slither")
+
+def output_json(filename, error, results):
+    """
+
+    :param filename: Filename where the json will be written. If None or "-", write to stdout
+    :param error: Error to report
+    :param results: Results to report
+    :param logger: Logger where to log potential info
+    :return:
+    """
+    # Create our encapsulated JSON result.
+    json_result = {
+        "success": error is None,
+        "error": error,
+        "results": results
+    }
+
+    if filename == "-":
+        filename = None
+
+    # Determine if we should output to stdout
+    if filename is None:
+        # Write json to console
+        print(json.dumps(json_result))
+    else:
+        # Write json to file
+        if os.path.isfile(filename):
+            logger.info(yellow(f'{filename} exists already, the overwrite is prevented'))
+        else:
+            with open(filename, 'w', encoding='utf8') as f:
+                json.dump(json_result, f, indent=2)

--- a/tests/check-upgradeability/test_5.txt
+++ b/tests/check-upgradeability/test_5.txt
@@ -1,7 +1,7 @@
 INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
 INFO:CheckInitialization:[91mContract_lack_to_call_modifier.initialize() does not call initializer[0m
 INFO:CheckInitialization:[91mMissing call to Contract_no_bug.initialize() in Contract_not_called_super_init[0m
-INFO:CheckInitialization:[91mContract_no_bug.initialize() is called multiples time in Contract_double_call[0m
+INFO:CheckInitialization:[91mContract_no_bug.initialize() is called multiple times in Contract_double_call[0m
 INFO:CheckInitialization:[92mCheck the deployement script to ensure that these functions are called:
 Contract_no_bug needs to be initialized by initialize()
 Contract_lack_to_call_modifier needs to be initialized by initialize()

--- a/tests/check-upgradeability/test_5.txt
+++ b/tests/check-upgradeability/test_5.txt
@@ -1,7 +1,7 @@
 INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
 INFO:CheckInitialization:[91mContract_lack_to_call_modifier.initialize() does not call initializer[0m
 INFO:CheckInitialization:[91mMissing call to Contract_no_bug.initialize() in Contract_not_called_super_init[0m
-INFO:CheckInitialization:[91mContract_no_bug.initialize() is called multiple time in Contract_double_call[0m
+INFO:CheckInitialization:[91mContract_no_bug.initialize() is called multiples time in Contract_double_call[0m
 INFO:CheckInitialization:[92mCheck the deployement script to ensure that these functions are called:
 Contract_no_bug needs to be initialized by initialize()
 Contract_lack_to_call_modifier needs to be initialized by initialize()


### PR DESCRIPTION
This PR addresses #347 to add JSON output support for `slither-check-upgradability` tool as per the format specified in https://github.com/crytic/slither/wiki/JSON-output.

For now, it adds only the textual information which was being logged. Next step is to add source mapping and any more contextual information, as required.