### PR TITLE
Fix get_dependencies

### DIFF
--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -114,8 +114,8 @@ def get_dependencies(variable, context, only_unprotected=False):
     assert isinstance(context, (Contract, Function))
     assert isinstance(only_unprotected, bool)
     if only_unprotected:
-        return context.context[KEY_NON_SSA].get(variable, [])
-    return context.context[KEY_NON_SSA_UNPROTECTED].get(variable, [])
+        return context.context[KEY_NON_SSA_UNPROTECTED].get(variable, [])
+    return context.context[KEY_NON_SSA].get(variable, [])
 
 # endregion
 ###################################################################################


### PR DESCRIPTION
`get_dependencies` incorrect used `only_unprotected`.

At first glance, this only affected the data dependency printer, and should not have impacted detectors

Fix #399