### PR TITLE
Add suport for new call syntax: {gas: X, value: Y}

### DIFF
--- a/slither/core/expressions/call_expression.py
+++ b/slither/core/expressions/call_expression.py
@@ -44,4 +44,14 @@ class CallExpression(Expression):
         return self._type_call
 
     def __str__(self):
-        return str(self._called) + '(' + ','.join([str(a) for a in self._arguments]) + ')'
+        txt = str(self._called)
+        if self.call_gas or self.call_value:
+            gas = f'gas: {self.call_gas}' if self.call_gas else ''
+            value = f'value: {self.call_value}' if self.call_value else ''
+            if gas and value:
+                txt += '{' + f'{gas}, {value}' + '}'
+            elif gas:
+                txt += '{' + f'{gas}' + '}'
+            else:
+                txt += '{' + f'{value}' + '}'
+        return txt + '(' + ','.join([str(a) for a in self._arguments]) + ')'

--- a/slither/core/expressions/call_expression.py
+++ b/slither/core/expressions/call_expression.py
@@ -1,5 +1,6 @@
 from slither.core.expressions.expression import Expression
 
+
 class CallExpression(Expression):
 
     def __init__(self, called, arguments, type_call):
@@ -8,6 +9,27 @@ class CallExpression(Expression):
         self._called = called
         self._arguments = arguments
         self._type_call = type_call
+        # gas and value are only available if the syntax is {gas: , value: }
+        # For the .gas().value(), the member are considered as function call
+        # And converted later to the correct info (convert.py)
+        self._gas = None
+        self._value = None
+
+    @property
+    def call_value(self):
+        return self._value
+
+    @call_value.setter
+    def call_value(self, v):
+        self._value = v
+
+    @property
+    def call_gas(self):
+        return self._gas
+
+    @call_gas.setter
+    def call_gas(self, gas):
+        self._gas = gas
 
     @property
     def called(self):
@@ -23,4 +45,3 @@ class CallExpression(Expression):
 
     def __str__(self):
         return str(self._called) + '(' + ','.join([str(a) for a in self._arguments]) + ')'
-

--- a/slither/core/expressions/member_access.py
+++ b/slither/core/expressions/member_access.py
@@ -1,11 +1,11 @@
 from slither.core.expressions.expression import Expression
 from slither.core.expressions.expression_typed import ExpressionTyped
-from slither.core.solidity_types.type import Type
+
 
 class MemberAccess(ExpressionTyped):
 
     def __init__(self, member_name, member_type, expression):
-        #assert isinstance(member_type, Type)
+        # assert isinstance(member_type, Type)
         # TODO member_type is not always a Type
         assert isinstance(expression, Expression)
         super(MemberAccess, self).__init__()
@@ -27,4 +27,3 @@ class MemberAccess(ExpressionTyped):
 
     def __str__(self):
         return str(self.expression) + '.' + self.member_name
-

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -620,7 +620,13 @@ def extract_tmp_call(ins, contract):
         msgcall = HighLevelCall(ins.ori.variable_left, ins.ori.variable_right, ins.nbr_arguments, ins.lvalue,
                                 ins.type_call)
         msgcall.call_id = ins.call_id
+
+        if ins.call_gas:
+            msgcall.call_gas = ins.call_gas
+        if ins.call_value:
+            msgcall.call_value = ins.call_value
         msgcall.set_expression(ins.expression)
+
         return msgcall
 
     if isinstance(ins.ori, TmpCall):

--- a/slither/slithir/operations/member.py
+++ b/slither/slithir/operations/member.py
@@ -16,6 +16,9 @@ class Member(OperationWithLValue):
         self._variable_left = variable_left
         self._variable_right = variable_right
         self._lvalue = result
+        self._gas = None
+        self._value = None
+
 
     @property
     def read(self):
@@ -28,6 +31,22 @@ class Member(OperationWithLValue):
     @property
     def variable_right(self):
         return self._variable_right
+
+    @property
+    def call_value(self):
+        return self._value
+
+    @call_value.setter
+    def call_value(self, v):
+        self._value = v
+
+    @property
+    def call_gas(self):
+        return self._gas
+
+    @call_gas.setter
+    def call_gas(self, gas):
+        self._gas = gas
 
     def __str__(self):
         return '{}({}) -> {}.{}'.format(self.lvalue, self.lvalue.type, self.variable_left, self.variable_right)

--- a/slither/slithir/tmp_operations/tmp_call.py
+++ b/slither/slithir/tmp_operations/tmp_call.py
@@ -19,6 +19,24 @@ class TmpCall(OperationWithLValue):
         self._lvalue = result
         self._ori = None # 
         self._callid = None
+        self._gas = None
+        self._value = None
+
+    @property
+    def call_value(self):
+        return self._value
+
+    @call_value.setter
+    def call_value(self, v):
+        self._value = v
+
+    @property
+    def call_gas(self):
+        return self._gas
+
+    @call_gas.setter
+    def call_gas(self, gas):
+        self._gas = gas
 
     @property
     def call_id(self):
@@ -35,10 +53,6 @@ class TmpCall(OperationWithLValue):
     @property
     def called(self):
         return self._called
-
-    @property
-    def read(self):
-        return [self.called]
 
     @called.setter
     def called(self, c):

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -2,8 +2,7 @@ import logging
 
 from slither.core.cfg.node import NodeType
 from slither.core.declarations import (Contract, Enum, Function,
-                                       SolidityFunction, SolidityVariable,
-                                       SolidityVariableComposed, Structure)
+                                       SolidityFunction, SolidityVariable, Structure)
 from slither.core.solidity_types.type import Type
 from slither.core.variables.local_variable import LocalVariable
 from slither.core.variables.state_variable import StateVariable

--- a/slither/visitors/expression/expression.py
+++ b/slither/visitors/expression/expression.py
@@ -107,6 +107,10 @@ class ExpressionVisitor:
         for arg in expression.arguments:
             if arg:
                 self._visit_expression(arg)
+        if expression.call_value:
+            self._visit_expression(expression.call_value)
+        if expression.call_gas:
+            self._visit_expression(expression.call_gas)
 
     def _visit_conditional_expression(self, expression):
         self._visit_expression(expression.if_expression)

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -150,6 +150,14 @@ class ExpressionToSlithIR(ExpressionVisitor):
 
             message_call = TmpCall(called, len(args), val, expression.type_call)
             message_call.set_expression(expression)
+            # Gas/value are only accessible here if the syntax {gas: , value: }
+            # Is used over .gas().value()
+            if expression.call_gas:
+                call_gas = get(expression.call_gas)
+                message_call.call_gas = call_gas
+            if expression.call_value:
+                call_value = get(expression.call_value)
+                message_call.call_value = call_value
             self._result.append(message_call)
             set_val(expression, val)
 


### PR DESCRIPTION
For example:
```solidity
contract C {
    function g(uint) external payable {}
    function f(uint a) public payable {
        this.g{value: 42, gas: 23+a}(10);
    }
}
```
Generate now:
```
		Expression: this.g{gas: 23 + a, value: 42}(10)
		IRs:
			TMP_0(uint256) = 23 + a
			HIGH_LEVEL_CALL, dest:this(address), function:g, arguments:['10'] value:42 gas:TMP_0
```

Fix #419