### PR TITLE
Refactor of slither-upgradeability-check

### DIFF
--- a/scripts/travis_test_upgradability.sh
+++ b/scripts/travis_test_upgradability.sh
@@ -128,6 +128,31 @@ then
     exit -1
 fi
 
+slither-check-upgradeability "$DIR_TESTS/contractV1.sol" ContractV1 --solc solc-0.5.0 --new-contract-filename "$DIR_TESTS/contract_v2_constant.sol" --new-contract-name ContractV2 > test_10.txt 2>&1
+DIFF=$(diff test_10.txt "$DIR_TESTS/test_10.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 10 failed"
+    cat test_10.txt
+    echo ""
+    cat "$DIR_TESTS/test_10.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+slither-check-upgradeability "$DIR_TESTS/contract_v1_var_init.sol" ContractV1 --solc solc-0.5.0  > test_11.txt 2>&1
+DIFF=$(diff test_11.txt "$DIR_TESTS/test_11.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 11 failed"
+    cat test_11.txt
+    echo ""
+    cat "$DIR_TESTS/test_11.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
 
 rm test_1.txt
 rm test_2.txt
@@ -138,4 +163,5 @@ rm test_6.txt
 rm test_7.txt
 rm test_8.txt
 rm test_9.txt
-
+rm test_10.txt
+rm test_11.txt

--- a/scripts/travis_test_upgradability.sh
+++ b/scripts/travis_test_upgradability.sh
@@ -4,7 +4,7 @@
 
 DIR_TESTS="tests/check-upgradeability"
 
-slither-check-upgradeability "$DIR_TESTS/proxy.sol" Proxy "$DIR_TESTS/contractV1.sol" ContractV1 --solc solc-0.5.0 > test_1.txt 2>&1
+slither-check-upgradeability  "$DIR_TESTS/contractV1.sol" ContractV1 --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy --solc solc-0.5.0 > test_1.txt 2>&1
 DIFF=$(diff test_1.txt "$DIR_TESTS/test_1.txt")
 if [  "$DIFF" != "" ] 
 then
@@ -15,7 +15,7 @@ then
     exit -1
 fi
 
-slither-check-upgradeability "$DIR_TESTS/proxy.sol" Proxy "$DIR_TESTS/contractV1.sol" ContractV1 --solc solc-0.5.0 --new-version "$DIR_TESTS/contractV2.sol" --new-contract-name ContractV2 > test_2.txt 2>&1 
+slither-check-upgradeability "$DIR_TESTS/contractV1.sol" ContractV1  --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy --solc solc-0.5.0 --new-contract-filename "$DIR_TESTS/contractV2.sol" --new-contract-name ContractV2 > test_2.txt 2>&1
 DIFF=$(diff test_2.txt "$DIR_TESTS/test_2.txt")
 if [  "$DIFF" != "" ] 
 then
@@ -26,7 +26,7 @@ then
     exit -1
 fi
 
-slither-check-upgradeability "$DIR_TESTS/proxy.sol" Proxy "$DIR_TESTS/contractV1.sol" ContractV1 --solc solc-0.5.0 --new-version "$DIR_TESTS/contractV2_bug.sol" --new-contract-name ContractV2 > test_3.txt 2>&1 
+slither-check-upgradeability "$DIR_TESTS/contractV1.sol" ContractV1 --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy --solc solc-0.5.0 --new-contract-filename "$DIR_TESTS/contractV2_bug.sol" --new-contract-name ContractV2 > test_3.txt 2>&1
 DIFF=$(diff test_3.txt "$DIR_TESTS/test_3.txt")
 if [  "$DIFF" != "" ] 
 then
@@ -37,7 +37,7 @@ then
     exit -1
 fi
 
-slither-check-upgradeability "$DIR_TESTS/proxy.sol" Proxy "$DIR_TESTS/contractV1.sol" ContractV1 --solc solc-0.5.0 --new-version "$DIR_TESTS/contractV2_bug2.sol" --new-contract-name ContractV2 > test_4.txt 2>&1 
+slither-check-upgradeability "$DIR_TESTS/contractV1.sol" ContractV1 --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy --solc solc-0.5.0 --new-contract-filename "$DIR_TESTS/contractV2_bug2.sol" --new-contract-name ContractV2 > test_4.txt 2>&1
 DIFF=$(diff test_4.txt "$DIR_TESTS/test_4.txt")
 if [  "$DIFF" != "" ] 
 then
@@ -48,7 +48,7 @@ then
     exit -1
 fi
 
-slither-check-upgradeability "$DIR_TESTS/proxy.sol" Proxy "$DIR_TESTS/contract_initialization.sol" Contract_no_bug --solc solc-0.5.0 > test_5.txt 2>&1 
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_no_bug --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_5.txt 2>&1
 DIFF=$(diff test_5.txt "$DIR_TESTS/test_5.txt")
 if [  "$DIFF" != "" ] 
 then
@@ -61,9 +61,81 @@ then
     exit -1
 fi
 
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_no_bug --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_5.txt 2>&1
+DIFF=$(diff test_5.txt "$DIR_TESTS/test_5.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 5 failed"
+    cat test_5.txt
+    echo ""
+    cat "$DIR_TESTS/test_5.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_lack_to_call_modifier --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_6.txt 2>&1
+DIFF=$(diff test_6.txt "$DIR_TESTS/test_6.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 6 failed"
+    cat test_6.txt
+    echo ""
+    cat "$DIR_TESTS/test_6.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_not_called_super_init --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_7.txt 2>&1
+DIFF=$(diff test_7.txt "$DIR_TESTS/test_7.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 7 failed"
+    cat test_7.txt
+    echo ""
+    cat "$DIR_TESTS/test_7.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_no_bug_inherits --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_8.txt 2>&1
+DIFF=$(diff test_8.txt "$DIR_TESTS/test_8.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 8 failed"
+    cat test_8.txt
+    echo ""
+    cat "$DIR_TESTS/test_8.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+slither-check-upgradeability "$DIR_TESTS/contract_initialization.sol" Contract_double_call --proxy-filename "$DIR_TESTS/proxy.sol" --proxy-name Proxy  --solc solc-0.5.0 > test_9.txt 2>&1
+DIFF=$(diff test_9.txt "$DIR_TESTS/test_9.txt")
+if [  "$DIFF" != "" ]
+then
+    echo "slither-check-upgradeability 9 failed"
+    cat test_9.txt
+    echo ""
+    cat "$DIR_TESTS/test_9.txt"
+    echo ""
+    echo "$DIFF"
+    exit -1
+fi
+
+
 rm test_1.txt
 rm test_2.txt
 rm test_3.txt
 rm test_4.txt
 rm test_5.txt
+rm test_6.txt
+rm test_7.txt
+rm test_8.txt
+rm test_9.txt
 

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -508,6 +508,16 @@ class Contract(ChildSlither, SourceMapping):
         """
         return next((v for v in self.state_variables if v.name == variable_name), None)
 
+    def get_state_variable_from_canonical_name(self, canonical_name):
+        """
+            Return a state variable from a canonical_name
+        Args:
+            canonical_name (str): name of the variable
+        Returns:
+            StateVariable
+        """
+        return next((v for v in self.state_variables if v.name == canonical_name), None)
+
     def get_structure_from_name(self, structure_name):
         """
             Return a structure from a name

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from slither import Slither
 from crytic_compile import cryticparser
 from slither.exceptions import SlitherException
+from slither.utils.colors import red
 from slither.utils.json_utils import output_json
 
 from .compare_variables_order import compare_variables_order
@@ -79,6 +80,7 @@ def _checks_on_contract_update(contract_v1, contract_v2, json_results):
     :param json_results:
     :return:
     """
+
     ret = compare_variables_order(contract_v1, contract_v2)
     json_results['compare-variables-order-implementation'][contract_v1.name][contract_v2.name] = ret
 
@@ -131,7 +133,7 @@ def main():
         v1_contract = v1.get_contract_from_name(v1_name)
         if v1_contract is None:
             info = 'Contract {} not found in {}'.format(v1_name, v1.filename)
-            logger.error(info)
+            logger.error(red(info))
             if args.json:
                 output_json(args.json, str(info), {"upgradeability-check": json_results})
             return
@@ -149,7 +151,7 @@ def main():
             proxy_contract = proxy.get_contract_from_name(args.proxy_name)
             if proxy_contract is None:
                 info = 'Proxy {} not found in {}'.format(args.proxy_name, proxy.filename)
-                logger.error(info)
+                logger.error(red(info))
                 if args.json:
                     output_json(args.json, str(info), {"upgradeability-check": json_results})
                 return
@@ -166,7 +168,7 @@ def main():
             v2_contract = v2.get_contract_from_name(args.new_contract_name)
             if v2_contract is None:
                 info = 'New logic contract {} not found in {}'.format(args.new_contract_name, v2.filename)
-                logger.error(info)
+                logger.error(red(info))
                 if args.json:
                     output_json(args.json, str(info), {"upgradeability-check": json_results})
                 return

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -1,35 +1,44 @@
 import logging
 import argparse
 import sys
+from collections import defaultdict
 
 from slither import Slither
 from crytic_compile import cryticparser
 from slither.exceptions import SlitherException
 from slither.utils.json_utils import output_json
 
-from .compare_variables_order import compare_variables_order_implementation, compare_variables_order_proxy
+from .compare_variables_order import compare_variables_order
 from .compare_function_ids import compare_function_ids
 from .check_initialization import check_initialization
-
+from .check_variable_initialization import check_variable_initialization
+from .constant_checks import constant_conformance_check
 
 logging.basicConfig()
 logger = logging.getLogger("Slither-check-upgradeability")
 logger.setLevel(logging.INFO)
 
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+formatter = logging.Formatter('%(message)s')
+logger.addHandler(ch)
+logger.handlers[0].setFormatter(formatter)
+logger.propagate = False
+
 def parse_args():
 
     parser = argparse.ArgumentParser(description='Slither Upgradeability Checks. For usage information see https://github.com/crytic/slither/wiki/Upgradeability-Checks.',
-                                     usage="slither-check-upgradeability proxy.sol ProxyName implem.sol ContractName")
+                                     usage="slither-check-upgradeability contract.sol ContractName")
 
 
-    parser.add_argument('proxy.sol', help='Proxy filename')
-    parser.add_argument('ProxyName', help='Contract name')
+    parser.add_argument('contract.sol', help='Codebase to analyze')
+    parser.add_argument('ContractName', help='Contract name (logic contract)')
 
-    parser.add_argument('implem.sol', help='Implementation filename')
-    parser.add_argument('ContractName', help='Contract name')
+    parser.add_argument('--proxy-name', help='Proxy name')
+    parser.add_argument('--proxy-filename', help='Proxy filename (if different)')
 
-    parser.add_argument('--new-version', help='New implementation filename')
     parser.add_argument('--new-contract-name', help='New contract name (if changed)')
+    parser.add_argument('--new-contract-filename', help='New implementation filename (if different)')
 
     parser.add_argument('--json',
                         help='Export the results as a JSON file ("--json -" to export to stdout)',
@@ -47,60 +56,137 @@ def parse_args():
 
 ###################################################################################
 ###################################################################################
+# region
+###################################################################################
+###################################################################################
+
+def _checks_on_contract(contract, json_results):
+    """
+
+    :param contract:
+    :param json_results:
+    :return:
+    """
+    json_results['check-initialization'][contract.name] = check_initialization(contract)
+    json_results['variable-initialization'][contract.name] = check_variable_initialization(contract)
+
+
+def _checks_on_contract_update(contract_v1, contract_v2, json_results):
+    """
+
+    :param contract_v1:
+    :param contract_v2:
+    :param json_results:
+    :return:
+    """
+    ret = compare_variables_order(contract_v1, contract_v2)
+    json_results['compare-variables-order-implementation'][contract_v1.name][contract_v2.name] = ret
+
+    json_results['constant_conformance'][contract_v1.name][contract_v2.name] = constant_conformance_check(contract_v1,
+                                                                                                          contract_v2)
+
+
+def _checks_on_contract_and_proxy(contract, proxy, json_results, missing_variable_check=True):
+    """
+
+    :param contract:
+    :param proxy:
+    :param json_results:
+    :return:
+    """
+    json_results['compare-function-ids'][contract.name] = compare_function_ids(contract, proxy)
+    json_results['compare-variables-order-proxy'][contract.name] = compare_variables_order(contract,
+                                                                                           proxy,
+                                                                                           missing_variable_check)
+
+# endregion
+###################################################################################
+###################################################################################
 # region Main
 ###################################################################################
 ###################################################################################
 
 
 def main():
+    json_results = {
+        'check-initialization': defaultdict(dict),
+        'variable-initialization': defaultdict(dict),
+        'compare-function-ids': defaultdict(dict),
+        'compare-variables-order-implementation': defaultdict(dict),
+        'compare-variables-order-proxy': defaultdict(dict),
+        'constant_conformance': defaultdict(dict),
+        'proxy-present': False,
+        'contract_v2-present': False
+    }
+
     args = parse_args()
 
-    proxy_filename = vars(args)['proxy.sol']
-    proxy = Slither(proxy_filename, **vars(args))
-    proxy_name = args.ProxyName
+    v1_filename = vars(args)['contract.sol']
 
-    v1_filename = vars(args)['implem.sol']
-    v1 = Slither(v1_filename, **vars(args))
-    v1_name = args.ContractName
+    try:
+        v1 = Slither(v1_filename, **vars(args))
 
-    # Define some variables for potential JSON output
-    json_results = {}
-    output_error = ''
+        # Analyze logic contract
+        v1_name = args.ContractName
+        v1_contract = v1.get_contract_from_name(v1_name)
+        if v1_contract is None:
+            info = 'Contract {} not found in {}'.format(v1_name, v1.filename)
+            logger.error(info)
+            if args.json:
+                output_json(args.json, str(info), {"upgradeability-check": json_results})
+            return
 
-    json_results['check-initialization'] = check_initialization(v1)
+        _checks_on_contract(v1_contract, json_results)
 
-    if not args.new_version:
-        json_results['compare-function-ids'] = compare_function_ids(v1, v1_name, proxy, proxy_name)
-        json_results['compare-variables-order-proxy'] = compare_variables_order_proxy(v1, v1_name, proxy, proxy_name)
-    else:
-        v2 = Slither(args.new_version, **vars(args))
-        v2_name = v1_name if not args.new_contract_name else args.new_contract_name
+        # Analyze Proxy
+        proxy_contract = None
+        if args.proxy_name:
+            if args.proxy_filename:
+                proxy = Slither(args.proxy_filename, **vars(args))
+            else:
+                proxy = v1
 
-        json_results['check-initialization-v2'] = check_initialization(v2)
+            proxy_contract = proxy.get_contract_from_name(args.proxy_name)
+            if proxy_contract is None:
+                info = 'Proxy {} not found in {}'.format(args.proxy_name, proxy.filename)
+                logger.error(info)
+                if args.json:
+                    output_json(args.json, str(info), {"upgradeability-check": json_results})
+                return
+            json_results['proxy-present'] = True
+            _checks_on_contract_and_proxy(v1_contract, proxy_contract, json_results)
 
-        json_results['compare-function-ids'] = compare_function_ids(v2, v2_name, proxy, proxy_name)
+        # Analyze new version
+        if args.new_contract_name:
+            if args.new_contract_filename:
+                v2 = Slither(args.new_contract_filename, **vars(args))
+            else:
+                v2 = v1
 
-        results = {}
-        output_error = ''
+            v2_contract = v2.get_contract_from_name(args.new_contract_name)
+            if v2_contract is None:
+                info = 'New logic contract {} not found in {}'.format(args.new_contract_name, v2.filename)
+                logger.error(info)
+                if args.json:
+                    output_json(args.json, str(info), {"upgradeability-check": json_results})
+                return
+            json_results['contract_v2-present'] = True
 
-        try:
-            results = compare_variables_order_proxy(v2, v2_name, proxy, proxy_name)
-        except SlitherException as se:
-            output_error = str(se)
-        json_results['compare-variables-order-proxy'] = results
-        
-        try:
-            results = compare_variables_order_implementation(v1, v1_name, v2, v2_name)
-        except SlitherException as se:
-            output_error += str(se)
-        json_results['compare-variables-order-implementation'] = results
+            if proxy_contract:
+                _checks_on_contract_and_proxy(v2_contract,
+                                              proxy_contract,
+                                              json_results,
+                                              missing_variable_check=False)
 
-    if output_error == '':
-        output_error = None
-        
-    # If we are outputting JSON, capture the redirected output and disable the redirect to output the final JSON.
-    if args.json:
-        output_json(args.json, output_error, {"upgradeability-check": json_results})
+            _checks_on_contract_update(v1_contract, v2_contract, json_results)
 
-        
+        if args.json:
+            output_json(args.json, None, {"upgradeability-check": json_results})
+
+    except SlitherException as e:
+        logger.error(str(e))
+        if args.json:
+            output_json(args.json, str(e), {"upgradeability-check": json_results})
+        return
+
 # endregion

--- a/slither/tools/upgradeability/check_variable_initialization.py
+++ b/slither/tools/upgradeability/check_variable_initialization.py
@@ -1,5 +1,6 @@
 import logging
 
+from slither.utils import json_utils
 from slither.utils.colors import red, green
 
 logger = logging.getLogger("Slither-check-upgradeability")
@@ -19,14 +20,9 @@ def check_variable_initialization(contract):
         if s.initialized and not s.is_constant:
             info = f'{s.canonical_name} has an initial value ({s.source_mapping_str})'
             logger.info(red(info))
-            results['variables-initialized'].append(
-                {
-                    'description': info,
-                    'name': s.name,
-                    'contract': s.contract.name,
-                    'source_mapping': s.source_mapping
-                }
-            )
+            json_elem = json_utils.generate_json_result(info)
+            json_utils.add_variable_to_json(s, json_elem)
+            results['variables-initialized'].append(json_elem)
             error_found = True
 
     if not error_found:

--- a/slither/tools/upgradeability/check_variable_initialization.py
+++ b/slither/tools/upgradeability/check_variable_initialization.py
@@ -1,0 +1,35 @@
+import logging
+
+from slither.utils.colors import red, green
+
+logger = logging.getLogger("Slither-check-upgradeability")
+
+
+def check_variable_initialization(contract):
+    results = {
+        'variables-initialized': []
+    }
+
+    logger.info(green(
+        '\n## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)'))
+
+    error_found = False
+
+    for s in contract.state_variables:
+        if s.initialized and not s.is_constant:
+            info = f'{s.canonical_name} has an initial value ({s.source_mapping_str})'
+            logger.info(red(info))
+            results['variables-initialized'].append(
+                {
+                    'description': info,
+                    'name': s.name,
+                    'contract': s.contract.name,
+                    'source_mapping': s.source_mapping
+                }
+            )
+            error_found = True
+
+    if not error_found:
+        logger.info(green('No error found'))
+
+    return results

--- a/slither/tools/upgradeability/compare_function_ids.py
+++ b/slither/tools/upgradeability/compare_function_ids.py
@@ -8,8 +8,7 @@ from slither import Slither
 from slither.utils.function import get_function_id
 from slither.utils.colors import red, green
 
-logger = logging.getLogger("CompareFunctions")
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("Slither-check-upgradeability")
 
 def get_signatures(c):
     functions = c.functions
@@ -20,46 +19,42 @@ def get_signatures(c):
     return list(set(functions+variables))
 
 
-def compare_function_ids(implem, implem_name, proxy, proxy_name):
+def compare_function_ids(implem, proxy):
 
-    results = {}
+    results = {
+        'function-id-collision':[],
+        'shadowing':[],
+    }
     
-    logger.info(green('Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)'))
+    logger.info(green('\n## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)'))
 
-    implem_contract = implem.get_contract_from_name(implem_name)
-    if implem_contract is None:
-        info = f'{implem_name} not found in {implem.filename}'
-        logger.info(red(info))
-        results['implementation-contract-not-found'] = info
-        return results
-    proxy_contract = proxy.get_contract_from_name(proxy_name)
-    if proxy_contract is None:
-        info = f'{proxy_name} not found in {proxy.filename}'
-        logger.info(red(info))
-        results['proxy-contract-not-found'] = info
-        return results
-
-    signatures_implem = get_signatures(implem_contract)
-    signatures_proxy = get_signatures(proxy_contract)
+    signatures_implem = get_signatures(implem)
+    signatures_proxy = get_signatures(proxy)
 
     signatures_ids_implem = {get_function_id(s): s for s in signatures_implem}
     signatures_ids_proxy = {get_function_id(s): s for s in signatures_proxy}
 
-    found = False
+    error_found = False
     for (k, _) in signatures_ids_implem.items():
         if k in signatures_ids_proxy:
-            found = True
+            error_found = True
             if signatures_ids_implem[k] != signatures_ids_proxy[k]:
                 info = 'Function id collision found {} {}'.format(signatures_ids_implem[k], signatures_ids_proxy[k])
                 logger.info(red(info))
-                results['function-id-collision'] = info
+                results['function-id-collision'].append({
+                    'description': info,
+                    'function1': signatures_ids_implem[k],
+                    'function2': signatures_ids_proxy[k],
+                })
                 
             else:
                 info = 'Shadowing between proxy and implementation found {}'.format(signatures_ids_implem[k])
                 logger.info(red(info))
-                results['shadowing'] = info
+                results['shadowing'].append({
+                    'function': signatures_ids_implem[k]
+                })
 
-    if not found:
-        logger.info(green('No function ids collision found'))
+    if not error_found:
+        logger.info(green('No error found'))
 
     return results

--- a/slither/tools/upgradeability/compare_function_ids.py
+++ b/slither/tools/upgradeability/compare_function_ids.py
@@ -12,7 +12,8 @@ logger = logging.getLogger("Slither-check-upgradeability")
 
 def get_signatures(c):
     functions = c.functions
-    functions = [f.full_name for f in functions if f.visibility in ['public', 'external'] and not f.is_constructor]
+    functions = [f.full_name for f in functions if f.visibility in ['public', 'external'] and
+                 not f.is_constructor and not f.is_fallback]
 
     variables = c.state_variables
     variables = [variable.name+ '()' for variable in variables if variable.visibility in ['public']]

--- a/slither/tools/upgradeability/compare_variables_order.py
+++ b/slither/tools/upgradeability/compare_variables_order.py
@@ -2,6 +2,8 @@
     Check if the variables respect the same ordering
 '''
 import logging
+
+from slither.utils import json_utils
 from slither.utils.colors import red, green, yellow
 
 logger = logging.getLogger("Slither-check-upgradeability")
@@ -29,11 +31,11 @@ def compare_variables_order(contract1, contract2, missing_variable_check=True):
             if missing_variable_check:
                 info = f'Variable only in {contract1.name}: {variable1.name} ({variable1.source_mapping_str})'
                 logger.info(yellow(info))
-                results['missing_variables'].append({
-                    'description': info,
-                    'variable': variable1.name,
-                    'source_mapping': variable1.source_mapping
-                })
+
+                json_elem = json_utils.generate_json_result(info)
+                json_utils.add_variable_to_json(variable1, json_elem)
+                results['missing_variables'].append(json_elem)
+
                 error_found = True
             continue
 
@@ -44,14 +46,12 @@ def compare_variables_order(contract1, contract2, missing_variable_check=True):
             info += f'\t Variable {idx} in {contract1.name}: {variable1.name} {variable1.type} ({variable1.source_mapping_str})\n'
             info += f'\t Variable {idx} in {contract2.name}: {variable2.name} {variable2.type} ({variable2.source_mapping_str})\n'
             logger.info(red(info))
-            results['different-variables'].append({
-                'description': info,
-                'index': idx,
-                'variable1': variable1.name,
-                'variable1_source_mapping': variable1.source_mapping,
-                'variable2': variable2.name,
-                'variable2_source_mapping': variable2.source_mapping,
-            })
+
+            json_elem = json_utils.generate_json_result(info, additional_fields={'index': idx})
+            json_utils.add_variable_to_json(variable1, json_elem)
+            json_utils.add_variable_to_json(variable2, json_elem)
+            results['different-variables'].append(json_elem)
+
             error_found = True
 
     idx = idx + 1
@@ -61,12 +61,9 @@ def compare_variables_order(contract1, contract2, missing_variable_check=True):
 
         info = f'Extra variables in {contract2.name}: {variable2.name} ({variable2.source_mapping_str})\n'
         logger.info(yellow(info))
-        results['extra-variables'].append({
-            'description': info,
-            'index': idx,
-            'variable': variable2.name,
-            'variable_source_mapping': variable2.source_mapping
-        })
+        json_elem = json_utils.generate_json_result(info, additional_fields={'index': idx})
+        json_utils.add_variable_to_json(variable2, json_elem)
+        results['extra-variables'].append(json_elem)
         idx = idx + 1
 
     if not error_found:

--- a/slither/tools/upgradeability/compare_variables_order.py
+++ b/slither/tools/upgradeability/compare_variables_order.py
@@ -2,118 +2,75 @@
     Check if the variables respect the same ordering
 '''
 import logging
-from slither import Slither
-from slither.utils.function import get_function_id
 from slither.utils.colors import red, green, yellow
-from slither.exceptions import SlitherException
 
-logger = logging.getLogger("VariablesOrder")
-logger.setLevel(logging.INFO)
+logger = logging.getLogger("Slither-check-upgradeability")
 
-def compare_variables_order_implementation(v1, contract_name1, v2, contract_name2):
 
-    results = {}
-    
-    logger.info(green('Run variables order checks between implementations... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)'))
+def compare_variables_order(contract1, contract2, missing_variable_check=True):
 
-    contract_v1 = v1.get_contract_from_name(contract_name1)
-    if contract_v1 is None:
-        info = 'Contract {} not found in {}'.format(contract_name1, v1.filename)
-        logger.info(red(info))
-        raise SlitherException(info)
+    results = {
+        'missing_variables': [],
+        'different-variables': [],
+        'extra-variables': []
+    }
 
-    contract_v2 = v2.get_contract_from_name(contract_name2)
-    if contract_v2 is None:
-        info = 'Contract {} not found in {}'.format(contract_name2, v2.filename)
-        logger.info(red(info))
-        raise SlitherException(info)
+    logger.info(green(
+        f'\n## Run variables ordering checks between {contract1.name} and {contract2.name}... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)'))
 
-    order_v1 = [(variable.name, variable.type) for variable in contract_v1.state_variables if not variable.is_constant]
-    order_v2 = [(variable.name, variable.type) for variable in contract_v2.state_variables if not variable.is_constant]
+    order1 = [variable for variable in contract1.state_variables if not variable.is_constant]
+    order2 = [variable for variable in contract2.state_variables if not variable.is_constant]
 
-    results['missing-variable'] = []
-    results['different-variables'] = []
-    found = False
-    for idx in range(0, len(order_v1)):
-        (v1_name, v1_type) =  order_v1[idx]
-        if len(order_v2) < idx:
-            info = 'Missing variable in the new version: {} {}'.format(v1_name, v1_type)
-            logger.info(red(info))
-            results['missing-variable'].append(info)
+    error_found = False
+    idx = 0
+    for idx in range(0, len(order1)):
+        variable1 = order1[idx]
+        if len(order2) <= idx:
+            if missing_variable_check:
+                info = f'Variable only in {contract1.name}: {variable1.name} ({variable1.source_mapping_str})'
+                logger.info(yellow(info))
+                results['missing_variables'].append({
+                    'description': info,
+                    'variable': variable1.name,
+                    'source_mapping': variable1.source_mapping
+                })
+                error_found = True
             continue
-        (v2_name, v2_type) =  order_v2[idx]
 
-        if (v1_name != v2_name) or (v1_type != v2_type):
-            found = True
-            info = 'Different variables between v1 and v2: {} {} -> {} {}'.format(v1_name, v1_type, v2_name, v2_type)
+        variable2 = order2[idx]
+
+        if (variable1.name != variable2.name) or (variable1.type != variable2.type):
+            info = f'Different variables between {contract1.name} and {contract2.name}:\n'
+            info += f'\t Variable {idx} in {contract1.name}: {variable1.name} {variable1.type} ({variable1.source_mapping_str})\n'
+            info += f'\t Variable {idx} in {contract2.name}: {variable2.name} {variable2.type} ({variable2.source_mapping_str})\n'
             logger.info(red(info))
-            results['different-variables'].append(info)
+            results['different-variables'].append({
+                'description': info,
+                'index': idx,
+                'variable1': variable1.name,
+                'variable1_source_mapping': variable1.source_mapping,
+                'variable2': variable2.name,
+                'variable2_source_mapping': variable2.source_mapping,
+            })
+            error_found = True
 
-    if len(order_v2) > len(order_v1):
-        new_variables = order_v2[len(order_v1):]
-        for (name, t) in new_variables:
-            logger.info(green('New variable: {} {}'.format(name, t)))
+    idx = idx + 1
 
-    if not found:
-        logger.info(green('No variables ordering error found between implementations'))
+    while idx < len(order2):
+        variable2 = order2[idx]
+
+        info = f'Extra variables in {contract2.name}: {variable2.name} ({variable2.source_mapping_str})\n'
+        logger.info(yellow(info))
+        results['extra-variables'].append({
+            'description': info,
+            'index': idx,
+            'variable': variable2.name,
+            'variable_source_mapping': variable2.source_mapping
+        })
+        idx = idx + 1
+
+    if not error_found:
+        logger.info(green('No error found'))
 
     return results
 
-
-def compare_variables_order_proxy(implem, implem_name, proxy, proxy_name):
-
-    results = {}
-    
-    logger.info(green('Run variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)'))
-
-    contract_implem = implem.get_contract_from_name(implem_name)
-    if contract_implem is None:
-        info = 'Contract {} not found in {}'.format(implem_name, implem.filename)
-        logger.info(red(info))
-        raise SlitherException(info)
-
-    contract_proxy = proxy.get_contract_from_name(proxy_name)
-    if contract_proxy is None:
-        info = 'Contract {} not found in {}'.format(proxy_name, proxy.filename)
-        logger.info(red(info))
-        raise SlitherException(info)
-
-    order_implem = [(variable.name, variable.type) for variable in contract_implem.state_variables if not variable.is_constant]
-    order_proxy = [(variable.name, variable.type) for variable in contract_proxy.state_variables if not variable.is_constant]
-
-
-    results['extra-variable'] = []
-    results['different-variables'] = []
-    found = False
-    for idx in range(0, len(order_proxy)):
-        (proxy_name, proxy_type) =  order_proxy[idx]
-        if len(order_implem) <= idx:
-            info = 'Extra variable in the proxy: {} {}'.format(proxy_name, proxy_type)
-            logger.info(red(info))
-            results['extra-variable'].append(info)
-            continue
-        (implem_name, implem_type) =  order_implem[idx]
-
-        if (proxy_name != implem_name) or (proxy_type != implem_type):
-            found = True
-            info = 'Different variables between proxy and implem: {} {} -> {} {}'.format(proxy_name,
-                                                                                         proxy_type,
-                                                                                         implem_name,
-                                                                                         implem_type)
-            logger.info(red(info))
-            results['different-variables'].append(info)
-        else:
-            logger.info(yellow('Variable in the proxy: {} {}'.format(proxy_name,
-                                                                     proxy_type)))
-
-
-    #if len(order_implem) > len(order_proxy):
-    #    new_variables = order_implem[len(order_proxy):]
-    #    for (name, t) in new_variables:
-    #        logger.info(green('Variable only in implem: {} {}'.format(name, t)))
-
-    if not found:
-        logger.info(green('No variables ordering error found between implementation and the proxy'))
-
-
-    return results

--- a/slither/tools/upgradeability/constant_checks.py
+++ b/slither/tools/upgradeability/constant_checks.py
@@ -1,0 +1,70 @@
+import logging
+
+from slither.utils.colors import red, yellow, green
+
+logger = logging.getLogger("Slither-check-upgradeability")
+
+def constant_conformance_check(contract_v1, contract_v2):
+
+    results = {
+        "became_constants": [],
+        "were_constants": [],
+        "not_found_in_v2": [],
+    }
+
+    logger.info(green(
+        '\n## Run variable constants conformance check... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)'))
+    error_found = False
+
+    state_variables_v1 = contract_v1.state_variables
+    state_variables_v2 = contract_v2.state_variables
+
+    for idx in range(0, len(state_variables_v1)):
+        state_v1 = contract_v1.state_variables[idx]
+
+        if len(state_variables_v2) <= idx:
+            break
+
+        state_v2 = contract_v2.state_variables[idx]
+
+        if state_v2:
+            if state_v1.is_constant:
+                if not state_v2.is_constant:
+                    info = f'{state_v1.canonical_name} was constant and {contract_v2.name} is not'
+                    logger.info(red(info))
+                    results['were_constants'].append({
+                        'description': info,
+                        'contract_v1': contract_v1.name,
+                        'contract_v2': contract_v2.name,
+                        'variable': state_v1.name,
+                        'source_mapping': state_v1.source_mapping
+                    })
+                    error_found = True
+            elif state_v2.is_constant:
+                info = f'{state_v1.canonical_name} was not constant and {contract_v2.name} is'
+                logger.info(red(info))
+                results['became_constants'].append({
+                    'description': info,
+                    'contract_v1': contract_v1.name,
+                    'contract_v2': contract_v2.name,
+                    'variable': state_v1.name,
+                    'source_mapping': state_v1.source_mapping
+                })
+                error_found = True
+
+        else:
+            info = f'{state_v1.canonical_name} not found in {contract_v2.name}, not check was done'
+            logger.info(yellow(info))
+            results['not_found_in_v2'].append({
+                'description': info,
+                'contract_v1': contract_v1.name,
+                'contract_v2': contract_v2.name,
+                'variable': state_v1.name,
+                'source_mapping': state_v1.source_mapping
+            })
+            error_found = True
+
+    if not error_found:
+        logger.info(green('No error found'))
+
+    return results

--- a/slither/tools/upgradeability/constant_checks.py
+++ b/slither/tools/upgradeability/constant_checks.py
@@ -1,5 +1,6 @@
 import logging
 
+from slither.utils import json_utils
 from slither.utils.colors import red, yellow, green
 
 logger = logging.getLogger("Slither-check-upgradeability")
@@ -32,36 +33,32 @@ def constant_conformance_check(contract_v1, contract_v2):
                 if not state_v2.is_constant:
                     info = f'{state_v1.canonical_name} ({state_v1.source_mapping_str}) was constant and {state_v2.canonical_name} is not ({state_v2.source_mapping_str})'
                     logger.info(red(info))
-                    results['were_constants'].append({
-                        'description': info,
-                        'contract_v1': contract_v1.name,
-                        'contract_v2': contract_v2.name,
-                        'variable': state_v1.name,
-                        'source_mapping': state_v1.source_mapping
-                    })
+
+                    json_elem = json_utils.generate_json_result(info)
+                    json_utils.add_variable_to_json(state_v1, json_elem)
+                    json_utils.add_variable_to_json(state_v2, json_elem)
+                    results['were_constants'].append(json_elem)
                     error_found = True
+
             elif state_v2.is_constant:
                 info = f'{state_v1.canonical_name} ({state_v1.source_mapping_str}) was not constant but {state_v2.canonical_name} is ({state_v2.source_mapping_str})'
                 logger.info(red(info))
-                results['became_constants'].append({
-                    'description': info,
-                    'contract_v1': contract_v1.name,
-                    'contract_v2': contract_v2.name,
-                    'variable': state_v1.name,
-                    'source_mapping': state_v1.source_mapping
-                })
+
+                json_elem = json_utils.generate_json_result(info)
+                json_utils.add_variable_to_json(state_v1, json_elem)
+                json_utils.add_variable_to_json(state_v2, json_elem)
+                results['became_constants'].append(json_elem)
                 error_found = True
 
         else:
             info = f'{state_v1.canonical_name} not found in {contract_v2.name}, not check was done'
             logger.info(yellow(info))
-            results['not_found_in_v2'].append({
-                'description': info,
-                'contract_v1': contract_v1.name,
-                'contract_v2': contract_v2.name,
-                'variable': state_v1.name,
-                'source_mapping': state_v1.source_mapping
-            })
+
+            json_elem = json_utils.generate_json_result(info)
+            json_utils.add_variable_to_json(state_v1, json_elem)
+            json_utils.add_contract_to_json(contract_v2, json_elem)
+            results['not_found_in_v2'].append(json_elem)
+
             error_found = True
 
     if not error_found:

--- a/slither/tools/upgradeability/constant_checks.py
+++ b/slither/tools/upgradeability/constant_checks.py
@@ -30,7 +30,7 @@ def constant_conformance_check(contract_v1, contract_v2):
         if state_v2:
             if state_v1.is_constant:
                 if not state_v2.is_constant:
-                    info = f'{state_v1.canonical_name} was constant and {contract_v2.name} is not'
+                    info = f'{state_v1.canonical_name} ({state_v1.source_mapping_str}) was constant and {state_v2.canonical_name} is not ({state_v2.source_mapping_str})'
                     logger.info(red(info))
                     results['were_constants'].append({
                         'description': info,
@@ -41,7 +41,7 @@ def constant_conformance_check(contract_v1, contract_v2):
                     })
                     error_found = True
             elif state_v2.is_constant:
-                info = f'{state_v1.canonical_name} was not constant and {contract_v2.name} is'
+                info = f'{state_v1.canonical_name} ({state_v1.source_mapping_str}) was not constant but {state_v2.canonical_name} is ({state_v2.source_mapping_str})'
                 logger.info(red(info))
                 results['became_constants'].append({
                     'description': info,

--- a/tests/check-upgradeability/contract_v1_var_init.sol
+++ b/tests/check-upgradeability/contract_v1_var_init.sol
@@ -1,0 +1,3 @@
+contract ContractV1{
+    address destination = address(0x41);
+}

--- a/tests/check-upgradeability/contract_v2_constant.sol
+++ b/tests/check-upgradeability/contract_v2_constant.sol
@@ -1,0 +1,3 @@
+contract ContractV2{
+    address constant destination = address(0x41);
+}

--- a/tests/check-upgradeability/test_1.txt
+++ b/tests/check-upgradeability/test_1.txt
@@ -1,7 +1,12 @@
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CompareFunctions:[92mRun function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-INFO:CompareFunctions:[92mNo function ids collision found[0m
-INFO:VariablesOrder:[92mRun variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[93mVariable in the proxy: destination address[0m
-INFO:VariablesOrder:[92mNo variables ordering error found between implementation and the proxy[0m
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_10.txt
+++ b/tests/check-upgradeability/test_10.txt
@@ -1,0 +1,12 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and ContractV2... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[93mVariable only in ContractV1: destination (tests/check-upgradeability/contractV1.sol#2)[0m
+[92m
+## Run variable constants conformance check... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[91mContractV1.destination (tests/check-upgradeability/contractV1.sol#2) was not constant but ContractV2.destination is (tests/check-upgradeability/contract_v2_constant.sol#2)[0m

--- a/tests/check-upgradeability/test_11.txt
+++ b/tests/check-upgradeability/test_11.txt
@@ -1,0 +1,6 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[91mContractV1.destination has an initial value (tests/check-upgradeability/contract_v1_var_init.sol#2)[0m

--- a/tests/check-upgradeability/test_2.txt
+++ b/tests/check-upgradeability/test_2.txt
@@ -1,11 +1,24 @@
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CompareFunctions:[92mRun function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-INFO:CompareFunctions:[92mNo function ids collision found[0m
-INFO:VariablesOrder:[92mRun variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[93mVariable in the proxy: destination address[0m
-INFO:VariablesOrder:[92mNo variables ordering error found between implementation and the proxy[0m
-INFO:VariablesOrder:[92mRun variables order checks between implementations... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[92mNo variables ordering error found between implementations[0m
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV2 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and ContractV2... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variable constants conformance check... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_3.txt
+++ b/tests/check-upgradeability/test_3.txt
@@ -12,7 +12,7 @@
 [92mNo error found[0m
 [92m
 ## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-[91mShadowing between proxy and implementation found myFunc()[0m
+[91mShadowing between ContractV2.myFunc (tests/check-upgradeability/contractV2_bug.sol#4) and Proxy.myFunc() (tests/check-upgradeability/proxy.sol#11)[0m
 [92m
 ## Run variables ordering checks between ContractV2 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
 [91mDifferent variables between ContractV2 and Proxy:

--- a/tests/check-upgradeability/test_3.txt
+++ b/tests/check-upgradeability/test_3.txt
@@ -1,11 +1,32 @@
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CompareFunctions:[92mRun function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-INFO:CompareFunctions:[91mShadowing between proxy and implementation found myFunc()[0m
-INFO:VariablesOrder:[92mRun variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[91mDifferent variables between proxy and implem: destination address -> destination uint256[0m
-INFO:VariablesOrder:[92mRun variables order checks between implementations... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[91mDifferent variables between v1 and v2: destination address -> destination uint256[0m
-INFO:VariablesOrder:[92mNew variable: myFunc uint256[0m
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[91mShadowing between proxy and implementation found myFunc()[0m
+[92m
+## Run variables ordering checks between ContractV2 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[91mDifferent variables between ContractV2 and Proxy:
+	 Variable 0 in ContractV2: destination uint256 (tests/check-upgradeability/contractV2_bug.sol#2)
+	 Variable 0 in Proxy: destination address (tests/check-upgradeability/proxy.sol#9)
+[0m
+[92m
+## Run variables ordering checks between ContractV1 and ContractV2... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[91mDifferent variables between ContractV1 and ContractV2:
+	 Variable 0 in ContractV1: destination address (tests/check-upgradeability/contractV1.sol#2)
+	 Variable 0 in ContractV2: destination uint256 (tests/check-upgradeability/contractV2_bug.sol#2)
+[0m
+[93mExtra variables in ContractV2: myFunc (tests/check-upgradeability/contractV2_bug.sol#4)
+[0m
+[92m
+## Run variable constants conformance check... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_4.txt
+++ b/tests/check-upgradeability/test_4.txt
@@ -1,11 +1,32 @@
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
-INFO:CompareFunctions:[92mRun function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-INFO:CompareFunctions:[92mNo function ids collision found[0m
-INFO:VariablesOrder:[92mRun variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[91mDifferent variables between proxy and implem: destination address -> val uint256[0m
-INFO:VariablesOrder:[92mRun variables order checks between implementations... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[91mDifferent variables between v1 and v2: destination address -> val uint256[0m
-INFO:VariablesOrder:[92mNew variable: destination address[0m
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[93mInitializable contract not found, the contract does not follow a standard initalization schema.[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV1 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between ContractV2 and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[91mDifferent variables between ContractV2 and Proxy:
+	 Variable 0 in ContractV2: val uint256 (tests/check-upgradeability/contractV2_bug2.sol#2)
+	 Variable 0 in Proxy: destination address (tests/check-upgradeability/proxy.sol#9)
+[0m
+[92m
+## Run variables ordering checks between ContractV1 and ContractV2... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[91mDifferent variables between ContractV1 and ContractV2:
+	 Variable 0 in ContractV1: destination address (tests/check-upgradeability/contractV1.sol#2)
+	 Variable 0 in ContractV2: val uint256 (tests/check-upgradeability/contractV2_bug2.sol#2)
+[0m
+[93mExtra variables in ContractV2: destination (tests/check-upgradeability/contractV2_bug2.sol#5)
+[0m
+[92m
+## Run variable constants conformance check... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_5.txt
+++ b/tests/check-upgradeability/test_5.txt
@@ -1,16 +1,18 @@
-INFO:CheckInitialization:[92mRun initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
-INFO:CheckInitialization:[91mContract_lack_to_call_modifier.initialize() does not call initializer[0m
-INFO:CheckInitialization:[91mMissing call to Contract_no_bug.initialize() in Contract_not_called_super_init[0m
-INFO:CheckInitialization:[91mContract_no_bug.initialize() is called multiple times in Contract_double_call[0m
-INFO:CheckInitialization:[92mCheck the deployement script to ensure that these functions are called:
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[92mAll the init functions have the initializer modifier[0m
+[92mNo missing call to an init function found[0m
+[92mNo double call to init functions found[0m
+[92mCheck the deployement script to ensure that these functions are called:
 Contract_no_bug needs to be initialized by initialize()
-Contract_lack_to_call_modifier needs to be initialized by initialize()
-Contract_not_called_super_init needs to be initialized by initialize()
-Contract_no_bug_inherits needs to be initialized by initialize()
-Contract_double_call needs to be initialized by initialize()
 [0m
-INFO:CompareFunctions:[92mRun function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
-INFO:CompareFunctions:[92mNo function ids collision found[0m
-INFO:VariablesOrder:[92mRun variables order checks between the implementation and the proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
-INFO:VariablesOrder:[93mVariable in the proxy: destination address[0m
-INFO:VariablesOrder:[92mNo variables ordering error found between implementation and the proxy[0m
+[92mNo error found[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between Contract_no_bug and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_6.txt
+++ b/tests/check-upgradeability/test_6.txt
@@ -1,0 +1,18 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[91mContract_lack_to_call_modifier.initialize() does not call the initializer modifier[0m
+[92mNo missing call to an init function found[0m
+[92mNo double call to init functions found[0m
+[92mCheck the deployement script to ensure that these functions are called:
+Contract_lack_to_call_modifier needs to be initialized by initialize()
+[0m
+[92mNo error found[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between Contract_lack_to_call_modifier and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_7.txt
+++ b/tests/check-upgradeability/test_7.txt
@@ -1,0 +1,18 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[92mAll the init functions have the initializer modifier[0m
+[91mMissing call to Contract_no_bug.initialize() in Contract_not_called_super_init.initialize()[0m
+[92mNo double call to init functions found[0m
+[92mCheck the deployement script to ensure that these functions are called:
+Contract_not_called_super_init needs to be initialized by initialize()
+[0m
+[92mNo error found[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between Contract_not_called_super_init and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_8.txt
+++ b/tests/check-upgradeability/test_8.txt
@@ -1,0 +1,18 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[92mAll the init functions have the initializer modifier[0m
+[92mNo missing call to an init function found[0m
+[92mNo double call to init functions found[0m
+[92mCheck the deployement script to ensure that these functions are called:
+Contract_no_bug_inherits needs to be initialized by initialize()
+[0m
+[92mNo error found[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between Contract_no_bug_inherits and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m

--- a/tests/check-upgradeability/test_9.txt
+++ b/tests/check-upgradeability/test_9.txt
@@ -1,0 +1,18 @@
+[92m
+## Run initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialization-checks)[0m
+[92mAll the init functions have the initializer modifier[0m
+[92mNo missing call to an init function found[0m
+[91mContract_no_bug.initialize() is called multiple times in initialize()[0m
+[92mCheck the deployement script to ensure that these functions are called:
+Contract_double_call needs to be initialized by initialize()
+[0m
+[92mNo error found[0m
+[92m
+## Run variable initialization checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks)[0m
+[92mNo error found[0m
+[92m
+## Run function ids checks... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-checks)[0m
+[92mNo error found[0m
+[92m
+## Run variables ordering checks between Contract_double_call and Proxy... (see https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-order-checks)[0m
+[92mNo error found[0m


### PR DESCRIPTION
This PR contains several improvements on the upgradeability checks:

- Only the logic contract is needed, proxy becomes optional
- Change flag name [BREAKING CHANGE]
- Clean main to ease the add of new checks
- Clean variable ordering logic; merge the two function into one generic (fix #274)
- Refactor json output and add source mapping (fix #347). 
- Add check for constant conformance (fix #188)
- Overall output improvements
- Remove FP in case of fallback function collision (fix #331)


The json output and the constant conformance checks need to be tested. 
The documentation needs to be updated to merge this PR.