### PR TITLE
--filter-paths option now handles regex and relative paths

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -4,6 +4,7 @@
 import os
 import logging
 import json
+import re
 from slither.core.context.context import Context
 from slither.slithir.operations import InternalCall
 from slither.utils.colors import red
@@ -204,6 +205,12 @@ class Slither(Context):
     ###################################################################################
     ###################################################################################
 
+    def relative_path_format(self, path):
+        """
+           Strip relative paths of "." and ".."
+        """
+        return path.split('..')[-1].strip('.').strip('/')
+
     def valid_result(self, r):
         '''
             Check if the result is valid
@@ -212,12 +219,18 @@ class Slither(Context):
                 - Or a similar result was reported and saved during a previous run
                 - The --exclude-dependencies flag is set and results are only related to dependencies
         '''
-        source_mapping_elements = [elem['source_mapping']['filename_absolute'] for elem in r['elements'] if 'source_mapping' in elem]
-        if r['elements'] and all((any(path in src_mapping for path in self._paths_to_filter) for src_mapping in source_mapping_elements)):
+        source_mapping_elements = [elem['source_mapping']['filename_absolute']
+                                   for elem in r['elements'] if 'source_mapping' in elem]
+        source_mapping_elements = map(lambda x: os.path.normpath(x) if x else x, source_mapping_elements)
+        matching = all(
+            any(bool(re.search(self.relative_path_format(path), src_mapping)) for path in self._paths_to_filter)
+            for src_mapping in source_mapping_elements
+        )
+
+        if r['elements'] and matching:
             return False
         if r['elements'] and self._exclude_dependencies:
             return not all(element['source_mapping']['is_dependency'] for element in r['elements'])
-
         if r['id'] in self._previous_results_ids:
             return False
         # Conserve previous result filtering. This is conserved for compatibility, but is meant to be removed


### PR DESCRIPTION
I convert each element in source_mapping_elements with normpath() (collapses redundant separators and up-level references)

Now using regular expression search to see if pattern matches the src_mapping. Each pattern is run through method that handles relative paths.

I also broke up list comprehensions to multiple lines for readability 