### PR TITLE
Use node 10.17.0 for embark and etherlime

### DIFF
--- a/scripts/travis_test_embark.sh
+++ b/scripts/travis_test_embark.sh
@@ -7,8 +7,8 @@ cd test_embark
 
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 source ~/.nvm/nvm.sh
-nvm install --lts
-nvm use --lts
+nvm install 10.17.0
+nvm use 10.17.0
 npm --version
 
 npm install -g embark

--- a/scripts/travis_test_etherlime.sh
+++ b/scripts/travis_test_etherlime.sh
@@ -7,8 +7,8 @@ cd test_etherlime
 
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
 source ~/.nvm/nvm.sh
-nvm install --lts
-nvm use --lts
+nvm install 10.17.0
+nvm use 10.17.0
 
 npm i -g etherlime
 etherlime init


### PR DESCRIPTION
Node 12.x became the [new active node version](https://github.com/nodejs/Release#release-schedule), which breaks embark and etherlime