### PR TITLE
Pragma: detect if the directive is a solidity version

### DIFF
--- a/slither/core/declarations/pragma_directive.py
+++ b/slither/core/declarations/pragma_directive.py
@@ -21,5 +21,11 @@ class Pragma(SourceMapping):
     def name(self):
         return self.version
 
+    @property
+    def is_solidity_version(self):
+        if len(self._directive) > 0:
+            return self._directive[0].lower() == 'solidity'
+        return False
+
     def __str__(self):
         return 'pragma '+''.join(self.directive)

--- a/slither/detectors/attributes/constant_pragma.py
+++ b/slither/detectors/attributes/constant_pragma.py
@@ -26,7 +26,7 @@ class ConstantPragma(AbstractDetector):
     def _detect(self):
         results = []
         pragma = self.slither.pragma_directives
-        versions = [p.version for p in pragma]
+        versions = [p.version for p in pragma if p.is_solidity_version]
         versions = sorted(list(set(versions)))
 
         if len(versions) > 1:


### PR DESCRIPTION
This PR improves the handling of the pragma directive

- Add `is_solidity_version` property to Pragma object
- Filter constant pragma detector to solidity version only (fix #382)