### PR TITLE
[WIP] Improve support for codebase with names' reuse

### DIFF
--- a/slither/all_exceptions.py
+++ b/slither/all_exceptions.py
@@ -2,6 +2,6 @@
 This module import all slither exceptions
 """
 from slither.slithir.exceptions import SlithIRError
-from slither.solc_parsing.exceptions import ParsingError, ParsingContractNotFound, ParsingNameReuse, VariableNotFound
+from slither.solc_parsing.exceptions import ParsingError, VariableNotFound
 from slither.core.exceptions import SlitherCoreError
 from slither.exceptions import SlitherException

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -50,6 +50,8 @@ class Contract(ChildSlither, SourceMapping):
 
         self._initial_state_variables = [] # ssa
 
+        self._is_incorrectly_parsed = False
+
     ###################################################################################
     ###################################################################################
     # region General's properties
@@ -873,6 +875,21 @@ class Contract(ChildSlither, SourceMapping):
                                     self._is_upgradeable_proxy = True
                                     return self._is_upgradeable_proxy
         return self._is_upgradeable_proxy
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Internals
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def is_incorrectly_constructed(self):
+        """
+        Return true if there was an internal Slither's issue when analyzing the contract
+        :return:
+        """
+        return self._is_incorrectly_parsed
 
     # endregion
     ###################################################################################

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -5,6 +5,8 @@ import os
 import logging
 import json
 import re
+from collections import defaultdict
+
 from slither.core.context.context import Context
 from slither.slithir.operations import InternalCall
 from slither.utils.colors import red
@@ -42,6 +44,9 @@ class Slither(Context):
         self._exclude_dependencies = False
 
         self._markdown_root = ""
+
+        self._contract_name_collisions = defaultdict(list)
+        self._contract_with_missing_inheritance = set()
 
     ###################################################################################
     ###################################################################################
@@ -300,4 +305,19 @@ class Slither(Context):
     def generate_patches(self, p):
         self._generate_patches = p
 
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Internals
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def contract_name_collisions(self):
+        return self._contract_name_collisions
+
+    @property
+    def contracts_with_missing_inheritance(self):
+        return self._contract_with_missing_inheritance
     # endregion

--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -44,5 +44,6 @@ from .statements.type_based_tautology import TypeBasedTautology
 from .statements.boolean_constant_equality import BooleanEquality
 from .statements.boolean_constant_misuse import BooleanConstantMisuse
 from .statements.divide_before_multiply import DivideBeforeMultiply
+from .slither.name_reused import NameReused
 #
 #

--- a/slither/detectors/slither/name_reused.py
+++ b/slither/detectors/slither/name_reused.py
@@ -1,0 +1,75 @@
+from collections import defaultdict
+
+from slither.detectors.abstract_detector import (AbstractDetector,
+                                                 DetectorClassification)
+
+
+def _find_missing_inheritance(slither):
+    missings = slither.contracts_with_missing_inheritance
+
+    ret = []
+    for b in missings:
+        is_most_base = True
+        for inheritance in b.immediate_inheritance:
+            if inheritance in missings:
+                is_most_base = False
+        if is_most_base:
+            ret.append(b)
+
+    return ret
+
+
+class NameReused(AbstractDetector):
+    ARGUMENT = 'name-reused'
+    HELP = "Contract's name reused"
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = 'https://github.com/crytic/slither/wiki/Detector-Documentation#name-reused'
+
+    WIKI_TITLE = 'Name reused'
+    WIKI_DESCRIPTION = 'todo'
+    WIKI_EXPLOIT_SCENARIO = 'todo'
+    WIKI_RECOMMENDATION = 'Rename the contract.'
+
+    def _detect(self):
+        results = []
+
+        names_reused = self.slither.contract_name_collisions
+
+        incorrectly_constructed = [contract for contract in self.contracts
+                                   if contract.is_incorrectly_constructed]
+
+        inheritance_corrupted = defaultdict(list)
+        for contract in incorrectly_constructed:
+            for father in contract.inheritance:
+                inheritance_corrupted[father.name].append(contract)
+
+        for contract_name, files in names_reused.items():
+            info = [contract_name, ' is re-used:\n']
+            for file in files:
+                if file is None:
+                    info += ['\t- In an file not found, most likely in\n']
+                else:
+                    info += ['\t- ', file, '\n']
+
+            if contract_name in inheritance_corrupted:
+                info += ['\tAs a result, the inherited contracts are not correctly analyzed:\n']
+            for corrupted in inheritance_corrupted[contract_name]:
+                info += ["\t\t- ", corrupted, '\n']
+            res = self.generate_result(info)
+            results.append(res)
+
+        most_base_with_missing_inheritance = _find_missing_inheritance(self.slither)
+
+        for b in most_base_with_missing_inheritance:
+            info = [b, ' inherits from a contract for which the name is reused.\n',
+                    'Slither could not determine the contract, but it is either:\n']
+            for inheritance in b.immediate_inheritance:
+                info += ['\t-', inheritance, '\n']
+            info += [b, ' and all the contracts inheriting from it are not correctly analyzed:\n']
+            for derived in b.derived_contracts:
+                info += ['\t-', derived, '\n']
+            res = self.generate_result(info)
+            results.append(res)
+        return results

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -10,6 +10,7 @@ from crytic_compile import CryticCompile, InvalidCompilation
 
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from slither.printers.abstract_printer import AbstractPrinter
+from .solc_parsing.exceptions import VariableNotFound
 from .solc_parsing.slitherSolc import SlitherSolc
 from .exceptions import SlitherError
 
@@ -83,6 +84,7 @@ class Slither(SlitherSolc):
         self._triage_mode = triage_mode
 
         self._analyze_contracts()
+
 
     def _init_from_raw_json(self, filename):
         if not os.path.isfile(filename):

--- a/slither/solc_parsing/exceptions.py
+++ b/slither/solc_parsing/exceptions.py
@@ -2,8 +2,4 @@ from slither.exceptions import SlitherException
 
 class ParsingError(SlitherException): pass
 
-class ParsingNameReuse(SlitherException): pass
-
-class ParsingContractNotFound(SlitherException): pass
-
 class VariableNotFound(SlitherException): pass


### PR DESCRIPTION
Breaking change in the way Slither deals with codebase containing contracts with duplicate names:
- Add NameReused detector to report the name's reuse
- Slither will analyze the codebase that contains the issue, with partial context. As a result, the analysis might not be correct

Fix https://github.com/crytic/slither/issues/344