### PR TITLE
Improve support of codebase with contract's name reused

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1383,7 +1383,8 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
         compute_dominators(self.nodes)
         compute_dominance_frontier(self.nodes)
         transform_slithir_vars_to_ssa(self)
-        add_ssa_ir(self, all_ssa_state_variables_instances)
+        if not self.contract.is_incorrectly_constructed:
+            add_ssa_ir(self, all_ssa_state_variables_instances)
 
     def update_read_write_using_ssa(self):
         for node in self.nodes:

--- a/slither/detectors/slither/name_reused.py
+++ b/slither/detectors/slither/name_reused.py
@@ -79,10 +79,12 @@ As a result, the second contract cannot be analyzed.
         for b in most_base_with_missing_inheritance:
             info = [b, ' inherits from a contract for which the name is reused.\n']
             if b.inheritance:
-                info += ['\t- Slither could not determine which contract has a duplicate name, but it is NOT:\n']
+                info += ['\t- Slither could not determine which contract has a duplicate name:\n']
                 for inheritance in b.inheritance:
                     info += ['\t\t-', inheritance, '\n']
-                info += ['\t- Check the inheritance tree to find which contract is missing from this list.\n']
+                info += ['\t- Check if:\n']
+                info += ['\t\t- A inherited contract is missing from this list,\n']
+                info += ['\t\t- The contract are imported from the correct files.\n']
             if b.derived_contracts:
                 info += [f'\t- This issue impacts the contracts inheriting from {b.name}:\n']
                 for derived in b.derived_contracts:

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -273,7 +273,8 @@ class ContractSolc04(Contract):
     ###################################################################################
     ###################################################################################
 
-    def log_incorrect_parsing(self):
+    def log_incorrect_parsing(self, error):
+        logger.error(error)
         self._is_incorrectly_parsed = True
 
     def analyze_content_modifiers(self):
@@ -281,8 +282,7 @@ class ContractSolc04(Contract):
             for modifier in self.modifiers:
                 modifier.analyze_content()
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing modifier {e}')
         return
 
     def analyze_content_functions(self):
@@ -290,8 +290,7 @@ class ContractSolc04(Contract):
             for function in self.functions:
                 function.analyze_content()
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing function {e}')
         return
 
     def analyze_params_modifiers(self):
@@ -303,8 +302,7 @@ class ContractSolc04(Contract):
             Cls = ModifierSolc
             self._modifiers = self._analyze_params_elements(elements_no_params, getter, getter_available, Cls)
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing params {e}')
         self._modifiers_no_params = []
 
         return
@@ -317,8 +315,7 @@ class ContractSolc04(Contract):
             Cls = FunctionSolc
             self._functions = self._analyze_params_elements(elements_no_params, getter, getter_available, Cls)
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing params {e}')
         self._functions_no_params = []
         return
 
@@ -369,8 +366,7 @@ class ContractSolc04(Contract):
                     element.is_shadowed = True
                     accessible_elements[element.full_name].shadows = True
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing params {e}')
         return all_elements
 
     def analyze_constant_state_variables(self):
@@ -458,8 +454,7 @@ class ContractSolc04(Contract):
                 var.analyze(self)
             return
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing state variable {e}')
 
     def analyze_using_for(self):
         try:
@@ -491,8 +486,7 @@ class ContractSolc04(Contract):
                     self._using_for[old].append(new)
             self._usingForNotParsed = []
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing using for {e}')
 
     def analyze_enums(self):
         try:
@@ -505,8 +499,7 @@ class ContractSolc04(Contract):
                 self._analyze_enum(enum)
             self._enumsNotParsed = None
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing enum {e}')
 
     def _analyze_enum(self, enum):
         # Enum can be parsed in one pass
@@ -540,8 +533,7 @@ class ContractSolc04(Contract):
             for struct in self.structures:
                 self._analyze_struct(struct)
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing struct {e}')
 
     def analyze_events(self):
         try:
@@ -555,8 +547,7 @@ class ContractSolc04(Contract):
                 event.set_offset(event_to_parse['src'], self.slither)
                 self._events[event.full_name] = event
         except (VariableNotFound, KeyError) as e:
-            logger.error(e)
-            self.log_incorrect_parsing()
+            self.log_incorrect_parsing(f'Missing event {e}')
 
         self._eventsNotParsed = None
 

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -227,7 +227,7 @@ class SlitherSolc(Slither):
 
             if missing_inheritance:
                 self._contract_with_missing_inheritance.add(contract)
-                contract.log_incorrect_parsing()
+                contract.log_incorrect_parsing(f'Missing inheritance {contract}')
                 contract.set_is_analyzed(True)
                 contract.delete_content()
 


### PR DESCRIPTION
In some cases, the contract is found but incorrect.

This PRs stops the IR generation in this situation, to prevent crashes during the IR analyses.