### PR TITLE
Fix incorrect parsing of abi.decode

### DIFF
--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -312,8 +312,10 @@ def _parse_elementary_type_name_expression(expression, is_compact_ast, caller_co
     else:
         assert 'children' not in expression
         value = expression['attributes']['value']
-    t = parse_type(UnknownType(value), caller_context)
-
+    if isinstance(value, dict):
+        t = parse_type(value, caller_context)
+    else:
+        t = parse_type(UnknownType(value), caller_context)
     e = ElementaryTypeNameExpression(t)
     e.set_offset(expression['src'], caller_context.slither)
     return e


### PR DESCRIPTION
Example
```solidity
contract C{

    function f(bytes memory data) public{
        abi.decode(data, (address));
    }

}
```