### PR TITLE
Fix constructor call if no constructor exist

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -672,6 +672,14 @@ def extract_tmp_call(ins, contract):
         # Called a base constructor, where there is no constructor
         if ins.called.constructor is None:
             return Nop()
+        # Case where:
+        # contract A{ constructor(uint) }
+        # contract B is A {}
+        # contract C is B{ constructor() A(10) B() {}
+        # C calls B(), which does not exist
+        # Ideally we should compare here for the parameters types too
+        if len(ins.called.constructor.parameters) != ins.nbr_arguments:
+            return Nop()
         internalcall = InternalCall(ins.called.constructor, ins.nbr_arguments, ins.lvalue,
                                     ins.type_call)
         internalcall.call_id = ins.call_id

--- a/slither/solc_parsing/cfg/node.py
+++ b/slither/solc_parsing/cfg/node.py
@@ -65,5 +65,4 @@ class NodeSolc(Node):
             self._expression_calls = pp.result()
             self._external_calls_as_expressions = [c for c in self.calls_as_expression if not isinstance(c.called, Identifier)]
             self._internal_calls_as_expressions = [c for c in self.calls_as_expression if isinstance(c.called, Identifier)]
-            
 


### PR DESCRIPTION
This PR fixes when this happens:
```
contract A{ constructor(uint) }
contract B is A {}
contract C is B{ constructor() A(10) B() {}
```
`C` calls `B()`, which does not exist. Slither incorrectly took `A.constructor` as the call's target.

This is a quick fix, a long term solution would be to check for the constructor's signature. Unfortunately, this information is not yet created when the conversion is done; the correct fix will require more work.