### PR TITLE
Add unique ID per finding

### DIFF
--- a/scripts/tests_generate_expected_json_4.sh
+++ b/scripts/tests_generate_expected_json_4.sh
@@ -54,5 +54,5 @@ generate_expected_json(){
 #generate_expected_json tests/shadowing_builtin_symbols.sol "shadowing-builtin"
 #generate_expected_json tests/shadowing_local_variable.sol "shadowing-local"
 #generate_expected_json tests/solc_version_incorrect.sol "solc-version"
-#generate_expected_json tests/right_to_left_override.sol "rtlo"
+generate_expected_json tests/right_to_left_override.sol "rtlo"
 #generate_expected_json tests/unchecked_lowlevel.sol "unchecked-lowlevel"

--- a/slither/detectors/source/rtlo.py
+++ b/slither/detectors/source/rtlo.py
@@ -68,7 +68,9 @@ contract Token
                 else:
                     # We found another instance of the character, define our output
                     idx = start_index + result_index
-                    info = f"{filename} contains a unicode right-to-left-override character at byte offset {idx}:\n"
+                    
+                    relative = self.slither.crytic_compile.filename_lookup(filename).relative
+                    info = f"{relative} contains a unicode right-to-left-override character at byte offset {idx}:\n"
 
                     # We have a patch, so pattern.find will return at least one result
 

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -186,7 +186,7 @@ class Output:
         self._data['elements'] = []
         self._data['description'] = ''.join(_convert_to_description(d) for d in info)
         self._data['markdown'] = ''.join(_convert_to_markdown(d, markdown_root) for d in info)
-        
+
         id_txt = ''.join(_convert_to_id(d) for d in info)
         self._data['id'] = hashlib.sha3_256(id_txt.encode('utf-8')).hexdigest()
 

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import json
 import logging
@@ -101,6 +102,31 @@ def _convert_to_markdown(d, markdown_root):
 
     raise SlitherError(f'{type(d)} cannot be converted (no name, or canonical_name')
 
+def _convert_to_id(d):
+    '''
+    Id keeps the source mapping of the node, otherwise we risk to consider two different node as the same
+    :param d:
+    :return:
+    '''
+    if isinstance(d, str):
+        return d
+
+    if not isinstance(d, SourceMapping):
+        raise SlitherError(f'{d} does not inherit from SourceMapping, conversion impossible')
+
+    if isinstance(d, Node):
+        if d.expression:
+            return f'{d.expression} ({d.source_mapping_str})'
+        else:
+            return f'{str(d)} ({d.source_mapping_str})'
+
+    if hasattr(d, 'canonical_name'):
+        return f'{d.canonical_name}'
+
+    if hasattr(d, 'name'):
+        return f'{d.name}'
+
+    raise SlitherError(f'{type(d)} cannot be converted (no name, or canonical_name')
 
 # endregion
 ###################################################################################
@@ -160,6 +186,9 @@ class Output:
         self._data['elements'] = []
         self._data['description'] = ''.join(_convert_to_description(d) for d in info)
         self._data['markdown'] = ''.join(_convert_to_markdown(d, markdown_root) for d in info)
+        
+        id_txt = ''.join(_convert_to_id(d) for d in info)
+        self._data['id'] = hashlib.sha3_256(id_txt.encode('utf-8')).hexdigest()
 
         if standard_format:
             to_add = [i for i in info if not isinstance(i, str)]

--- a/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.json
+++ b/tests/expected_json/arbitrary_send-0.5.1.arbitrary-send.json
@@ -190,6 +190,7 @@
         ],
         "description": "Test.direct() (tests/arbitrary_send-0.5.1.sol#11-13) sends eth to arbitrary user\n\tDangerous calls:\n\t- msg.sender.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#12)\n",
         "markdown": "[Test.direct()](tests/arbitrary_send-0.5.1.sol#L11-L13) sends eth to arbitrary user\n\tDangerous calls:\n\t- [msg.sender.send(address(this).balance)](tests/arbitrary_send-0.5.1.sol#L12)\n",
+        "id": "5479aabac8e802dcfc47713305fe8ed8d58001b9891d028dd9e4d61d5b2a3a3e",
         "check": "arbitrary-send",
         "impact": "High",
         "confidence": "Medium"
@@ -381,6 +382,7 @@
         ],
         "description": "Test.indirect() (tests/arbitrary_send-0.5.1.sol#19-21) sends eth to arbitrary user\n\tDangerous calls:\n\t- destination.send(address(this).balance) (tests/arbitrary_send-0.5.1.sol#20)\n",
         "markdown": "[Test.indirect()](tests/arbitrary_send-0.5.1.sol#L19-L21) sends eth to arbitrary user\n\tDangerous calls:\n\t- [destination.send(address(this).balance)](tests/arbitrary_send-0.5.1.sol#L20)\n",
+        "id": "94e4360762e1ecac015c1c6cc6045bb0b0599cb576aa64dd0f9b5554631607a6",
         "check": "arbitrary-send",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/arbitrary_send.arbitrary-send.json
+++ b/tests/expected_json/arbitrary_send.arbitrary-send.json
@@ -190,6 +190,7 @@
         ],
         "description": "Test.direct() (tests/arbitrary_send.sol#11-13) sends eth to arbitrary user\n\tDangerous calls:\n\t- msg.sender.send(address(this).balance) (tests/arbitrary_send.sol#12)\n",
         "markdown": "[Test.direct()](tests/arbitrary_send.sol#L11-L13) sends eth to arbitrary user\n\tDangerous calls:\n\t- [msg.sender.send(address(this).balance)](tests/arbitrary_send.sol#L12)\n",
+        "id": "db62976d0c290f0b09f4df06f97bf2921c4d7ee734eb086b5f1a619f3583d83b",
         "check": "arbitrary-send",
         "impact": "High",
         "confidence": "Medium"
@@ -381,6 +382,7 @@
         ],
         "description": "Test.indirect() (tests/arbitrary_send.sol#19-21) sends eth to arbitrary user\n\tDangerous calls:\n\t- destination.send(address(this).balance) (tests/arbitrary_send.sol#20)\n",
         "markdown": "[Test.indirect()](tests/arbitrary_send.sol#L19-L21) sends eth to arbitrary user\n\tDangerous calls:\n\t- [destination.send(address(this).balance)](tests/arbitrary_send.sol#L20)\n",
+        "id": "643af1938b9f04e949e0ccaffd907915b3ed93652671e3f5613e8b5f3ceef2bf",
         "check": "arbitrary-send",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/backdoor.backdoor.json
+++ b/tests/expected_json/backdoor.backdoor.json
@@ -55,6 +55,7 @@
         ],
         "description": "Backdoor function found in C.i_am_a_backdoor() (tests/backdoor.sol#4-6)\n",
         "markdown": "Backdoor function found in [C.i_am_a_backdoor()](tests/backdoor.sol#L4-L6)\n",
+        "id": "8a9008f2f5cd23b34feb0235dcc30ecb8d09a10eff151b522939caead117ef7a",
         "check": "backdoor",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/backdoor.suicidal.json
+++ b/tests/expected_json/backdoor.suicidal.json
@@ -55,6 +55,7 @@
         ],
         "description": "C.i_am_a_backdoor() (tests/backdoor.sol#4-6) allows anyone to destruct the contract\n",
         "markdown": "[C.i_am_a_backdoor()](tests/backdoor.sol#L4-L6) allows anyone to destruct the contract\n",
+        "id": "bb1e4596537b6e2c29f4221e733692fd6dac8555095181718e440ca525016eb7",
         "check": "suicidal",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/const_state_variables.constable-states.json
+++ b/tests/expected_json/const_state_variables.constable-states.json
@@ -63,6 +63,7 @@
         ],
         "description": "A.myFriendsAddress (tests/const_state_variables.sol#7) should be constant\n",
         "markdown": "[A.myFriendsAddress](tests/const_state_variables.sol#L7) should be constant\n",
+        "id": "1454db80653b732bf6acbe54ff0ae4707002207a2a8216708c12d61c88a43e5f",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"
@@ -127,6 +128,7 @@
         ],
         "description": "A.test (tests/const_state_variables.sol#10) should be constant\n",
         "markdown": "[A.test](tests/const_state_variables.sol#L10) should be constant\n",
+        "id": "5d9e3fb413322b71a93e90f7e89bd8c83cd4884d577d039598c681fe9db38b1d",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"
@@ -191,6 +193,7 @@
         ],
         "description": "A.text2 (tests/const_state_variables.sol#14) should be constant\n",
         "markdown": "[A.text2](tests/const_state_variables.sol#L14) should be constant\n",
+        "id": "df11e6201c4558a8c5cd90b55b134b9ca8f07203b2264d3aa93bd7745e8cb4ba",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"
@@ -251,6 +254,7 @@
         ],
         "description": "B.mySistersAddress (tests/const_state_variables.sol#26) should be constant\n",
         "markdown": "[B.mySistersAddress](tests/const_state_variables.sol#L26) should be constant\n",
+        "id": "bee93a722c8eae4a48aade67d8ef537d84c106f48fc9eb738c795fce10d3bc63",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"
@@ -311,6 +315,7 @@
         ],
         "description": "MyConc.should_be_constant (tests/const_state_variables.sol#42) should be constant\n",
         "markdown": "[MyConc.should_be_constant](tests/const_state_variables.sol#L42) should be constant\n",
+        "id": "cbcafa2a3efba4d21ac1b51b4b823e5082d556bc3d6cf3fd2ab3188f9f218fc1",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"
@@ -371,6 +376,7 @@
         ],
         "description": "MyConc.should_be_constant_2 (tests/const_state_variables.sol#43) should be constant\n",
         "markdown": "[MyConc.should_be_constant_2](tests/const_state_variables.sol#L43) should be constant\n",
+        "id": "9a48a4122de1a6a4774a9f1e0d4917bd0fa08f17b4af41b86ba07689e51bf711",
         "check": "constable-states",
         "impact": "Optimization",
         "confidence": "High"

--- a/tests/expected_json/constant-0.5.1.constant-function.json
+++ b/tests/expected_json/constant-0.5.1.constant-function.json
@@ -66,6 +66,7 @@
         ],
         "description": "Constant.test_assembly_bug() (tests/constant-0.5.1.sol#15-17) is declared view but contains assembly code\n",
         "markdown": "[Constant.test_assembly_bug()](tests/constant-0.5.1.sol#L15-L17) is declared view but contains assembly code\n",
+        "id": "1f892cae08b89096bdc4d6ecdf55a3adc4b4314390e054fe2547d9c8e9f76e23",
         "additional_fields": {
           "contains_assembly": true
         },

--- a/tests/expected_json/constant.constant-function.json
+++ b/tests/expected_json/constant.constant-function.json
@@ -135,6 +135,7 @@
         ],
         "description": "Constant.test_view_bug() (tests/constant.sol#5-7) is declared view but changes state variables:\n\t- Constant.a (tests/constant.sol#3)\n",
         "markdown": "[Constant.test_view_bug()](tests/constant.sol#L5-L7) is declared view but changes state variables:\n\t- [Constant.a](tests/constant.sol#L3)\n",
+        "id": "4dee61d8835d20c6f1f7c195d8bd1e9de5dbcc096396a5b8db391136f9f5fdf1",
         "additional_fields": {
           "contains_assembly": false
         },
@@ -274,6 +275,7 @@
         ],
         "description": "Constant.test_constant_bug() (tests/constant.sol#9-11) is declared view but changes state variables:\n\t- Constant.a (tests/constant.sol#3)\n",
         "markdown": "[Constant.test_constant_bug()](tests/constant.sol#L9-L11) is declared view but changes state variables:\n\t- [Constant.a](tests/constant.sol#L3)\n",
+        "id": "145e2d34dfc5b932c8d67d480c0eaec9baa8c728e2a310529572c0c4a5c6046a",
         "additional_fields": {
           "contains_assembly": false
         },
@@ -351,6 +353,7 @@
         ],
         "description": "Constant.test_assembly_bug() (tests/constant.sol#22-24) is declared view but contains assembly code\n",
         "markdown": "[Constant.test_assembly_bug()](tests/constant.sol#L22-L24) is declared view but contains assembly code\n",
+        "id": "1f892cae08b89096bdc4d6ecdf55a3adc4b4314390e054fe2547d9c8e9f76e23",
         "additional_fields": {
           "contains_assembly": true
         },

--- a/tests/expected_json/controlled_delegatecall.controlled-delegatecall.json
+++ b/tests/expected_json/controlled_delegatecall.controlled-delegatecall.json
@@ -160,6 +160,7 @@
         ],
         "description": "C.bad_delegate_call(bytes) (tests/controlled_delegatecall.sol#8-11) uses delegatecall to a input-controlled function id\n\t- addr_bad.delegatecall(data) (tests/controlled_delegatecall.sol#10)\n",
         "markdown": "[C.bad_delegate_call(bytes)](tests/controlled_delegatecall.sol#L8-L11) uses delegatecall to a input-controlled function id\n\t- [addr_bad.delegatecall(data)](tests/controlled_delegatecall.sol#L10)\n",
+        "id": "a97990bb03ea7d6b3844cfe53689f9d3f32e49baf83e603760588e34c7cba64f",
         "check": "controlled-delegatecall",
         "impact": "High",
         "confidence": "Medium"
@@ -319,6 +320,7 @@
         ],
         "description": "C.bad_delegate_call2(bytes) (tests/controlled_delegatecall.sol#18-20) uses delegatecall to a input-controlled function id\n\t- addr_bad.delegatecall(abi.encode(func_id,data)) (tests/controlled_delegatecall.sol#19)\n",
         "markdown": "[C.bad_delegate_call2(bytes)](tests/controlled_delegatecall.sol#L18-L20) uses delegatecall to a input-controlled function id\n\t- [addr_bad.delegatecall(abi.encode(func_id,data))](tests/controlled_delegatecall.sol#L19)\n",
+        "id": "611ca2baf5d14852abb16f98b888d9d52760b8e729599d472c669a9b2f008026",
         "check": "controlled-delegatecall",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/deprecated_calls.deprecated-standards.json
+++ b/tests/expected_json/deprecated_calls.deprecated-standards.json
@@ -72,6 +72,7 @@
         ],
         "description": "Deprecated standard detected ContractWithDeprecatedReferences.globalBlockHash (tests/deprecated_calls.sol#2):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
         "markdown": "Deprecated standard detected [ContractWithDeprecatedReferences.globalBlockHash](tests/deprecated_calls.sol#L2):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "84ecc7e9ce51f3a7103d3674e237fe1ba07899cca5d40de91172c36f434fc9ce",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -172,6 +173,7 @@
         ],
         "description": "Deprecated standard detected msg.gas == msg.value (tests/deprecated_calls.sol#7):\n\t- Usage of \"msg.gas\" should be replaced with \"gasleft()\"\n",
         "markdown": "Deprecated standard detected [msg.gas == msg.value](tests/deprecated_calls.sol#L7):\n\t- Usage of \"msg.gas\" should be replaced with \"gasleft()\"\n",
+        "id": "0af1a05682eb2ab89143849898f6e2fb9bdfa6bdd01d43d81d41e10c4dfe58d7",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -272,6 +274,7 @@
         ],
         "description": "Deprecated standard detected THROW None (tests/deprecated_calls.sol#9):\n\t- Usage of \"throw\" should be replaced with \"revert()\"\n",
         "markdown": "Deprecated standard detected [THROW None](tests/deprecated_calls.sol#L9):\n\t- Usage of \"throw\" should be replaced with \"revert()\"\n",
+        "id": "1a3241d58683640c33ae9e1bcd65bafd7472e7b7c9d2ec695f84590a2cef286a",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -378,6 +381,7 @@
         ],
         "description": "Deprecated standard detected sha3Result = sha3()(test deprecated sha3 usage) (tests/deprecated_calls.sol#16):\n\t- Usage of \"sha3()\" should be replaced with \"keccak256()\"\n",
         "markdown": "Deprecated standard detected [sha3Result = sha3()(test deprecated sha3 usage)](tests/deprecated_calls.sol#L16):\n\t- Usage of \"sha3()\" should be replaced with \"keccak256()\"\n",
+        "id": "3926d80bb1119eb9faf7abdf2c2b61ce7accc5bcf4c0eaed120910e6662891f3",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -484,6 +488,7 @@
         ],
         "description": "Deprecated standard detected blockHashResult = block.blockhash(0) (tests/deprecated_calls.sol#19):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
         "markdown": "Deprecated standard detected [blockHashResult = block.blockhash(0)](tests/deprecated_calls.sol#L19):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "0e462458439683a8a7a6d2113e962b00bb79ead8d7f6f462a158cf114bd22e96",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -590,6 +595,7 @@
         ],
         "description": "Deprecated standard detected address(this).callcode() (tests/deprecated_calls.sol#22):\n\t- Usage of \"callcode\" should be replaced with \"delegatecall\"\n",
         "markdown": "Deprecated standard detected [address(this).callcode()](tests/deprecated_calls.sol#L22):\n\t- Usage of \"callcode\" should be replaced with \"delegatecall\"\n",
+        "id": "8d21d721e732845b6a72e96498c98f07a214f4acfb2f956a93dc48b57ed5de95",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -696,6 +702,7 @@
         ],
         "description": "Deprecated standard detected suicide(address)(address(0)) (tests/deprecated_calls.sol#25):\n\t- Usage of \"suicide()\" should be replaced with \"selfdestruct()\"\n",
         "markdown": "Deprecated standard detected [suicide(address)(address(0))](tests/deprecated_calls.sol#L25):\n\t- Usage of \"suicide()\" should be replaced with \"selfdestruct()\"\n",
+        "id": "741bd57823d2933e7f19c5bebab1a57506f0fd377e148ae9383c2b40ca768508",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"
@@ -816,6 +823,7 @@
         ],
         "description": "Deprecated standard detected globalBlockHash = block.blockhash(0) (tests/deprecated_calls.sol#2):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
         "markdown": "Deprecated standard detected [globalBlockHash = block.blockhash(0)](tests/deprecated_calls.sol#L2):\n\t- Usage of \"block.blockhash()\" should be replaced with \"blockhash()\"\n",
+        "id": "1a17fcbea6521ac0d23bbae6d75bcb85c6ba345a57e976e9e3a8d7862bbd9773",
         "check": "deprecated-standards",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/erc20_indexed.erc20-indexed.json
+++ b/tests/expected_json/erc20_indexed.erc20-indexed.json
@@ -59,6 +59,7 @@
         ],
         "description": "ERC20 event IERC20BadTransfer(address,address,uint256) (tests/erc20_indexed.sol#19)does not index parameter from\n",
         "markdown": "ERC20 event [IERC20BadTransfer(address,address,uint256)](tests/erc20_indexed.sol#L19)does not index parameter from\n",
+        "id": "a86c7a54115f270548e82d71570dc4d2900b622b0f82c6fce137f3a35314af53",
         "check": "erc20-indexed",
         "impact": "Informational",
         "confidence": "High"
@@ -119,6 +120,7 @@
         ],
         "description": "ERC20 event IERC20BadTransfer(address,address,uint256) (tests/erc20_indexed.sol#19)does not index parameter to\n",
         "markdown": "ERC20 event [IERC20BadTransfer(address,address,uint256)](tests/erc20_indexed.sol#L19)does not index parameter to\n",
+        "id": "29c46eb3a4695004959847ae09377729cdf3aa583de95560090b9bd49977c49b",
         "check": "erc20-indexed",
         "impact": "Informational",
         "confidence": "High"
@@ -179,6 +181,7 @@
         ],
         "description": "ERC20 event IERC20BadApproval(address,address,uint256) (tests/erc20_indexed.sol#20)does not index parameter owner\n",
         "markdown": "ERC20 event [IERC20BadApproval(address,address,uint256)](tests/erc20_indexed.sol#L20)does not index parameter owner\n",
+        "id": "7d72b56a71ca96db304878f25484c496af1d283a9b777dc788f1473974057025",
         "check": "erc20-indexed",
         "impact": "Informational",
         "confidence": "High"
@@ -239,6 +242,7 @@
         ],
         "description": "ERC20 event IERC20BadApproval(address,address,uint256) (tests/erc20_indexed.sol#20)does not index parameter spender\n",
         "markdown": "ERC20 event [IERC20BadApproval(address,address,uint256)](tests/erc20_indexed.sol#L20)does not index parameter spender\n",
+        "id": "df4d927d202bdca1fc411d6960d3f62ed2784f5eca7435cb0503f4154f2e3bc6",
         "check": "erc20-indexed",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/external_function.external-function.json
+++ b/tests/expected_json/external_function.external-function.json
@@ -67,6 +67,7 @@
         ],
         "description": "funcNotCalled3() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled3() (tests/external_function.sol#13-15)\n",
         "markdown": "funcNotCalled3() should be declared external:\n\t- [ContractWithFunctionNotCalled.funcNotCalled3()](tests/external_function.sol#L13-L15)\n",
+        "id": "026d9a579ea0304e58c8a5174296494f4b672e4ea032f4e17504f3dac327c4e6",
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High"
@@ -135,6 +136,7 @@
         ],
         "description": "funcNotCalled2() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled2() (tests/external_function.sol#17-19)\n",
         "markdown": "funcNotCalled2() should be declared external:\n\t- [ContractWithFunctionNotCalled.funcNotCalled2()](tests/external_function.sol#L17-L19)\n",
+        "id": "1ef1f19a92a8ab8d27df156d50dd75628ec3057b5f5eb16b7d1faa0e5c3850a0",
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High"
@@ -203,6 +205,7 @@
         ],
         "description": "funcNotCalled() should be declared external:\n\t- ContractWithFunctionNotCalled.funcNotCalled() (tests/external_function.sol#21-23)\n",
         "markdown": "funcNotCalled() should be declared external:\n\t- [ContractWithFunctionNotCalled.funcNotCalled()](tests/external_function.sol#L21-L23)\n",
+        "id": "369a2f3d071735755ff4f5bc43081fe858bbfb07eed94e5c6dda3c8daa22ba26",
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High"
@@ -267,6 +270,7 @@
         ],
         "description": "funcNotCalled() should be declared external:\n\t- ContractWithFunctionNotCalled2.funcNotCalled() (tests/external_function.sol#32-39)\n",
         "markdown": "funcNotCalled() should be declared external:\n\t- [ContractWithFunctionNotCalled2.funcNotCalled()](tests/external_function.sol#L32-L39)\n",
+        "id": "80a0a3a3954cc6e314079a1d8d96d6739d521ddbcf738e63078d7f210e443562",
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High"
@@ -327,6 +331,7 @@
         ],
         "description": "parameter_read_ok_for_external(uint256) should be declared external:\n\t- FunctionParameterWrite.parameter_read_ok_for_external(uint256) (tests/external_function.sol#74-76)\n",
         "markdown": "parameter_read_ok_for_external(uint256) should be declared external:\n\t- [FunctionParameterWrite.parameter_read_ok_for_external(uint256)](tests/external_function.sol#L74-L76)\n",
+        "id": "3a0a42d128eff9fb04d8f7605bf2d6f7574c2cbbdffa2dcabbae66d7568ecc59",
         "check": "external-function",
         "impact": "Optimization",
         "confidence": "High"

--- a/tests/expected_json/incorrect_equality.incorrect-equality.json
+++ b/tests/expected_json/incorrect_equality.incorrect-equality.json
@@ -146,6 +146,7 @@
         ],
         "description": "ERC20TestBalance.bad0(ERC20Function) (tests/incorrect_equality.sol#21-23) uses a dangerous strict equality:\n\t- require(bool)(erc.balanceOf(address(this)) == 10) (tests/incorrect_equality.sol#22)\n",
         "markdown": "[ERC20TestBalance.bad0(ERC20Function)](tests/incorrect_equality.sol#L21-L23) uses a dangerous strict equality:\n\t- [require(bool)(erc.balanceOf(address(this)) == 10)](tests/incorrect_equality.sol#L22)\n",
+        "id": "75aa0ac0f7038b6a92030dee5c4c8f4cc6ab3f491558e18c61b6db5fbbf971e4",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -293,6 +294,7 @@
         ],
         "description": "ERC20TestBalance.bad1(ERC20Variable) (tests/incorrect_equality.sol#25-27) uses a dangerous strict equality:\n\t- require(bool)(erc.balanceOf(msg.sender) == 10) (tests/incorrect_equality.sol#26)\n",
         "markdown": "[ERC20TestBalance.bad1(ERC20Variable)](tests/incorrect_equality.sol#L25-L27) uses a dangerous strict equality:\n\t- [require(bool)(erc.balanceOf(msg.sender) == 10)](tests/incorrect_equality.sol#L26)\n",
+        "id": "747d47c020b94e00fa06cc310b205306c37fda3811bafde5ee820ff84656127e",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -540,6 +542,7 @@
         ],
         "description": "TestContractBalance.bad0() (tests/incorrect_equality.sol#32-35) uses a dangerous strict equality:\n\t- require(bool)(address(address(this)).balance == 10000000000000000000) (tests/incorrect_equality.sol#33)\n",
         "markdown": "[TestContractBalance.bad0()](tests/incorrect_equality.sol#L32-L35) uses a dangerous strict equality:\n\t- [require(bool)(address(address(this)).balance == 10000000000000000000)](tests/incorrect_equality.sol#L33)\n",
+        "id": "90491e5c72bcd00b473b5d5748a62145c1c156d5805735ee893953595c144f7b",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -787,6 +790,7 @@
         ],
         "description": "TestContractBalance.bad1() (tests/incorrect_equality.sol#37-40) uses a dangerous strict equality:\n\t- require(bool)(10000000000000000000 == address(address(this)).balance) (tests/incorrect_equality.sol#38)\n",
         "markdown": "[TestContractBalance.bad1()](tests/incorrect_equality.sol#L37-L40) uses a dangerous strict equality:\n\t- [require(bool)(10000000000000000000 == address(address(this)).balance)](tests/incorrect_equality.sol#L38)\n",
+        "id": "1931d5770ec78d317bd036dc509a5f9914db54236e9ae451204efc17559396cb",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -1034,6 +1038,7 @@
         ],
         "description": "TestContractBalance.bad2() (tests/incorrect_equality.sol#42-45) uses a dangerous strict equality:\n\t- require(bool)(address(this).balance == 10000000000000000000) (tests/incorrect_equality.sol#43)\n",
         "markdown": "[TestContractBalance.bad2()](tests/incorrect_equality.sol#L42-L45) uses a dangerous strict equality:\n\t- [require(bool)(address(this).balance == 10000000000000000000)](tests/incorrect_equality.sol#L43)\n",
+        "id": "55f882e1ab114a792fce75d5cce66a3213ac069aa7cbb5625ca5623eb20171a0",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -1281,6 +1286,7 @@
         ],
         "description": "TestContractBalance.bad3() (tests/incorrect_equality.sol#47-50) uses a dangerous strict equality:\n\t- require(bool)(10000000000000000000 == address(this).balance) (tests/incorrect_equality.sol#48)\n",
         "markdown": "[TestContractBalance.bad3()](tests/incorrect_equality.sol#L47-L50) uses a dangerous strict equality:\n\t- [require(bool)(10000000000000000000 == address(this).balance)](tests/incorrect_equality.sol#L48)\n",
+        "id": "0f6f6872f53fd271e9a246cb5d6bbe56cdeb34df832f28844dd1e758d1ea8e20",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -1532,6 +1538,7 @@
         ],
         "description": "TestContractBalance.bad4() (tests/incorrect_equality.sol#52-57) uses a dangerous strict equality:\n\t- balance == 10000000000000000000 (tests/incorrect_equality.sol#54)\n",
         "markdown": "[TestContractBalance.bad4()](tests/incorrect_equality.sol#L52-L57) uses a dangerous strict equality:\n\t- [balance == 10000000000000000000](tests/incorrect_equality.sol#L54)\n",
+        "id": "10a836ebf912b1c384df149242be6ac888bd7739ab7b0e28e20221665a35dc1b",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -1783,6 +1790,7 @@
         ],
         "description": "TestContractBalance.bad5() (tests/incorrect_equality.sol#59-64) uses a dangerous strict equality:\n\t- 10000000000000000000 == balance (tests/incorrect_equality.sol#61)\n",
         "markdown": "[TestContractBalance.bad5()](tests/incorrect_equality.sol#L59-L64) uses a dangerous strict equality:\n\t- [10000000000000000000 == balance](tests/incorrect_equality.sol#L61)\n",
+        "id": "627eca9af27adf553a7508940ba1f8985ab374b291311fab8ca51db936af8a45",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -2034,6 +2042,7 @@
         ],
         "description": "TestContractBalance.bad6() (tests/incorrect_equality.sol#66-71) uses a dangerous strict equality:\n\t- balance == 10000000000000000000 (tests/incorrect_equality.sol#68)\n",
         "markdown": "[TestContractBalance.bad6()](tests/incorrect_equality.sol#L66-L71) uses a dangerous strict equality:\n\t- [balance == 10000000000000000000](tests/incorrect_equality.sol#L68)\n",
+        "id": "76e879b9ffe8cbfbecfe665508a4e826d2f7a1276895e72df3c027f8e7d48dc5",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -2217,6 +2226,7 @@
         ],
         "description": "TestSolidityKeyword.bad0() (tests/incorrect_equality.sol#123-125) uses a dangerous strict equality:\n\t- require(bool)(now == 0) (tests/incorrect_equality.sol#124)\n",
         "markdown": "[TestSolidityKeyword.bad0()](tests/incorrect_equality.sol#L123-L125) uses a dangerous strict equality:\n\t- [require(bool)(now == 0)](tests/incorrect_equality.sol#L124)\n",
+        "id": "e1a99aa0ace22569091c55b4b2c0d5f6b2650aa86a5e65aba3c7fa75ab50c5e9",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -2400,6 +2410,7 @@
         ],
         "description": "TestSolidityKeyword.bad1() (tests/incorrect_equality.sol#127-129) uses a dangerous strict equality:\n\t- require(bool)(block.number == 0) (tests/incorrect_equality.sol#128)\n",
         "markdown": "[TestSolidityKeyword.bad1()](tests/incorrect_equality.sol#L127-L129) uses a dangerous strict equality:\n\t- [require(bool)(block.number == 0)](tests/incorrect_equality.sol#L128)\n",
+        "id": "554e3fc05ff46a0c04a7a239f3ed04926fd3506208c5badaaebb1dc4ba8ef13a",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"
@@ -2583,6 +2594,7 @@
         ],
         "description": "TestSolidityKeyword.bad2() (tests/incorrect_equality.sol#131-133) uses a dangerous strict equality:\n\t- require(bool)(block.number == 0) (tests/incorrect_equality.sol#132)\n",
         "markdown": "[TestSolidityKeyword.bad2()](tests/incorrect_equality.sol#L131-L133) uses a dangerous strict equality:\n\t- [require(bool)(block.number == 0)](tests/incorrect_equality.sol#L132)\n",
+        "id": "820ed197f8fa55086981bdcc258e50464c75815e1ec873a426297361ad32e1d8",
         "check": "incorrect-equality",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/incorrect_erc20_interface.erc20-interface.json
+++ b/tests/expected_json/incorrect_erc20_interface.erc20-interface.json
@@ -79,6 +79,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.transfer(address,uint256) (tests/incorrect_erc20_interface.sol#4)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.transfer(address,uint256)](tests/incorrect_erc20_interface.sol#L4)\n",
+        "id": "d3df2e48ae6e8a1b05b275de574b480853a0839c272ce889e8a1664ae432698e",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -159,6 +160,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.approve(address,uint256) (tests/incorrect_erc20_interface.sol#5)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.approve(address,uint256)](tests/incorrect_erc20_interface.sol#L5)\n",
+        "id": "0fced3029cf59cf348a6b79c58dbb032d837fdd5a5f355600edebda1878e9e2e",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -239,6 +241,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.transferFrom(address,address,uint256) (tests/incorrect_erc20_interface.sol#6)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.transferFrom(address,address,uint256)](tests/incorrect_erc20_interface.sol#L6)\n",
+        "id": "ba13a1588595032984a3fad39610a2414bb8fcb522d1e632d52fa947ff207d73",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -319,6 +322,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.totalSupply() (tests/incorrect_erc20_interface.sol#7)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.totalSupply()](tests/incorrect_erc20_interface.sol#L7)\n",
+        "id": "c951e429e546af28ac08e241d391e874c1c9c70b0732ccfb63f3bbfb3eaac16e",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -399,6 +403,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.balanceOf(address) (tests/incorrect_erc20_interface.sol#8)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.balanceOf(address)](tests/incorrect_erc20_interface.sol#L8)\n",
+        "id": "758ca2456030a36dbd6115f2ccb1a43f53f1dabd66ed079806df0f6b7b4d21ef",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -479,6 +484,7 @@
         ],
         "description": "Token (tests/incorrect_erc20_interface.sol#3-10) has incorrect ERC20 function interface:Token.allowance(address,address) (tests/incorrect_erc20_interface.sol#9)\n",
         "markdown": "[Token](tests/incorrect_erc20_interface.sol#L3-L10) has incorrect ERC20 function interface:[Token.allowance(address,address)](tests/incorrect_erc20_interface.sol#L9)\n",
+        "id": "1286abfe21b09e21e1cec8b991f73664e104fa39f7f4190690ece3af45bc0c7a",
         "check": "erc20-interface",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/incorrect_erc721_interface.erc721-interface.json
+++ b/tests/expected_json/incorrect_erc721_interface.erc721-interface.json
@@ -77,6 +77,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:IERC165.supportsInterface(bytes4) (tests/incorrect_erc721_interface.sol#4)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[IERC165.supportsInterface(bytes4)](tests/incorrect_erc721_interface.sol#L4)\n",
+        "id": "a8593587ca70c51a9ab827843babec3b3eb7f9a08d76eea1e5528e668f7b291d",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -163,6 +164,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.balanceOf(address) (tests/incorrect_erc721_interface.sol#7)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.balanceOf(address)](tests/incorrect_erc721_interface.sol#L7)\n",
+        "id": "6fb9d0320e0b63e2c70f9844d5bea2be958e73beb6eaa4ccb2323ead0c7ef991",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -249,6 +251,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.ownerOf(uint256) (tests/incorrect_erc721_interface.sol#8)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.ownerOf(uint256)](tests/incorrect_erc721_interface.sol#L8)\n",
+        "id": "7d9235dd4ef8bc29a3b7700597cc1e4efb846377c928e5e50c5f49cb37f288d2",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -335,6 +338,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.safeTransferFrom(address,address,uint256,bytes) (tests/incorrect_erc721_interface.sol#9)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.safeTransferFrom(address,address,uint256,bytes)](tests/incorrect_erc721_interface.sol#L9)\n",
+        "id": "ccec612c4b5db00ab59b766b5dde3f8d3a8c6408ef595ab08bff21628587e2a1",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -421,6 +425,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.safeTransferFrom(address,address,uint256) (tests/incorrect_erc721_interface.sol#10)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.safeTransferFrom(address,address,uint256)](tests/incorrect_erc721_interface.sol#L10)\n",
+        "id": "50ab7b0f39f327ac6deccf3c16b4e6fee1dc249072ac41a4bd485ccf0c12315b",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -507,6 +512,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.transferFrom(address,address,uint256) (tests/incorrect_erc721_interface.sol#11)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.transferFrom(address,address,uint256)](tests/incorrect_erc721_interface.sol#L11)\n",
+        "id": "847b11227f3bfc9b120e0ea573f385a4bbc61c4b7f89f434864612a679b1133e",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -593,6 +599,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.approve(address,uint256) (tests/incorrect_erc721_interface.sol#12)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.approve(address,uint256)](tests/incorrect_erc721_interface.sol#L12)\n",
+        "id": "439c95972d0e084aff057161164b13ab63f85bee31d80b568b7155e58eac4b5d",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -679,6 +686,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.setApprovalForAll(address,bool) (tests/incorrect_erc721_interface.sol#13)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.setApprovalForAll(address,bool)](tests/incorrect_erc721_interface.sol#L13)\n",
+        "id": "b95e9bb000fb073c25fdbd9fff7bf0a3c44e04e70fc1a7da27c94c6b7fb8be40",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -765,6 +773,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.getApproved(uint256) (tests/incorrect_erc721_interface.sol#14)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.getApproved(uint256)](tests/incorrect_erc721_interface.sol#L14)\n",
+        "id": "2dce4891c7abea0fa8a8a20a8b8482e7e1d46d54bfd750701c604d5dadd8b937",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"
@@ -851,6 +860,7 @@
         ],
         "description": "Token (tests/incorrect_erc721_interface.sol#6-16) has incorrect ERC721 function interface:Token.isApprovedForAll(address,address) (tests/incorrect_erc721_interface.sol#15)\n",
         "markdown": "[Token](tests/incorrect_erc721_interface.sol#L6-L16) has incorrect ERC721 function interface:[Token.isApprovedForAll(address,address)](tests/incorrect_erc721_interface.sol#L15)\n",
+        "id": "fa9985c505689f9a45d1ac51e1dd8cf79eeb2c939946abfb5ac78f46e692d0eb",
         "check": "erc721-interface",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/inline_assembly_contract-0.5.1.assembly.json
+++ b/tests/expected_json/inline_assembly_contract-0.5.1.assembly.json
@@ -179,6 +179,7 @@
         ],
         "description": "GetCode.at(address) (tests/inline_assembly_contract-0.5.1.sol#6-20) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_contract-0.5.1.sol#7-20)\n",
         "markdown": "[GetCode.at(address)](tests/inline_assembly_contract-0.5.1.sol#L6-L20) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_contract-0.5.1.sol#L7-L20)\n",
+        "id": "8f8a296feb87f8865449404161841580a3bb405864ed5f2622fdffdbe6a93ad8",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/inline_assembly_contract.assembly.json
+++ b/tests/expected_json/inline_assembly_contract.assembly.json
@@ -179,6 +179,7 @@
         ],
         "description": "GetCode.at(address) (tests/inline_assembly_contract.sol#6-20) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_contract.sol#7-20)\n",
         "markdown": "[GetCode.at(address)](tests/inline_assembly_contract.sol#L6-L20) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_contract.sol#L7-L20)\n",
+        "id": "8f448cbd104ddfcc1c099119fcb367b581476208f7cc3ab5897f4a9b5b4a9080",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/inline_assembly_library-0.5.1.assembly.json
+++ b/tests/expected_json/inline_assembly_library-0.5.1.assembly.json
@@ -207,6 +207,7 @@
         ],
         "description": "VectorSum.sumAsm(uint256[]) (tests/inline_assembly_library-0.5.1.sol#16-22) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_library-0.5.1.sol#18-21)\n",
         "markdown": "[VectorSum.sumAsm(uint256[])](tests/inline_assembly_library-0.5.1.sol#L16-L22) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_library-0.5.1.sol#L18-L21)\n",
+        "id": "2d646463bf10753d2433783ea4a212d84dfb51269bb062f4ea5db21bd8ec6cb6",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"
@@ -465,6 +466,7 @@
         ],
         "description": "VectorSum.sumPureAsm(uint256[]) (tests/inline_assembly_library-0.5.1.sol#25-47) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_library-0.5.1.sol#26-47)\n",
         "markdown": "[VectorSum.sumPureAsm(uint256[])](tests/inline_assembly_library-0.5.1.sol#L25-L47) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_library-0.5.1.sol#L26-L47)\n",
+        "id": "df1118184108ae4b7b7300da137ebfc86c3279fcaffabf289d8e79bc23228105",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/inline_assembly_library.assembly.json
+++ b/tests/expected_json/inline_assembly_library.assembly.json
@@ -207,6 +207,7 @@
         ],
         "description": "VectorSum.sumAsm(uint256[]) (tests/inline_assembly_library.sol#16-22) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_library.sol#18-21)\n",
         "markdown": "[VectorSum.sumAsm(uint256[])](tests/inline_assembly_library.sol#L16-L22) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_library.sol#L18-L21)\n",
+        "id": "3ff39c86f26b81703ac5df9ce9d176a0a2c9948abccc76da3768272588588c04",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"
@@ -465,6 +466,7 @@
         ],
         "description": "VectorSum.sumPureAsm(uint256[]) (tests/inline_assembly_library.sol#25-47) uses assembly\n\t- INLINE ASM None (tests/inline_assembly_library.sol#26-47)\n",
         "markdown": "[VectorSum.sumPureAsm(uint256[])](tests/inline_assembly_library.sol#L25-L47) uses assembly\n\t- [INLINE ASM None](tests/inline_assembly_library.sol#L26-L47)\n",
+        "id": "423795860d3892652fcf5005055c4781586100070e0ecdffb7ca1014c3958191",
         "check": "assembly",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/locked_ether-0.5.1.locked-ether.json
+++ b/tests/expected_json/locked_ether-0.5.1.locked-ether.json
@@ -73,6 +73,7 @@
         ],
         "description": "Contract locking ether found in :\n\tContract OnlyLocked (tests/locked_ether-0.5.1.sol#26) has payable functions:\n\t - Locked.receive() (tests/locked_ether-0.5.1.sol#4-6)\n\tBut does not have a function to withdraw the ether\n",
         "markdown": "Contract locking ether found in :\n\tContract [OnlyLocked](tests/locked_ether-0.5.1.sol#L26) has payable functions:\n\t - [Locked.receive()](tests/locked_ether-0.5.1.sol#L4-L6)\n\tBut does not have a function to withdraw the ether\n",
+        "id": "38b2d47301e59ffa598ec48a8e874e6a7070d6cf4e4ab2909f33a8b72fc28a4b",
         "check": "locked-ether",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/locked_ether.locked-ether.json
+++ b/tests/expected_json/locked_ether.locked-ether.json
@@ -73,6 +73,7 @@
         ],
         "description": "Contract locking ether found in :\n\tContract OnlyLocked (tests/locked_ether.sol#26) has payable functions:\n\t - Locked.receive() (tests/locked_ether.sol#4-6)\n\tBut does not have a function to withdraw the ether\n",
         "markdown": "Contract locking ether found in :\n\tContract [OnlyLocked](tests/locked_ether.sol#L26) has payable functions:\n\t - [Locked.receive()](tests/locked_ether.sol#L4-L6)\n\tBut does not have a function to withdraw the ether\n",
+        "id": "38b2d47301e59ffa598ec48a8e874e6a7070d6cf4e4ab2909f33a8b72fc28a4b",
         "check": "locked-ether",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/low_level_calls.low-level-calls.json
+++ b/tests/expected_json/low_level_calls.low-level-calls.json
@@ -118,6 +118,7 @@
         ],
         "description": "Low level call in Sender.send(address) (tests/low_level_calls.sol#5-7):\n\t- _receiver.call.value(msg.value).gas(7777)() (tests/low_level_calls.sol#6)\n",
         "markdown": "Low level call in [Sender.send(address)](tests/low_level_calls.sol#L5-L7):\n\t- [_receiver.call.value(msg.value).gas(7777)()](tests/low_level_calls.sol#L6)\n",
+        "id": "5cb382cdae5ceb68ac0c67a88d9233a949dc990d5899578415da8139804cf149",
         "check": "low-level-calls",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/multiple_calls_in_loop.calls-loop.json
+++ b/tests/expected_json/multiple_calls_in_loop.calls-loop.json
@@ -142,6 +142,7 @@
         ],
         "description": "CallInLoop.bad() (tests/multiple_calls_in_loop.sol#9-13) has external calls inside a loop: destinations[i].transfer(i) (tests/multiple_calls_in_loop.sol#11)\n",
         "markdown": "[CallInLoop.bad()](tests/multiple_calls_in_loop.sol#L9-L13) has external calls inside a loop: [destinations[i].transfer(i)](tests/multiple_calls_in_loop.sol#L11)\n",
+        "id": "70793ed549e12ccf0735e919c865f639eec14665073037a97794396066e650ed",
         "check": "calls-loop",
         "impact": "Low",
         "confidence": "Medium"

--- a/tests/expected_json/naming_convention.naming-convention.json
+++ b/tests/expected_json/naming_convention.naming-convention.json
@@ -75,6 +75,7 @@
         ],
         "description": "Contract naming (tests/naming_convention.sol#3-48) is not in CapWords\n",
         "markdown": "Contract [naming](tests/naming_convention.sol#L3-L48) is not in CapWords\n",
+        "id": "7247d550fb327e3aeb21c82714137e5b45a7e9eeaa6a1bc878102c8081033f85",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -173,6 +174,7 @@
         ],
         "description": "Struct naming.test (tests/naming_convention.sol#14-16) is not in CapWords\n",
         "markdown": "Struct [naming.test](tests/naming_convention.sol#L14-L16) is not in CapWords\n",
+        "id": "0ef3ea412cb30b1f0df5fa2af4a7a06e2bf0373fae0770fd9e301aed12c209cf",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -270,6 +272,7 @@
         ],
         "description": "Event namingevent_(uint256) (tests/naming_convention.sol#23) is not in CapWords\n",
         "markdown": "Event [namingevent_(uint256)](tests/naming_convention.sol#L23) is not in CapWords\n",
+        "id": "978ecf4a2c8b96d947e60f6601cf60d0e25e07ebe80ebbc37a7e7f279afd1405",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -370,6 +373,7 @@
         ],
         "description": "Function naming.GetOne() (tests/naming_convention.sol#30-33) is not in mixedCase\n",
         "markdown": "Function [naming.GetOne()](tests/naming_convention.sol#L30-L33) is not in mixedCase\n",
+        "id": "bf6f97d6a82b84284efdade52d01bd6112007426e2e88d1568190d63c5c4a049",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -490,6 +494,7 @@
         ],
         "description": "Parameter naming.setInt(uint256,uint256).Number2 (tests/naming_convention.sol#35) is not in mixedCase\n",
         "markdown": "Parameter [naming.setInt(uint256,uint256).Number2](tests/naming_convention.sol#L35) is not in mixedCase\n",
+        "id": "f03bff0b488524254e19ff7d688d34211cd2f29934e22417c9f1fa43fc4a08ad",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -586,6 +591,7 @@
         ],
         "description": "Constant naming.MY_other_CONSTANT (tests/naming_convention.sol#9) is not in UPPER_CASE_WITH_UNDERSCORES\n",
         "markdown": "Constant [naming.MY_other_CONSTANT](tests/naming_convention.sol#L9) is not in UPPER_CASE_WITH_UNDERSCORES\n",
+        "id": "596c2e8064f8f2df55cd5c878eb59c0a74ac7f20719c420d8af307f2431a1a90",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -682,6 +688,7 @@
         ],
         "description": "Variable naming.Var_One (tests/naming_convention.sol#11) is not in mixedCase\n",
         "markdown": "Variable [naming.Var_One](tests/naming_convention.sol#L11) is not in mixedCase\n",
+        "id": "34b7c817201b3f3086fc3541f140898d9e9aabe999b1c0a6ef8639ec04351f26",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -778,6 +785,7 @@
         ],
         "description": "Enum naming.numbers (tests/naming_convention.sol#6) is not in CapWords\n",
         "markdown": "Enum [naming.numbers](tests/naming_convention.sol#L6) is not in CapWords\n",
+        "id": "7c87b076ea2865060182cf11d155caadb1dcea415ccce0ca8563a74a01611fc2",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -877,6 +885,7 @@
         ],
         "description": "Modifier naming.CantDo() (tests/naming_convention.sol#41-43) is not in mixedCase\n",
         "markdown": "Modifier [naming.CantDo()](tests/naming_convention.sol#L41-L43) is not in mixedCase\n",
+        "id": "b8a754a01bd47127f00032cdedd0ade3e27e6543631d8f5bc9e44365ab732895",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -964,6 +973,7 @@
         ],
         "description": "Parameter T.test(uint256,uint256)._used (tests/naming_convention.sol#59) is not in mixedCase\n",
         "markdown": "Parameter [T.test(uint256,uint256)._used](tests/naming_convention.sol#L59) is not in mixedCase\n",
+        "id": "818962ad9f50f13eb87b5c7deade22666431945fb60055f572b38246cfbf311e",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -1029,6 +1039,7 @@
         ],
         "description": "Variable T._myPublicVar (tests/naming_convention.sol#56) is not in mixedCase\n",
         "markdown": "Variable [T._myPublicVar](tests/naming_convention.sol#L56) is not in mixedCase\n",
+        "id": "8acd53815786acad5b92b51366daf79182a67ab438daa41a6e1ec8a9601fa9a3",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"
@@ -1094,6 +1105,7 @@
         ],
         "description": "Variable T.l (tests/naming_convention.sol#67) used l, O, I, which should not be used\n",
         "markdown": "Variable [T.l](tests/naming_convention.sol#L67) used l, O, I, which should not be used\n",
+        "id": "b595f9e6d03b8b501b7c4a9bf8ff0ad9bf11448a25f53d63ab5031c95f8ae89c",
         "check": "naming-convention",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/old_solc.sol.json.solc-version.json
+++ b/tests/expected_json/old_solc.sol.json.solc-version.json
@@ -31,6 +31,7 @@
         ],
         "description": "Pragma version0.4.21 (None) allows old versions\n",
         "markdown": "Pragma version[0.4.21](None) allows old versions\n",
+        "id": "328ceb03806c74c48201abc80cb5625f6c8f47711913161dc99748ee6a99b64f",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/pragma.0.4.24.pragma.json
+++ b/tests/expected_json/pragma.0.4.24.pragma.json
@@ -60,6 +60,7 @@
         ],
         "description": "Different versions of Solidity is used in :\n\t- Version used: ['^0.4.23', '^0.4.24']\n\t- ^0.4.23 (tests/pragma.0.4.23.sol#1)\n\t- ^0.4.24 (tests/pragma.0.4.24.sol#1)\n",
         "markdown": "Different versions of Solidity is used in :\n\t- Version used: ['^0.4.23', '^0.4.24']\n\t- [^0.4.23](tests/pragma.0.4.23.sol#L1)\n\t- [^0.4.24](tests/pragma.0.4.24.sol#L1)\n",
+        "id": "ab9edf8af725d611d1eaeb16713c0f2e9f51804dc985b1bc823bd87645713fb7",
         "check": "pragma",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
@@ -349,6 +349,7 @@
         ],
         "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy-0.5.1.sol#21)\n",
         "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy-0.5.1.sol#L14-L22):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(userBalance[msg.sender])()](tests/reentrancy-0.5.1.sol#L17)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy-0.5.1.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy-0.5.1.sol#L21)\n",
+        "id": "90119c12446a44e514bb4ccd7a0e869f210d7c3ec349d24d4237ace685a75df9",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"
@@ -702,6 +703,7 @@
         ],
         "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#44-53):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(amount)() (tests/reentrancy-0.5.1.sol#49)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = amount (tests/reentrancy-0.5.1.sol#51)\n",
         "markdown": "Reentrancy in [Reentrancy.withdrawBalance_fixed_3()](tests/reentrancy-0.5.1.sol#L44-L53):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(amount)()](tests/reentrancy-0.5.1.sol#L49)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy-0.5.1.sol#L4) in [userBalance[msg.sender] = amount](tests/reentrancy-0.5.1.sol#L51)\n",
+        "id": "048dce6132290bdee94cd1e52c330873fed4b1c9ad2f49df4ba3d6ef49266a41",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/reentrancy.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy.reentrancy-eth.json
@@ -400,6 +400,7 @@
         ],
         "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):\n\tExternal calls:\n\t- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#20)\n",
         "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy.sol#L14-L21):\n\tExternal calls:\n\t- [! (msg.sender.call.value(userBalance[msg.sender])())](tests/reentrancy.sol#L17)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy.sol#L20)\n",
+        "id": "330f0fadcfdda2b4364ee67d3112ff00e0e369162004c451163f0663c9b01313",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"
@@ -798,6 +799,7 @@
         ],
         "description": "Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):\n\tExternal calls:\n\t- msg.sender.call.value(amount / 2)() (tests/reentrancy.sol#67)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#68)\n",
         "markdown": "Reentrancy in [Reentrancy.withdrawBalance_nested()](tests/reentrancy.sol#L64-L70):\n\tExternal calls:\n\t- [msg.sender.call.value(amount / 2)()](tests/reentrancy.sol#L67)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy.sol#L68)\n",
+        "id": "30220828bfef61c2377527c7cee2ae5be443001f8dd39992d6e5af67153c402f",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/right_to_left_override.rtlo.json
+++ b/tests/expected_json/right_to_left_override.rtlo.json
@@ -26,6 +26,7 @@
         ],
         "description": "/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
         "markdown": "/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
+        "id": "a6c8caf0e8d2182254c7b66c9808b999315b14fe10087f12bdc0afa72a43c223",
         "check": "rtlo",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/right_to_left_override.rtlo.json
+++ b/tests/expected_json/right_to_left_override.rtlo.json
@@ -24,9 +24,9 @@
             }
           }
         ],
-        "description": "/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
-        "markdown": "/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
-        "id": "a6c8caf0e8d2182254c7b66c9808b999315b14fe10087f12bdc0afa72a43c223",
+        "description": "tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
+        "markdown": "tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:\n\t- b'        test1(/*A\\xe2\\x80\\xae/*B*/2 , 1/*\\xe2\\x80\\xad'\n",
+        "id": "7d1d0efc4c3c51bc1cc85572c67fa5244f01af85ab9e4bcef199d928a3b5447b",
         "check": "rtlo",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/right_to_left_override.rtlo.txt
+++ b/tests/expected_json/right_to_left_override.rtlo.txt
@@ -1,5 +1,5 @@
 [91m
-/home/travis/build/crytic/slither/tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:
+tests/right_to_left_override.sol contains a unicode right-to-left-override character at byte offset 96:
 	- b'        test1(/*A\xe2\x80\xae/*B*/2 , 1/*\xe2\x80\xad'
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#right-to-left-override-character[0m
 tests/right_to_left_override.sol analyzed (1 contracts with 1 detectors), 1 result(s) found

--- a/tests/expected_json/shadowing_abstract.shadowing-abstract.json
+++ b/tests/expected_json/shadowing_abstract.shadowing-abstract.json
@@ -90,6 +90,7 @@
         ],
         "description": "DerivedContract.owner (tests/shadowing_abstract.sol#7) shadows:\n\t- BaseContract.owner (tests/shadowing_abstract.sol#2)\n",
         "markdown": "[DerivedContract.owner](tests/shadowing_abstract.sol#L7) shadows:\n\t- [BaseContract.owner](tests/shadowing_abstract.sol#L2)\n",
+        "id": "9c5c3fc5091b9ecd6ec271fdbb3036d9d3426cdf9a09d6cc293fd7de9240e4ab",
         "check": "shadowing-abstract",
         "impact": "Medium",
         "confidence": "High"

--- a/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.json
+++ b/tests/expected_json/shadowing_builtin_symbols.shadowing-builtin.json
@@ -51,6 +51,7 @@
         ],
         "description": "BaseContract.blockhash (tests/shadowing_builtin_symbols.sol#4) (state variable) shadows built-in symbol\"\n",
         "markdown": "[BaseContract.blockhash](tests/shadowing_builtin_symbols.sol#L4) (state variable) shadows built-in symbol\"\n",
+        "id": "61d1c1452e694c321d00576decdf35c62efbe8860f664273955fadce5e063cc8",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -103,6 +104,7 @@
         ],
         "description": "BaseContract.now (tests/shadowing_builtin_symbols.sol#5) (state variable) shadows built-in symbol\"\n",
         "markdown": "[BaseContract.now](tests/shadowing_builtin_symbols.sol#L5) (state variable) shadows built-in symbol\"\n",
+        "id": "942ad0405af0bc533374dded6e2474c53892747c98d2df14d59cbb6840fa18b3",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -156,6 +158,7 @@
         ],
         "description": "BaseContractrevert(bool) (tests/shadowing_builtin_symbols.sol#7) (event) shadows built-in symbol\"\n",
         "markdown": "[BaseContractrevert(bool)](tests/shadowing_builtin_symbols.sol#L7) (event) shadows built-in symbol\"\n",
+        "id": "9c428e61cb4832d899b2bb711c8d428154425dbadf5dfc2e2d857254824d8f72",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -212,6 +215,7 @@
         ],
         "description": "ExtendedContract.assert(bool) (tests/shadowing_builtin_symbols.sol#13-15) (function) shadows built-in symbol\"\n",
         "markdown": "[ExtendedContract.assert(bool)](tests/shadowing_builtin_symbols.sol#L13-L15) (function) shadows built-in symbol\"\n",
+        "id": "b3a1b23c1daed52b1a2ff5fb76d4fcdf2bc0b2126524303321cf8e7835116d6f",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -288,6 +292,7 @@
         ],
         "description": "ExtendedContract.assert(bool).msg (tests/shadowing_builtin_symbols.sol#14) (local variable) shadows built-in symbol\"\n",
         "markdown": "[ExtendedContract.assert(bool).msg](tests/shadowing_builtin_symbols.sol#L14) (local variable) shadows built-in symbol\"\n",
+        "id": "a2a7e1e27320d38e52b51c9b1ec67cca0a403673ff6fdd59652f9cd8425d011f",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -341,6 +346,7 @@
         ],
         "description": "ExtendedContract.ecrecover (tests/shadowing_builtin_symbols.sol#11) (state variable) shadows built-in symbol\"\n",
         "markdown": "[ExtendedContract.ecrecover](tests/shadowing_builtin_symbols.sol#L11) (state variable) shadows built-in symbol\"\n",
+        "id": "39737925cf3bd4ebf9a1c7bbe39da8b80ba28e5a3d93a938d1a4cca78a6a436d",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -405,6 +411,7 @@
         ],
         "description": "FurtherExtendedContract.require() (tests/shadowing_builtin_symbols.sol#23-28) (modifier) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.require()](tests/shadowing_builtin_symbols.sol#L23-L28) (modifier) shadows built-in symbol\"\n",
+        "id": "db6c26c9a7c319c1a34c486e6e625c0906a2b118f8cd72f38a38c167832aab4f",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -489,6 +496,7 @@
         ],
         "description": "FurtherExtendedContract.require().keccak256 (tests/shadowing_builtin_symbols.sol#25) (local variable) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.require().keccak256](tests/shadowing_builtin_symbols.sol#L25) (local variable) shadows built-in symbol\"\n",
+        "id": "40f0453d27abf2d9ed76fe60853b6e2e0cd9a443d639e9da457460ea02b2bdc7",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -573,6 +581,7 @@
         ],
         "description": "FurtherExtendedContract.require().sha3 (tests/shadowing_builtin_symbols.sol#26) (local variable) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.require().sha3](tests/shadowing_builtin_symbols.sol#L26) (local variable) shadows built-in symbol\"\n",
+        "id": "c481dbbf77c99cb337740a656ebabae1c89bf13b9d7b7d315dcf54feeab1cd63",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -631,6 +640,7 @@
         ],
         "description": "FurtherExtendedContract.blockhash (tests/shadowing_builtin_symbols.sol#19) (state variable) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.blockhash](tests/shadowing_builtin_symbols.sol#L19) (state variable) shadows built-in symbol\"\n",
+        "id": "d405ccbec679f921252d475591a890a89a023b375dc4994119967693692f8da9",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -689,6 +699,7 @@
         ],
         "description": "FurtherExtendedContract.this (tests/shadowing_builtin_symbols.sol#20) (state variable) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.this](tests/shadowing_builtin_symbols.sol#L20) (state variable) shadows built-in symbol\"\n",
+        "id": "87e1cc0cb95181dd120d3e6e55d89fdc7b5cd01da2f89cd7a3d105738f57c10b",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -747,6 +758,7 @@
         ],
         "description": "FurtherExtendedContract.abi (tests/shadowing_builtin_symbols.sol#21) (state variable) shadows built-in symbol\"\n",
         "markdown": "[FurtherExtendedContract.abi](tests/shadowing_builtin_symbols.sol#L21) (state variable) shadows built-in symbol\"\n",
+        "id": "4665243a2df090e3543ab26447528fa3401916f4669fe1264145891846d4bc40",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"
@@ -797,6 +809,7 @@
         ],
         "description": "Reserved.mutable (tests/shadowing_builtin_symbols.sol#32) (state variable) shadows built-in symbol\"\n",
         "markdown": "[Reserved.mutable](tests/shadowing_builtin_symbols.sol#L32) (state variable) shadows built-in symbol\"\n",
+        "id": "11840553a9e11623596d7a07275814e65a5b1d90277ae0e2954cd8ce74d6a6d2",
         "check": "shadowing-builtin",
         "impact": "Low",
         "confidence": "High"

--- a/tests/expected_json/shadowing_local_variable.shadowing-local.json
+++ b/tests/expected_json/shadowing_local_variable.shadowing-local.json
@@ -210,6 +210,7 @@
         ],
         "description": "FurtherExtendedContract.shadowingParent(uint256).x (tests/shadowing_local_variable.sol#25) shadows:\n\t- FurtherExtendedContract.x (tests/shadowing_local_variable.sol#17) (state variable)\n\t- ExtendedContract.x (tests/shadowing_local_variable.sol#9) (state variable)\n\t- BaseContract.x (tests/shadowing_local_variable.sol#4) (state variable)\n",
         "markdown": "[FurtherExtendedContract.shadowingParent(uint256).x](tests/shadowing_local_variable.sol#L25) shadows:\n\t- [FurtherExtendedContract.x](tests/shadowing_local_variable.sol#L17) (state variable)\n\t- [ExtendedContract.x](tests/shadowing_local_variable.sol#L9) (state variable)\n\t- [BaseContract.x](tests/shadowing_local_variable.sol#L4) (state variable)\n",
+        "id": "0991435c12aa2d6f15e8da2a00a18e9c58ef65dcf31137cdb561655317353247",
         "check": "shadowing-local",
         "impact": "Low",
         "confidence": "High"
@@ -329,6 +330,7 @@
         ],
         "description": "FurtherExtendedContract.shadowingParent(uint256).y (tests/shadowing_local_variable.sol#25) shadows:\n\t- BaseContract.y (tests/shadowing_local_variable.sol#5) (state variable)\n",
         "markdown": "[FurtherExtendedContract.shadowingParent(uint256).y](tests/shadowing_local_variable.sol#L25) shadows:\n\t- [BaseContract.y](tests/shadowing_local_variable.sol#L5) (state variable)\n",
+        "id": "465bd81cbb09a3d2cc84ea6102fb059296f1970e85e2d86a171f8219f1a34508",
         "check": "shadowing-local",
         "impact": "Low",
         "confidence": "High"
@@ -452,6 +454,7 @@
         ],
         "description": "FurtherExtendedContract.shadowingParent(uint256).z (tests/shadowing_local_variable.sol#25) shadows:\n\t- ExtendedContract.z() (tests/shadowing_local_variable.sol#11) (function)\n",
         "markdown": "[FurtherExtendedContract.shadowingParent(uint256).z](tests/shadowing_local_variable.sol#L25) shadows:\n\t- [ExtendedContract.z()](tests/shadowing_local_variable.sol#L11) (function)\n",
+        "id": "e3d2948e9c1252fe84e0d7e58f6682af7af84ef209f6e71f039faccabf07b0bd",
         "check": "shadowing-local",
         "impact": "Low",
         "confidence": "High"
@@ -582,6 +585,7 @@
         ],
         "description": "FurtherExtendedContract.shadowingParent(uint256).w (tests/shadowing_local_variable.sol#25) shadows:\n\t- FurtherExtendedContract.w() (tests/shadowing_local_variable.sol#20-23) (modifier)\n",
         "markdown": "[FurtherExtendedContract.shadowingParent(uint256).w](tests/shadowing_local_variable.sol#L25) shadows:\n\t- [FurtherExtendedContract.w()](tests/shadowing_local_variable.sol#L20-L23) (modifier)\n",
+        "id": "a94a2b9331482c75582868e6d3cc5c9b01487e7505f219abcf36a20d76e0b089",
         "check": "shadowing-local",
         "impact": "Low",
         "confidence": "High"
@@ -705,6 +709,7 @@
         ],
         "description": "FurtherExtendedContract.shadowingParent(uint256).v (tests/shadowing_local_variable.sol#25) shadows:\n\t- ExtendedContractv() (tests/shadowing_local_variable.sol#13) (event)\n",
         "markdown": "[FurtherExtendedContract.shadowingParent(uint256).v](tests/shadowing_local_variable.sol#L25) shadows:\n\t- [ExtendedContractv()](tests/shadowing_local_variable.sol#L13) (event)\n",
+        "id": "973e31cc30dc7a3e1f089dfa5848234075f237f78fa492c772b1083e12c79054",
         "check": "shadowing-local",
         "impact": "Low",
         "confidence": "High"

--- a/tests/expected_json/shadowing_state_variable.shadowing-state.json
+++ b/tests/expected_json/shadowing_state_variable.shadowing-state.json
@@ -102,6 +102,7 @@
         ],
         "description": "DerivedContract.owner (tests/shadowing_state_variable.sol#12) shadows:\n\t- BaseContract.owner (tests/shadowing_state_variable.sol#2)\n",
         "markdown": "[DerivedContract.owner](tests/shadowing_state_variable.sol#L12) shadows:\n\t- [BaseContract.owner](tests/shadowing_state_variable.sol#L2)\n",
+        "id": "9c5c3fc5091b9ecd6ec271fdbb3036d9d3426cdf9a09d6cc293fd7de9240e4ab",
         "check": "shadowing-state",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/solc_version_incorrect.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect.solc-version.json
@@ -34,6 +34,7 @@
         ],
         "description": "Pragma version^0.4.23 (tests/solc_version_incorrect.sol#2) allows old versions\n",
         "markdown": "Pragma version[^0.4.23](tests/solc_version_incorrect.sol#L2) allows old versions\n",
+        "id": "c88d5b50c78f468b95732feb91693016824f78333adab2fdcca3152eec2bfa73",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"
@@ -72,6 +73,7 @@
         ],
         "description": "Pragma version>=0.4.0<0.6.0 (tests/solc_version_incorrect.sol#3) allows old versions\n",
         "markdown": "Pragma version[>=0.4.0<0.6.0](tests/solc_version_incorrect.sol#L3) allows old versions\n",
+        "id": "dfd3e70c2367b0c8eca5afa86d1773b9c7aa1d0a155e3a0495188800c41fe390",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
@@ -32,6 +32,7 @@
         ],
         "description": "Pragma version^0.5.5 (None) is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)\n",
         "markdown": "Pragma version[^0.5.5](None) is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)\n",
+        "id": "8bcf06a2e2c13723dbc16f843f73830ebdb86b7e8ee599524a0b9824bb89381c",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"
@@ -64,6 +65,7 @@
         ],
         "description": "Pragma version0.5.7 (None) necessitates versions too recent to be trusted. Consider deploying with 0.5.3\n",
         "markdown": "Pragma version[0.5.7](None) necessitates versions too recent to be trusted. Consider deploying with 0.5.3\n",
+        "id": "997cf0cfc722f31f7566c3fd180c01b0c7466a19df7c65ee590e9f3778cf62ee",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/timestamp.timestamp.json
+++ b/tests/expected_json/timestamp.timestamp.json
@@ -148,6 +148,7 @@
         ],
         "description": "Timestamp.bad0() (tests/timestamp.sol#4-6) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool)(block.timestamp == 0) (tests/timestamp.sol#5)\n",
         "markdown": "[Timestamp.bad0()](tests/timestamp.sol#L4-L6) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [require(bool)(block.timestamp == 0)](tests/timestamp.sol#L5)\n",
+        "id": "40a3d28a47f4ff093afc58a30950747eef4db7fe47ace94e10bc4e763e77d82f",
         "check": "timestamp",
         "impact": "Low",
         "confidence": "Medium"
@@ -299,6 +300,7 @@
         ],
         "description": "Timestamp.bad1() (tests/timestamp.sol#8-11) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- require(bool)(time == 0) (tests/timestamp.sol#10)\n",
         "markdown": "[Timestamp.bad1()](tests/timestamp.sol#L8-L11) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [require(bool)(time == 0)](tests/timestamp.sol#L10)\n",
+        "id": "62968bb5164984fc4ed41aa04d9413d371e20127d858b730fe122bc03c8e5c21",
         "check": "timestamp",
         "impact": "Low",
         "confidence": "Medium"
@@ -448,6 +450,7 @@
         ],
         "description": "Timestamp.bad2() (tests/timestamp.sol#13-15) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- block.timestamp > 0 (tests/timestamp.sol#14)\n",
         "markdown": "[Timestamp.bad2()](tests/timestamp.sol#L13-L15) uses timestamp for comparisons\n\tDangerous comparisons:\n\t- [block.timestamp > 0](tests/timestamp.sol#L14)\n",
+        "id": "64a9f860d4e2c9cf89239b055236c4d39129725ffc45e3348bbd1856822b331d",
         "check": "timestamp",
         "impact": "Low",
         "confidence": "Medium"

--- a/tests/expected_json/too_many_digits.too-many-digits.json
+++ b/tests/expected_json/too_many_digits.too-many-digits.json
@@ -192,6 +192,7 @@
         ],
         "description": "C.f() (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x1 = 0x000001 (tests/too_many_digits.sol#10)\n",
         "markdown": "[C.f()](tests/too_many_digits.sol#L9-L15) uses literals with too many digits:\n\t- [x1 = 0x000001](tests/too_many_digits.sol#L10)\n",
+        "id": "ad33e4cde46622380bf364b6f0829b9a7c8491e1c219e977211e3ed81a9927ed",
         "check": "too-many-digits",
         "impact": "Informational",
         "confidence": "Medium"
@@ -385,6 +386,7 @@
         ],
         "description": "C.f() (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x2 = 0x0000000000001 (tests/too_many_digits.sol#11)\n",
         "markdown": "[C.f()](tests/too_many_digits.sol#L9-L15) uses literals with too many digits:\n\t- [x2 = 0x0000000000001](tests/too_many_digits.sol#L11)\n",
+        "id": "584a7ffb54e80195135c9bdc36073c0f8edd8fb9f3208b3b2b181a5612f66c25",
         "check": "too-many-digits",
         "impact": "Informational",
         "confidence": "Medium"
@@ -578,6 +580,7 @@
         ],
         "description": "C.f() (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x3 = 1000000000000000000 (tests/too_many_digits.sol#12)\n",
         "markdown": "[C.f()](tests/too_many_digits.sol#L9-L15) uses literals with too many digits:\n\t- [x3 = 1000000000000000000](tests/too_many_digits.sol#L12)\n",
+        "id": "b88a6bfe113e8a92f42e445b6c3dfeb799c2254bc3c9c17c8fd92cb48f342385",
         "check": "too-many-digits",
         "impact": "Informational",
         "confidence": "Medium"
@@ -771,6 +774,7 @@
         ],
         "description": "C.f() (tests/too_many_digits.sol#9-15) uses literals with too many digits:\n\t- x4 = 100000 (tests/too_many_digits.sol#13)\n",
         "markdown": "[C.f()](tests/too_many_digits.sol#L9-L15) uses literals with too many digits:\n\t- [x4 = 100000](tests/too_many_digits.sol#L13)\n",
+        "id": "3f65c504c516f8c6d309479729b47889c1b002be56d955a99eaafe9accab5688",
         "check": "too-many-digits",
         "impact": "Informational",
         "confidence": "Medium"
@@ -960,6 +964,7 @@
         ],
         "description": "C.h() (tests/too_many_digits.sol#20-24) uses literals with too many digits:\n\t- x2 = 100000 (tests/too_many_digits.sol#22)\n",
         "markdown": "[C.h()](tests/too_many_digits.sol#L20-L24) uses literals with too many digits:\n\t- [x2 = 100000](tests/too_many_digits.sol#L22)\n",
+        "id": "5f803e158c8bf519958ed6d12ba22e3100916c9a24f952d5cd574fd9ffe3aedb",
         "check": "too-many-digits",
         "impact": "Informational",
         "confidence": "Medium"

--- a/tests/expected_json/tx_origin-0.5.1.tx-origin.json
+++ b/tests/expected_json/tx_origin-0.5.1.tx-origin.json
@@ -156,6 +156,7 @@
         ],
         "description": "TxOrigin.bug0() (tests/tx_origin-0.5.1.sol#9-11) uses tx.origin for authorization: require(bool)(tx.origin == owner) (tests/tx_origin-0.5.1.sol#10)\n",
         "markdown": "[TxOrigin.bug0()](tests/tx_origin-0.5.1.sol#L9-L11) uses tx.origin for authorization: [require(bool)(tx.origin == owner)](tests/tx_origin-0.5.1.sol#L10)\n",
+        "id": "a0c994da7e4fde05152f6b40d0db7741dc9154c0c27417d123775a43017fbd0c",
         "check": "tx-origin",
         "impact": "Medium",
         "confidence": "Medium"
@@ -317,6 +318,7 @@
         ],
         "description": "TxOrigin.bug2() (tests/tx_origin-0.5.1.sol#13-17) uses tx.origin for authorization: tx.origin != owner (tests/tx_origin-0.5.1.sol#14)\n",
         "markdown": "[TxOrigin.bug2()](tests/tx_origin-0.5.1.sol#L13-L17) uses tx.origin for authorization: [tx.origin != owner](tests/tx_origin-0.5.1.sol#L14)\n",
+        "id": "d7ce45ed56ab8579d6a9e88b9d57b5a3847a0925e3dd18dcb4a2f85b75bd7540",
         "check": "tx-origin",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/tx_origin.tx-origin.json
+++ b/tests/expected_json/tx_origin.tx-origin.json
@@ -156,6 +156,7 @@
         ],
         "description": "TxOrigin.bug0() (tests/tx_origin.sol#9-11) uses tx.origin for authorization: require(bool)(tx.origin == owner) (tests/tx_origin.sol#10)\n",
         "markdown": "[TxOrigin.bug0()](tests/tx_origin.sol#L9-L11) uses tx.origin for authorization: [require(bool)(tx.origin == owner)](tests/tx_origin.sol#L10)\n",
+        "id": "ee75fdded0c273df2f7875bab74fc778ff8f0c85bbed968c80d5fd787bbef62e",
         "check": "tx-origin",
         "impact": "Medium",
         "confidence": "Medium"
@@ -317,6 +318,7 @@
         ],
         "description": "TxOrigin.bug2() (tests/tx_origin.sol#13-17) uses tx.origin for authorization: tx.origin != owner (tests/tx_origin.sol#14)\n",
         "markdown": "[TxOrigin.bug2()](tests/tx_origin.sol#L13-L17) uses tx.origin for authorization: [tx.origin != owner](tests/tx_origin.sol#L14)\n",
+        "id": "76446f7e20ba58a5f2094d357d8982c01225c8f61d73f33ed98316c3a4e892f0",
         "check": "tx-origin",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.json
+++ b/tests/expected_json/unchecked_lowlevel-0.5.1.unchecked-lowlevel.json
@@ -130,6 +130,7 @@
         ],
         "description": "MyConc.bad(address) (tests/unchecked_lowlevel-0.5.1.sol#2-4) ignores return value by dst.call.value(msg.value)() (tests/unchecked_lowlevel-0.5.1.sol#3)\n",
         "markdown": "[MyConc.bad(address)](tests/unchecked_lowlevel-0.5.1.sol#L2-L4) ignores return value by [dst.call.value(msg.value)()](tests/unchecked_lowlevel-0.5.1.sol#L3)\n",
+        "id": "44ab2ac22a418dc8ec66536dc7409a0a2c23fd3276b3fb7fe919ec1f1eaf483f",
         "check": "unchecked-lowlevel",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.json
+++ b/tests/expected_json/unchecked_lowlevel.unchecked-lowlevel.json
@@ -128,6 +128,7 @@
         ],
         "description": "MyConc.bad(address) (tests/unchecked_lowlevel.sol#2-4) ignores return value by dst.call.value(msg.value)() (tests/unchecked_lowlevel.sol#3)\n",
         "markdown": "[MyConc.bad(address)](tests/unchecked_lowlevel.sol#L2-L4) ignores return value by [dst.call.value(msg.value)()](tests/unchecked_lowlevel.sol#L3)\n",
+        "id": "2975c4b0d2410cbe0a0901b36b4117c3c1017be5188e08339f0dd99a55b511ce",
         "check": "unchecked-lowlevel",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/unchecked_send-0.5.1.unchecked-send.json
+++ b/tests/expected_json/unchecked_send-0.5.1.unchecked-send.json
@@ -144,6 +144,7 @@
         ],
         "description": "MyConc.bad(address) (tests/unchecked_send-0.5.1.sol#2-4) ignores return value by dst.send(msg.value) (tests/unchecked_send-0.5.1.sol#3)\n",
         "markdown": "[MyConc.bad(address)](tests/unchecked_send-0.5.1.sol#L2-L4) ignores return value by [dst.send(msg.value)](tests/unchecked_send-0.5.1.sol#L3)\n",
+        "id": "9e4d70a9e602a08c249500b8a32bd5cfe289229d2621a0f299c694c30c30d883",
         "check": "unchecked-send",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/uninitialized-0.5.1.uninitialized-state.json
+++ b/tests/expected_json/uninitialized-0.5.1.uninitialized-state.json
@@ -103,6 +103,7 @@
         ],
         "description": "Uninitialized.destination (tests/uninitialized-0.5.1.sol#5) is never initialized. It is used in:\n\t- Uninitialized.transfer() (tests/uninitialized-0.5.1.sol#7-9)\n",
         "markdown": "[Uninitialized.destination](tests/uninitialized-0.5.1.sol#L5) is never initialized. It is used in:\n\t- [Uninitialized.transfer()](tests/uninitialized-0.5.1.sol#L7-L9)\n",
+        "id": "e4711aebbd53922a9fe1e728917bf8e98eac065305e20d766b6b552debe79e44",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -218,6 +219,7 @@
         ],
         "description": "Test.balances (tests/uninitialized-0.5.1.sol#15) is never initialized. It is used in:\n\t- Test.use() (tests/uninitialized-0.5.1.sol#23-26)\n",
         "markdown": "[Test.balances](tests/uninitialized-0.5.1.sol#L15) is never initialized. It is used in:\n\t- [Test.use()](tests/uninitialized-0.5.1.sol#L23-L26)\n",
+        "id": "a2750d175b02d51aeb47a4576f74725ba991d3c8cf828a33ee78ccc34cf9e7d7",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -339,6 +341,7 @@
         ],
         "description": "Test2.st (tests/uninitialized-0.5.1.sol#45) is never initialized. It is used in:\n\t- Test2.use() (tests/uninitialized-0.5.1.sol#53-56)\n",
         "markdown": "[Test2.st](tests/uninitialized-0.5.1.sol#L45) is never initialized. It is used in:\n\t- [Test2.use()](tests/uninitialized-0.5.1.sol#L53-L56)\n",
+        "id": "427f100397f455d8000eff7b1d2463763ca8e452d5d98f7b7de693fd5e625a32",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -459,6 +462,7 @@
         ],
         "description": "Test2.v (tests/uninitialized-0.5.1.sol#47) is never initialized. It is used in:\n\t- Test2.init() (tests/uninitialized-0.5.1.sol#49-51)\n",
         "markdown": "[Test2.v](tests/uninitialized-0.5.1.sol#L47) is never initialized. It is used in:\n\t- [Test2.init()](tests/uninitialized-0.5.1.sol#L49-L51)\n",
+        "id": "bf96eee949943a12926cf1407a2df2b07e99b30a6fc2e78aebf088cdefcf77a7",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/uninitialized.uninitialized-state.json
+++ b/tests/expected_json/uninitialized.uninitialized-state.json
@@ -103,6 +103,7 @@
         ],
         "description": "Uninitialized.destination (tests/uninitialized.sol#5) is never initialized. It is used in:\n\t- Uninitialized.transfer() (tests/uninitialized.sol#7-9)\n",
         "markdown": "[Uninitialized.destination](tests/uninitialized.sol#L5) is never initialized. It is used in:\n\t- [Uninitialized.transfer()](tests/uninitialized.sol#L7-L9)\n",
+        "id": "e4711aebbd53922a9fe1e728917bf8e98eac065305e20d766b6b552debe79e44",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -218,6 +219,7 @@
         ],
         "description": "Test.balances (tests/uninitialized.sol#15) is never initialized. It is used in:\n\t- Test.use() (tests/uninitialized.sol#23-26)\n",
         "markdown": "[Test.balances](tests/uninitialized.sol#L15) is never initialized. It is used in:\n\t- [Test.use()](tests/uninitialized.sol#L23-L26)\n",
+        "id": "a2750d175b02d51aeb47a4576f74725ba991d3c8cf828a33ee78ccc34cf9e7d7",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -339,6 +341,7 @@
         ],
         "description": "Test2.st (tests/uninitialized.sol#45) is never initialized. It is used in:\n\t- Test2.use() (tests/uninitialized.sol#53-56)\n",
         "markdown": "[Test2.st](tests/uninitialized.sol#L45) is never initialized. It is used in:\n\t- [Test2.use()](tests/uninitialized.sol#L53-L56)\n",
+        "id": "427f100397f455d8000eff7b1d2463763ca8e452d5d98f7b7de693fd5e625a32",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"
@@ -459,6 +462,7 @@
         ],
         "description": "Test2.v (tests/uninitialized.sol#47) is never initialized. It is used in:\n\t- Test2.init() (tests/uninitialized.sol#49-51)\n",
         "markdown": "[Test2.v](tests/uninitialized.sol#L47) is never initialized. It is used in:\n\t- [Test2.init()](tests/uninitialized.sol#L49-L51)\n",
+        "id": "bf96eee949943a12926cf1407a2df2b07e99b30a6fc2e78aebf088cdefcf77a7",
         "check": "uninitialized-state",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/uninitialized_local_variable.uninitialized-local.json
+++ b/tests/expected_json/uninitialized_local_variable.uninitialized-local.json
@@ -79,6 +79,7 @@
         ],
         "description": "Uninitialized.func().uint_not_init (tests/uninitialized_local_variable.sol#4) is a local variable never initialiazed\n",
         "markdown": "[Uninitialized.func().uint_not_init](tests/uninitialized_local_variable.sol#L4) is a local variable never initialiazed\n",
+        "id": "8cb0b6b473ffecf3c2284584eb0012c742d36709f75c7516c3ba9748f3c27a98",
         "check": "uninitialized-local",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.json
+++ b/tests/expected_json/uninitialized_storage_pointer.uninitialized-storage.json
@@ -85,6 +85,7 @@
         ],
         "description": "Uninitialized.func().st_bug (tests/uninitialized_storage_pointer.sol#10) is a storage variable never initialiazed\n",
         "markdown": "[Uninitialized.func().st_bug](tests/uninitialized_storage_pointer.sol#L10) is a storage variable never initialiazed\n",
+        "id": "af9ceb591701024a2199a04e66a121086d330d4cdeb3b160514cce2bb440579f",
         "check": "uninitialized-storage",
         "impact": "High",
         "confidence": "High"

--- a/tests/expected_json/unused_return.unused-return.json
+++ b/tests/expected_json/unused_return.unused-return.json
@@ -164,6 +164,7 @@
         ],
         "description": "User.test(Target) (tests/unused_return.sol#17-29) ignores return value by t.f() (tests/unused_return.sol#18)\n",
         "markdown": "[User.test(Target)](tests/unused_return.sol#L17-L29) ignores return value by [t.f()](tests/unused_return.sol#L18)\n",
+        "id": "69f2810e24dbba754b406ce8b47e37543e9e491c0aa60d4dd2198c960e82b096",
         "check": "unused-return",
         "impact": "Medium",
         "confidence": "Medium"
@@ -329,6 +330,7 @@
         ],
         "description": "User.test(Target) (tests/unused_return.sol#17-29) ignores return value by a.add(0) (tests/unused_return.sol#22)\n",
         "markdown": "[User.test(Target)](tests/unused_return.sol#L17-L29) ignores return value by [a.add(0)](tests/unused_return.sol#L22)\n",
+        "id": "502f40d2e259e5e0268547489b716077dff7ce3df82fb05eb76ccb5ffa38f72b",
         "check": "unused-return",
         "impact": "Medium",
         "confidence": "Medium"

--- a/tests/expected_json/unused_state.unused-state.json
+++ b/tests/expected_json/unused_state.unused-state.json
@@ -75,6 +75,7 @@
         ],
         "description": "A.unused (tests/unused_state.sol#4) is never used in B (tests/unused_state.sol#11-16)\n",
         "markdown": "[A.unused](tests/unused_state.sol#L4) is never used in [B](tests/unused_state.sol#L11-L16)\n",
+        "id": "195279490862ae355bac3d27d0cdb1aa18200a5daed8f3dbd84dc5b120e29482",
         "check": "unused-state",
         "impact": "Informational",
         "confidence": "High"
@@ -151,6 +152,7 @@
         ],
         "description": "A.unused2 (tests/unused_state.sol#5) is never used in B (tests/unused_state.sol#11-16)\n",
         "markdown": "[A.unused2](tests/unused_state.sol#L5) is never used in [B](tests/unused_state.sol#L11-L16)\n",
+        "id": "886250d01813743573f3d311b742e0f818e0012ccbf8ad97738c029fd129d870",
         "check": "unused-state",
         "impact": "Informational",
         "confidence": "High"
@@ -227,6 +229,7 @@
         ],
         "description": "A.unused3 (tests/unused_state.sol#6) is never used in B (tests/unused_state.sol#11-16)\n",
         "markdown": "[A.unused3](tests/unused_state.sol#L6) is never used in [B](tests/unused_state.sol#L11-L16)\n",
+        "id": "e2ac51590509d97ff791ce50d9a711fc5ad01c20d23eacf6fb31939bd91b9f48",
         "check": "unused-state",
         "impact": "Informational",
         "confidence": "High"
@@ -303,6 +306,7 @@
         ],
         "description": "A.unused4 (tests/unused_state.sol#7) is never used in B (tests/unused_state.sol#11-16)\n",
         "markdown": "[A.unused4](tests/unused_state.sol#L7) is never used in [B](tests/unused_state.sol#L11-L16)\n",
+        "id": "562d3e6a04f6f6068c3e4f0c074ecdbcff87929e43ec6fbeb6c088e715f63cf2",
         "check": "unused-state",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/void-cst.void-cst.json
+++ b/tests/expected_json/void-cst.void-cst.json
@@ -122,6 +122,7 @@
         ],
         "description": "Void constructor called in D.constructor() (tests/void-cst.sol#10-12):\n\t- C() (tests/void-cst.sol#10)\n",
         "markdown": "Void constructor called in [D.constructor()](tests/void-cst.sol#L10-L12):\n\t- [C()](tests/void-cst.sol#L10)\n",
+        "id": "2d4e0ed4dc3c0871d43c6de59147f2bc48b0b2591237bfca8cdc3576388fce5a",
         "check": "void-cst",
         "impact": "Low",
         "confidence": "High"


### PR DESCRIPTION
Add a unique ID per finding.

The ID is based on the finding's description. It is not sensible to the contract/function/variable source mapping. The ID is sensible to the node/expression source mapping (otherwise we risk collisions).

If we end up supporting contracts with similar names, the ID schema will need to be changed, otherwise, we risk collisions.

Replace https://github.com/crytic/slither/pull/335