### PR TITLE
Refactor reentrancy detectors

### DIFF
--- a/scripts/tests_generate_expected_json_5.sh
+++ b/scripts/tests_generate_expected_json_5.sh
@@ -21,7 +21,7 @@ generate_expected_json(){
 }
 
 #generate_expected_json tests/void-cst.sol "void-cst"
-generate_expected_json tests/solc_version_incorrect_05.ast.json "solc-version"
+#generate_expected_json tests/solc_version_incorrect_05.ast.json "solc-version"
 #generate_expected_json tests/uninitialized-0.5.1.sol "uninitialized-state"
 #generate_expected_json tests/backdoor.sol "backdoor"
 #generate_expected_json tests/backdoor.sol "suicidal"

--- a/slither/detectors/reentrancy/reentrancy.py
+++ b/slither/detectors/reentrancy/reentrancy.py
@@ -4,12 +4,14 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
+from typing import Set, Dict
 
-from slither.core.cfg.node import NodeType
+from slither.core.cfg.node import NodeType, Node
 from slither.core.declarations import Function
 from slither.core.expressions import UnaryOperation, UnaryOperationType
+from slither.core.variables.variable import Variable
 from slither.detectors.abstract_detector import AbstractDetector
-from slither.slithir.operations import Call, EventCall
+from slither.slithir.operations import Call, EventCall, Operation
 
 
 def union_dict(d1, d2):
@@ -23,10 +25,135 @@ def dict_are_equal(d1, d2):
     return all(set(d1[k]) == set(d2[k]) for k in d1.keys())
 
 
+
+class AbstractState:
+    KEY = 'REENTRANCY'
+
+    def __init__(self):
+        # send_eth returns the list of calls sending value
+        # calls returns the list of calls that can callback
+        # read returns the variable read
+        # read_prior_calls returns the variable read prior a call
+        self._send_eth: Set[Call] = set()
+        self._calls: Set[Call] = set()
+        self._reads: Set[Variable] = set()
+        self._reads_prior_calls: Dict[Node, Set[Variable]] = dict()
+        self._events: Set[EventCall] = set()
+        self._written: Set[Variable] = set()
+
+    @property
+    def send_eth(self) -> Set[Call]:
+        """
+        Return the list of calls sending value
+        :return:
+        """
+        return self._send_eth
+
+    @property
+    def calls(self) -> Set[Call]:
+        """
+        Return the list of calls that can callback
+        :return:
+        """
+        return self._calls
+
+    @property
+    def reads(self) -> Set[Variable]:
+        """
+        Return of variables that are read
+        :return:
+        """
+        return self._reads
+
+    @property
+    def written(self) -> Set[Variable]:
+        """
+        Return of variables that are written
+        :return:
+        """
+        return self._written
+
+    @property
+    def reads_prior_calls(self) -> Dict[Node, Set[Variable]]:
+        """
+        Return the dictionary node -> variables read before any call
+        :return:
+        """
+        return self._reads_prior_calls
+
+    @property
+    def events(self) -> Set[EventCall]:
+        """
+        Return the list of events
+        :return:
+        """
+        return self._events
+
+    def merge_fathers(self, node, skip_father):
+        for father in node.fathers:
+            if self.KEY in father.context:
+                self._send_eth |= set([s for s in father.context[self.KEY].send_eth if s != skip_father])
+                self._calls |= set([c for c in father.context[self.KEY].calls if c != skip_father])
+                self._reads |= set(father.context[self.KEY].reads)
+                self._reads_prior_calls = union_dict(self.reads_prior_calls,
+                                                     father.context[self.KEY].reads_prior_calls)
+
+    def analyze_node(self, node, detector):
+        state_vars_read = set(node.state_variables_read)
+
+        # All the state variables written
+        state_vars_written = set(node.state_variables_written)
+        slithir_operations = []
+        # Add the state variables written in internal calls
+        for internal_call in node.internal_calls:
+            # Filter to Function, as internal_call can be a solidity call
+            if isinstance(internal_call, Function):
+                state_vars_written |= set(internal_call.all_state_variables_written())
+                state_vars_read |= set(internal_call.all_state_variables_read())
+                slithir_operations += internal_call.all_slithir_operations()
+
+        contains_call = False
+
+        self._written = set(state_vars_written)
+        if detector._can_callback(node.irs + slithir_operations):
+            self._calls |= {node}
+            self._reads_prior_calls[node] = set(self._reads_prior_calls.get(node, set()) |
+                                                node.context[self.KEY].reads |
+                                                state_vars_read)
+            contains_call = True
+        if detector._can_send_eth(node.irs + slithir_operations):
+            self._send_eth |= {node}
+
+        self._reads |= state_vars_read
+
+        self._events = set([ir for ir in node.irs if isinstance(ir, EventCall)])
+
+        return contains_call
+
+    def add(self, fathers):
+        self._send_eth |= fathers.send_eth
+        self._calls |= fathers.calls
+        self._reads |= fathers.reads
+        self._reads_prior_calls = union_dict(self._reads_prior_calls, fathers.reads_prior_calls)
+
+def does_not_bring_new_info(new_info: AbstractState, old_info: AbstractState) -> bool:
+    if new_info.calls.issubset(old_info.calls):
+        if new_info.send_eth.issubset(old_info.send_eth):
+            if new_info.reads.issubset(old_info.reads):
+                if dict_are_equal(new_info.reads_prior_calls,
+                                  old_info.reads_prior_calls):
+                    return True
+    return False
+
+
 class Reentrancy(AbstractDetector):
     KEY = 'REENTRANCY'
 
-    def _can_callback(self, irs):
+    # can_callback and can_send_eth are static method
+    # allowing inherited classes to define different behaviors
+    # For example reentrancy_no_gas consider Send and Transfer as reentrant functions
+    @staticmethod
+    def _can_callback(irs):
         """
             Detect if the node contains a call that can
             be used to re-entrance
@@ -63,8 +190,7 @@ class Reentrancy(AbstractDetector):
 
             This will work only on naive implementation
         """
-        return isinstance(node.expression, UnaryOperation) \
-               and node.expression.type == UnaryOperationType.BANG
+        return isinstance(node.expression, UnaryOperation) and node.expression.type == UnaryOperationType.BANG
 
     def _explore(self, node, visited, skip_father=None):
         """
@@ -87,64 +213,69 @@ class Reentrancy(AbstractDetector):
         # calls returns the list of calls that can callback
         # read returns the variable read
         # read_prior_calls returns the variable read prior a call
-        fathers_context = {'send_eth': set(), 'calls': set(), 'read': set(), 'read_prior_calls': {}}
+        fathers_context = AbstractState() #{'send_eth': set(), 'calls': set(), 'read': set(), 'read_prior_calls': {}}
 
-        for father in node.fathers:
-            if self.KEY in father.context:
-                fathers_context['send_eth'] |= set(
-                    [s for s in father.context[self.KEY]['send_eth'] if s != skip_father])
-                fathers_context['calls'] |= set([c for c in father.context[self.KEY]['calls'] if c != skip_father])
-                fathers_context['read'] |= set(father.context[self.KEY]['read'])
-                fathers_context['read_prior_calls'] = union_dict(fathers_context['read_prior_calls'],
-                                                                 father.context[self.KEY]['read_prior_calls'])
+        fathers_context.merge_fathers(node, skip_father)
+        # for father in node.fathers:
+        #     if self.KEY in father.context:
+        #         fathers_context['send_eth'] |= set(
+        #             [s for s in father.context[self.KEY]['send_eth'] if s != skip_father])
+        #         fathers_context['calls'] |= set([c for c in father.context[self.KEY]['calls'] if c != skip_father])
+        #         fathers_context['read'] |= set(father.context[self.KEY]['read'])
+        #         fathers_context['read_prior_calls'] = union_dict(fathers_context['read_prior_calls'],
+        #                                                          father.context[self.KEY]['read_prior_calls'])
 
         # Exclude path that dont bring further information
         if node in self.visited_all_paths:
-            if fathers_context['calls'].issubset(self.visited_all_paths[node]['calls']):
-                if fathers_context['send_eth'].issubset(self.visited_all_paths[node]['send_eth']):
-                    if fathers_context['read'].issubset(self.visited_all_paths[node]['read']):
-                        if dict_are_equal(self.visited_all_paths[node]['read_prior_calls'],
-                                          fathers_context['read_prior_calls']):
-                            return
+            if does_not_bring_new_info(fathers_context, self.visited_all_paths[node]):
+                return
+        # if node in self.visited_all_paths:
+        #     if fathers_context['calls'].issubset(self.visited_all_paths[node]['calls']):
+        #         if fathers_context['send_eth'].issubset(self.visited_all_paths[node]['send_eth']):
+        #             if fathers_context['read'].issubset(self.visited_all_paths[node]['read']):
+        #                 if dict_are_equal(self.visited_all_paths[node]['read_prior_calls'],
+        #                                   fathers_context['read_prior_calls']):
+        #                     return
         else:
-            self.visited_all_paths[node] = {'send_eth': set(), 'calls': set(), 'read': set(),
-                                            'read_prior_calls': {}, 'events': set()}
+            self.visited_all_paths[node] = AbstractState()
+            # self.visited_all_paths[node] = {'send_eth': set(), 'calls': set(), 'read': set(),
+            #                                 'read_prior_calls': {}, 'events': set()}
 
-        self.visited_all_paths[node]['send_eth'] |= fathers_context['send_eth']
-        self.visited_all_paths[node]['calls'] |=  fathers_context['calls']
-        self.visited_all_paths[node]['read'] |= fathers_context['read']
-        self.visited_all_paths[node]['read_prior_calls'] = union_dict(self.visited_all_paths[node]['read_prior_calls'],
-                                                                      fathers_context['read_prior_calls'])
+
+        self.visited_all_paths[node].add(fathers_context)
 
         node.context[self.KEY] = fathers_context
 
-        state_vars_read = set(node.state_variables_read)
+        contains_call = fathers_context.analyze_node(node, self)
+        node.context[self.KEY] = fathers_context
 
-        # All the state variables written
-        state_vars_written = set(node.state_variables_written)
-        slithir_operations = []
-        # Add the state variables written in internal calls
-        for internal_call in node.internal_calls:
-            # Filter to Function, as internal_call can be a solidity call
-            if isinstance(internal_call, Function):
-                state_vars_written |= set(internal_call.all_state_variables_written())
-                state_vars_read |= set(internal_call.all_state_variables_read())
-                slithir_operations += internal_call.all_slithir_operations()
-
-        contains_call = False
-        node.context[self.KEY]['written'] = set(state_vars_written)
-        if self._can_callback(node.irs + slithir_operations):
-            node.context[self.KEY]['calls'] |= {node}
-            node.context[self.KEY]['read_prior_calls'][node] = set(
-                node.context[self.KEY]['read_prior_calls'].get(node, set()) | node.context[self.KEY][
-                    'read'] | state_vars_read)
-            contains_call = True
-        if self._can_send_eth(node.irs + slithir_operations):
-            node.context[self.KEY]['send_eth'] |= {node}
-
-        node.context[self.KEY]['read'] |= state_vars_read
-
-        node.context[self.KEY]['events'] = set([ir for ir in node.irs if isinstance(ir, EventCall)])
+        # state_vars_read = set(node.state_variables_read)
+        #
+        # # All the state variables written
+        # state_vars_written = set(node.state_variables_written)
+        # slithir_operations = []
+        # # Add the state variables written in internal calls
+        # for internal_call in node.internal_calls:
+        #     # Filter to Function, as internal_call can be a solidity call
+        #     if isinstance(internal_call, Function):
+        #         state_vars_written |= set(internal_call.all_state_variables_written())
+        #         state_vars_read |= set(internal_call.all_state_variables_read())
+        #         slithir_operations += internal_call.all_slithir_operations()
+        #
+        # contains_call = False
+        # node.context[self.KEY]['written'] = set(state_vars_written)
+        # if _can_callback(node.irs + slithir_operations):
+        #     node.context[self.KEY]['calls'] |= {node}
+        #     node.context[self.KEY]['read_prior_calls'][node] = set(
+        #         node.context[self.KEY]['read_prior_calls'].get(node, set()) | node.context[self.KEY][
+        #             'read'] | state_vars_read)
+        #     contains_call = True
+        # if _can_send_eth(node.irs + slithir_operations):
+        #     node.context[self.KEY]['send_eth'] |= {node}
+        #
+        # node.context[self.KEY]['read'] |= state_vars_read
+        #
+        # node.context[self.KEY]['events'] = set([ir for ir in node.irs if isinstance(ir, EventCall)])
 
         sons = node.sons
         if contains_call and node.type in [NodeType.IF, NodeType.IFLOOP]:

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -4,11 +4,15 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
+from collections import namedtuple, defaultdict
+from typing import List
 
 from slither.detectors.abstract_detector import DetectorClassification
+from .reentrancy import Reentrancy, to_hashable
 
+FindingKey = namedtuple('FindingKey', ['function', 'calls', 'send_eth'])
+FindingValue = namedtuple('FindingValue', ['variable', 'node', 'nodes'])
 
-from .reentrancy import Reentrancy
 
 class ReentrancyBenign(Reentrancy):
     ARGUMENT = 'reentrancy-benign'
@@ -39,32 +43,32 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
     STANDARD_JSON = False
 
     def find_reentrancies(self):
-        result = {}
+        result = defaultdict(set)
         for contract in self.contracts:
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
                     # dead code
-                    if not self.KEY in node.context:
+                    if self.KEY not in node.context:
                         continue
                     if node.context[self.KEY].calls:
-                        if not any(n!=node for n in node.context[self.KEY].calls):
+                        if not any(n != node for n in node.context[self.KEY].calls):
                             continue
                         read_then_written = []
                         for c in node.context[self.KEY].calls:
                             read_then_written += [v for v in node.context[self.KEY].written
-                                                 if v in node.context[self.KEY].reads_prior_calls[c]]
-                        not_read_then_written = [(v, node) for v in node.context[self.KEY].written
-                                                 if v not in read_then_written]
+                                                  if v in node.context[self.KEY].reads_prior_calls[c]]
+                        not_read_then_written = set([FindingValue(v,
+                                                                  node,
+                                                                  tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                                     for (v, nodes)
+                                                     in node.context[self.KEY].written.items()
+                                                     if v not in read_then_written])
                         if not_read_then_written:
-
                             # calls are ordered
-                            finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)),
-                                           tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x:x.node_id)))
-                            finding_vars = not_read_then_written
-                            if finding_key not in result:
-                                result[finding_key] = []
-                            result[finding_key] = list(set(result[finding_key] + finding_vars))
+                            finding_key = FindingKey(function=node.function,
+                                                     calls=to_hashable(node.context[self.KEY].calls),
+                                                     send_eth=to_hashable(node.context[self.KEY].send_eth))
+                            result[finding_key] |= not_read_then_written
         return result
 
     def _detect(self):
@@ -76,23 +80,34 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x:x[0][0].name)
+        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
+        varsWritten: List[FindingValue]
         for (func, calls, send_eth), varsWritten in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x.node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x.node_id)
+            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            varsWritten = sorted(varsWritten, key=lambda x: (x.variable.name, x.node.node_id))
+
             info = ['Reentrancy in ', func, ':\n']
 
             info += ['\tExternal calls:\n']
-            for call_info in calls:
-                info += ['\t- ' , call_info, '\n']
+            for (call_info, calls_list) in calls:
+                info += ['\t- ', call_info, '\n']
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        info += ['\t\t- ', call_list_info, '\n']
             if calls != send_eth and send_eth:
                 info += ['\tExternal calls sending eth:\n']
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     info += ['\t- ', call_info, '\n']
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            info += ['\t\t- ', call_list_info, '\n']
             info += ['\tState variables written after the call(s):\n']
-            for (v, node) in sorted(varsWritten, key=lambda x: (x[0].name, x[1].node_id)):
-                info += ['\t- ', v, ' in ', node, '\n']
-
+            for finding_value in varsWritten:
+                info += ['\t- ', finding_value.node, '\n']
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        info += ['\t\t- ', other_node, '\n']
 
             # Create our JSON result
             res = self.generate_result(info)
@@ -101,26 +116,42 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 res.add(call_info, {
                     "underlying_type": "external_calls"
                 })
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        res.add(call_list_info, {
+                            "underlying_type": "external_calls_sending_eth"
+                        })
 
             #
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for call_info in send_eth:
+                for (call_info, calls_list) in calls:
                     res.add(call_info, {
                         "underlying_type": "external_calls_sending_eth"
                     })
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            res.add(call_list_info, {
+                                "underlying_type": "external_calls_sending_eth"
+                            })
 
             # Add all variables written via nodes which write them.
-            for (v, node) in varsWritten:
-                res.add(node, {
+            for finding_value in varsWritten:
+                res.add(finding_value.node, {
                     "underlying_type": "variables_written",
-                    "variable_name": v.name
+                    "variable_name": finding_value.variable.name
                 })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "variables_written",
+                            "variable_name": finding_value.variable.name
+                        })
 
             # Append our result
             results.append(res)

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -46,21 +46,21 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
                     # dead code
                     if not self.KEY in node.context:
                         continue
-                    if node.context[self.KEY]['calls']:
-                        if not any(n!=node for n in node.context[self.KEY]['calls']):
+                    if node.context[self.KEY].calls:
+                        if not any(n!=node for n in node.context[self.KEY].calls):
                             continue
                         read_then_written = []
-                        for c in node.context[self.KEY]['calls']:
-                            read_then_written += [v for v in node.context[self.KEY]['written']
-                                                 if v in node.context[self.KEY]['read_prior_calls'][c]]
-                        not_read_then_written = [(v, node) for v in node.context[self.KEY]['written']
+                        for c in node.context[self.KEY].calls:
+                            read_then_written += [v for v in node.context[self.KEY].written
+                                                 if v in node.context[self.KEY].reads_prior_calls[c]]
+                        not_read_then_written = [(v, node) for v in node.context[self.KEY].written
                                                  if v not in read_then_written]
                         if not_read_then_written:
 
                             # calls are ordered
                             finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY]['calls']), key=lambda x:x.node_id)),
-                                           tuple(sorted(list(node.context[self.KEY]['send_eth']), key=lambda x:x.node_id)))
+                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)),
+                                           tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x:x.node_id)))
                             finding_vars = not_read_then_written
                             if finding_key not in result:
                                 result[finding_key] = []

--- a/slither/detectors/reentrancy/reentrancy_eth.py
+++ b/slither/detectors/reentrancy/reentrancy_eth.py
@@ -4,10 +4,16 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
+from collections import namedtuple, defaultdict
+from typing import List
+
 from slither.detectors.abstract_detector import DetectorClassification
+from .reentrancy import Reentrancy, to_hashable
+
+FindingKey = namedtuple('FindingKey', ['function', 'calls', 'send_eth'])
+FindingValue = namedtuple('FindingValue', ['variable', 'node', 'nodes'])
 
 
-from .reentrancy import Reentrancy
 class ReentrancyEth(Reentrancy):
     ARGUMENT = 'reentrancy-eth'
     HELP = 'Reentrancy vulnerabilities (theft of ethers)'
@@ -34,13 +40,12 @@ Do not report reentrancies that don't involve ethers (see `reentrancy-no-eth`)''
 
 Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw more than its initial deposit to the contract.'''
 
-
     WIKI_RECOMMENDATION = 'Apply the [check-effects-interactions pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy).'
 
     STANDARD_JSON = False
 
     def find_reentrancies(self):
-        result = {}
+        result = defaultdict(set)
         for contract in self.contracts:
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
@@ -48,24 +53,26 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
                     if not self.KEY in node.context:
                         continue
                     if node.context[self.KEY].calls and node.context[self.KEY].send_eth:
-                        if not any(n!=node for n in node.context[self.KEY].send_eth):
+                        if not any(n != node for n in node.context[self.KEY].send_eth):
                             continue
-                        read_then_written = []
+                        read_then_written = set()
                         for c in node.context[self.KEY].calls:
                             if c == node:
                                 continue
-                            read_then_written += [(v, node) for v in node.context[self.KEY].written
-                                                 if v in node.context[self.KEY].reads_prior_calls[c]]
+                            read_then_written |= set([FindingValue(v,
+                                                                   node,
+                                                                   tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                                      for (v, nodes)
+                                                      in node.context[self.KEY].written.items()
+                                                      if v in node.context[self.KEY].reads_prior_calls[c]])
 
                         if read_then_written:
                             # calls are ordered
-                            finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)),
-                                           tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x:x.node_id)))
-                            finding_vars = read_then_written
-                            if finding_key not in result:
-                                result[finding_key] = []
-                            result[finding_key] = list(set(result[finding_key] + finding_vars))
+                            finding_key = FindingKey(function=node.function,
+                                                     calls=to_hashable(node.context[self.KEY].calls),
+                                                     send_eth=to_hashable(node.context[self.KEY].send_eth))
+
+                            result[finding_key] |= set(read_then_written)
         return result
 
     def _detect(self):
@@ -77,22 +84,33 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x:x[0][0].name)
+        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
+        varsWritten: List[FindingValue]
         for (func, calls, send_eth), varsWritten in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x.node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x.node_id)
+            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            varsWritten = sorted(varsWritten, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ['Reentrancy in ', func, ':\n']
             info += ['\tExternal calls:\n']
-            for call_info in calls:
-                info += ['\t- ' , call_info, '\n']
+            for (call_info, calls_list) in calls:
+                info += ['\t- ', call_info, '\n']
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        info += ['\t\t- ', call_list_info, '\n']
             if calls != send_eth and send_eth:
                 info += ['\tExternal calls sending eth:\n']
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     info += ['\t- ', call_info, '\n']
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            info += ['\t\t- ', call_list_info, '\n']
             info += ['\tState variables written after the call(s):\n']
-            for (v, node) in sorted(varsWritten, key=lambda x: (x[0].name, x[1].node_id)):
-                info += ['\t- ', v, ' in ', node, '\n']
+            for finding_value in varsWritten:
+                info += ['\t- ', finding_value.node, '\n']
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        info += ['\t\t- ', other_node, '\n']
 
             # Create our JSON result
             res = self.generate_result(info)
@@ -101,26 +119,40 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 res.add(call_info, {
                     "underlying_type": "external_calls"
                 })
-
-            #
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        res.add(call_list_info, {
+                            "underlying_type": "external_calls_sending_eth"
+                        })
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     res.add(call_info, {
                         "underlying_type": "external_calls_sending_eth"
                     })
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            res.add(call_list_info, {
+                                "underlying_type": "external_calls_sending_eth"
+                            })
 
             # Add all variables written via nodes which write them.
-            for (v, node) in varsWritten:
-                res.add(node, {
+            for finding_value in varsWritten:
+                res.add(finding_value.node, {
                     "underlying_type": "variables_written",
-                    "variable_name": v.name
+                    "variable_name": finding_value.variable.name
                 })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "variables_written",
+                            "variable_name": finding_value.variable.name
+                        })
 
             # Append our result
             results.append(res)

--- a/slither/detectors/reentrancy/reentrancy_eth.py
+++ b/slither/detectors/reentrancy/reentrancy_eth.py
@@ -47,21 +47,21 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
                     # dead code
                     if not self.KEY in node.context:
                         continue
-                    if node.context[self.KEY]['calls'] and node.context[self.KEY]['send_eth']:
-                        if not any(n!=node for n in node.context[self.KEY]['send_eth']):
+                    if node.context[self.KEY].calls and node.context[self.KEY].send_eth:
+                        if not any(n!=node for n in node.context[self.KEY].send_eth):
                             continue
                         read_then_written = []
-                        for c in node.context[self.KEY]['calls']:
+                        for c in node.context[self.KEY].calls:
                             if c == node:
                                 continue
-                            read_then_written += [(v, node) for v in node.context[self.KEY]['written']
-                                                 if v in node.context[self.KEY]['read_prior_calls'][c]]
+                            read_then_written += [(v, node) for v in node.context[self.KEY].written
+                                                 if v in node.context[self.KEY].reads_prior_calls[c]]
 
                         if read_then_written:
                             # calls are ordered
                             finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY]['calls']), key=lambda x:x.node_id)),
-                                           tuple(sorted(list(node.context[self.KEY]['send_eth']), key=lambda x:x.node_id)))
+                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)),
+                                           tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x:x.node_id)))
                             finding_vars = read_then_written
                             if finding_key not in result:
                                 result[finding_key] = []

--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -4,9 +4,13 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
-from slither.detectors.abstract_detector import DetectorClassification
+from collections import namedtuple, defaultdict
 
-from .reentrancy import Reentrancy
+from slither.detectors.abstract_detector import DetectorClassification
+from .reentrancy import Reentrancy, to_hashable
+
+FindingKey = namedtuple('FindingKey', ['function', 'calls', 'send_eth'])
+FindingValue = namedtuple('FindingValue', ['variable', 'node', 'nodes'])
 
 
 class ReentrancyEvent(Reentrancy):
@@ -37,7 +41,7 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
     STANDARD_JSON = False
 
     def find_reentrancies(self):
-        result = {}
+        result = defaultdict(set)
         for contract in self.contracts:
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
@@ -49,14 +53,16 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
                             continue
 
                         # calls are ordered
-                        finding_key = (node.function,
-                                       tuple(sorted(list(node.context[self.KEY].calls), key=lambda x: x.node_id)),
-                                       tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x: x.node_id)))
-                        finding_vars = list(node.context[self.KEY].events)
+                        finding_key = FindingKey(function=node.function,
+                                                 calls=to_hashable(node.context[self.KEY].calls),
+                                                 send_eth=to_hashable(node.context[self.KEY].send_eth))
+                        finding_vars = set([FindingValue(e,
+                                                         e.node,
+                                                         tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                            for (e, nodes)
+                                            in node.context[self.KEY].events.items()])
                         if finding_vars:
-                            if finding_key not in result:
-                                result[finding_key] = set()
-                            result[finding_key] = set(result[finding_key] | set(finding_vars))
+                            result[finding_key] |= finding_vars
         return result
 
     def _detect(self):
@@ -70,20 +76,30 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
 
         result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0][0].name)
         for (func, calls, send_eth), events in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x.node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x.node_id)
+            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            events = sorted(events, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ['Reentrancy in ', func, ':\n']
             info += ['\tExternal calls:\n']
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 info += ['\t- ', call_info, '\n']
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        info += ['\t\t- ', call_list_info, '\n']
             if calls != send_eth and send_eth:
                 info += ['\tExternal calls sending eth:\n']
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     info += ['\t- ', call_info, '\n']
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            info += ['\t\t- ', call_list_info, '\n']
             info += ['\tEvent emitted after the call(s):\n']
-            for event in sorted(events, key=lambda x: x.node.node_id):
-                info += ['\t- ', event.node, '\n']
+            for finding_value in events:
+                info += ['\t- ', finding_value.node, '\n']
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        info += ['\t\t- ', other_node, '\n']
 
             # Create our JSON result
             res = self.generate_result(info)
@@ -92,19 +108,39 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 res.add(call_info, {
                     "underlying_type": "external_calls"
                 })
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        res.add(call_list_info, {
+                            "underlying_type": "external_calls_sending_eth"
+                        })
 
             #
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     res.add(call_info, {
                         "underlying_type": "external_calls_sending_eth"
                     })
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            res.add(call_list_info, {
+                                "underlying_type": "external_calls_sending_eth"
+                            })
+
+            for finding_value in events:
+                res.add(finding_value.node, {
+                    "underlying_type": "event"
+                })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "event"
+                        })
 
             # Append our result
             results.append(res)

--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -6,8 +6,9 @@
 """
 from slither.detectors.abstract_detector import DetectorClassification
 
-
 from .reentrancy import Reentrancy
+
+
 class ReentrancyEvent(Reentrancy):
     ARGUMENT = 'reentrancy-events'
     HELP = 'Reentrancy vulnerabilities leading to out-of-order Events'
@@ -31,7 +32,6 @@ Only report reentrancies leading to out-of-order Events'''
 
 If `d.()` reenters, the `Counter` events will be showed in an incorrect order, which might lead to issues for third-parties.'''
 
-
     WIKI_RECOMMENDATION = 'Apply the [check-effects-interactions pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy).'
 
     STANDARD_JSON = False
@@ -42,17 +42,17 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
                     # dead code
-                    if not self.KEY in node.context:
+                    if self.KEY not in node.context:
                         continue
-                    if node.context[self.KEY]['calls']:
-                        if not any(n != node for n in node.context[self.KEY]['calls']):
+                    if node.context[self.KEY].calls:
+                        if not any(n != node for n in node.context[self.KEY].calls):
                             continue
 
                         # calls are ordered
                         finding_key = (node.function,
-                                       tuple(sorted(list(node.context[self.KEY]['calls']), key=lambda x: x.node_id)),
-                                       tuple(sorted(list(node.context[self.KEY]['send_eth']), key=lambda x: x.node_id)))
-                        finding_vars = list(node.context[self.KEY]['events'])
+                                       tuple(sorted(list(node.context[self.KEY].calls), key=lambda x: x.node_id)),
+                                       tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x: x.node_id)))
+                        finding_vars = list(node.context[self.KEY].events)
                         if finding_vars:
                             if finding_key not in result:
                                 result[finding_key] = set()
@@ -68,7 +68,7 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x:x[0][0].name)
+        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0][0].name)
         for (func, calls, send_eth), events in result_sorted:
             calls = sorted(list(set(calls)), key=lambda x: x.node_id)
             send_eth = sorted(list(set(send_eth)), key=lambda x: x.node_id)
@@ -76,7 +76,7 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
             info = ['Reentrancy in ', func, ':\n']
             info += ['\tExternal calls:\n']
             for call_info in calls:
-                info += ['\t- ' , call_info, '\n']
+                info += ['\t- ', call_info, '\n']
             if calls != send_eth and send_eth:
                 info += ['\tExternal calls sending eth:\n']
                 for call_info in send_eth:

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -4,10 +4,15 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
+from collections import namedtuple, defaultdict
+
 from slither.core.variables.variable import Variable
 from slither.detectors.abstract_detector import DetectorClassification
 from slither.slithir.operations import Send, Transfer, EventCall
-from .reentrancy import Reentrancy
+from .reentrancy import Reentrancy, to_hashable
+
+FindingKey = namedtuple('FindingKey', ['function', 'calls', 'send_eth'])
+FindingValue = namedtuple('FindingValue', ['variable', 'node', 'nodes'])
 
 
 class ReentrancyNoGas(Reentrancy):
@@ -37,17 +42,17 @@ Only report reentrancy that are based on `transfer` or `send`.'''
     WIKI_RECOMMENDATION = 'Apply the [check-effects-interactions pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy).'
 
     @staticmethod
-    def _can_callback(irs):
+    def can_callback(ir):
         """
         Same as Reentrancy, but also consider Send and Transfer
 
         """
-        return any((isinstance(ir, (Send, Transfer)) for ir in irs))
+        return isinstance(ir, (Send, Transfer))
 
     STANDARD_JSON = False
 
     def find_reentrancies(self):
-        result = {}
+        result = defaultdict(set)
         for contract in self.contracts:
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
@@ -59,15 +64,21 @@ Only report reentrancy that are based on `transfer` or `send`.'''
                             continue
 
                         # calls are ordered
-                        finding_key = (node.function,
-                                       tuple(sorted(list(node.context[self.KEY].calls), key=lambda x: x.node_id)),
-                                       tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x: x.node_id)))
-                        finding_vars = [(v, node) for v in node.context[self.KEY].written]
-                        finding_vars += [(e, e.node) for e in node.context[self.KEY].events]
+                        finding_key = FindingKey(function=node.function,
+                                                 calls=to_hashable(node.context[self.KEY].calls),
+                                                 send_eth=to_hashable(node.context[self.KEY].send_eth))
+                        finding_vars = set([FindingValue(v,
+                                                         node,
+                                                         tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                            for (v, nodes)
+                                            in node.context[self.KEY].written.items()])
+                        finding_vars |= set([FindingValue(e,
+                                                          e.node,
+                                                          tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                             for (e, nodes)
+                                             in node.context[self.KEY].events.items()])
                         if finding_vars:
-                            if finding_key not in result:
-                                result[finding_key] = set()
-                            result[finding_key] = set(result[finding_key] | set(finding_vars))
+                            result[finding_key] |= finding_vars
         return result
 
     def _detect(self):
@@ -81,29 +92,45 @@ Only report reentrancy that are based on `transfer` or `send`.'''
 
         result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0][0].name)
         for (func, calls, send_eth), varsWrittenOrEvent in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x.node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x.node_id)
+            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
             info = ['Reentrancy in ', func, ':\n']
 
             info += ['\tExternal calls:\n']
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 info += ['\t- ', call_info, '\n']
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        info += ['\t\t- ', call_list_info, '\n']
             if calls != send_eth and send_eth:
                 info += ['\tExternal calls sending eth:\n']
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     info += ['\t- ', call_info, '\n']
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            info += ['\t\t- ', call_list_info, '\n']
 
-            varsWritten = [(v, node) for (v, node) in varsWrittenOrEvent if isinstance(v, Variable)]
+            varsWritten = [FindingValue(v, node, nodes) for (v, node, nodes)
+                           in varsWrittenOrEvent if isinstance(v, Variable)]
+            varsWritten = sorted(varsWritten, key=lambda x: (x.variable.name, x.node.node_id))
             if varsWritten:
                 info += ['\tState variables written after the call(s):\n']
-                for (v, node) in sorted(varsWritten, key=lambda x: (x[0].name, x[1].node_id)):
-                    info += ['\t- ', v, ' in ', node, '\n']
+                for finding_value in varsWritten:
+                    info += ['\t- ', finding_value.node, '\n']
+                    for other_node in finding_value.nodes:
+                        if other_node != finding_value.node:
+                            info += ['\t\t- ', other_node, '\n']
 
-            events = [(e, node) for (e, node) in varsWrittenOrEvent if isinstance(e, EventCall)]
+            events = [FindingValue(v, node, nodes) for (v, node, nodes)
+                      in varsWrittenOrEvent if isinstance(v, EventCall)]
+            events = sorted(events, key=lambda x: (x.variable.name, x.node.node_id))
             if events:
                 info += ['\tEvent emitted after the call(s):\n']
-                for (_, node) in sorted(events, key=lambda x: x[1].node_id):
-                    info += ['\t- ', node, '\n']
+                for finding_value in events:
+                    info += ['\t- ', finding_value.node, '\n']
+                    for other_node in finding_value.nodes:
+                        if other_node != finding_value.node:
+                            info += ['\t\t- ', other_node, '\n']
 
             # Create our JSON result
             res = self.generate_result(info)
@@ -112,26 +139,51 @@ Only report reentrancy that are based on `transfer` or `send`.'''
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 res.add(call_info, {
                     "underlying_type": "external_calls"
                 })
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        res.add(call_list_info, {
+                            "underlying_type": "external_calls_sending_eth"
+                        })
 
             #
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for call_info in send_eth:
+                for (call_info, calls_list) in send_eth:
                     res.add(call_info, {
                         "underlying_type": "external_calls_sending_eth"
                     })
+                    for call_list_info in calls_list:
+                        if call_list_info != call_info:
+                            res.add(call_list_info, {
+                                "underlying_type": "external_calls_sending_eth"
+                            })
 
             # Add all variables written via nodes which write them.
-            for (v, node) in varsWritten:
-                res.add(node, {
+            for finding_value in varsWritten:
+                res.add(finding_value.node, {
                     "underlying_type": "variables_written",
-                    "variable_name": v.name
+                    "variable_name": finding_value.variable.name
                 })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "variables_written",
+                            "variable_name": finding_value.variable.name
+                        })
+            for finding_value in events:
+                res.add(finding_value.node, {
+                    "underlying_type": "event"
+                })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "event"
+                        })
 
             # Append our result
             results.append(res)

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -36,7 +36,8 @@ Only report reentrancy that are based on `transfer` or `send`.'''
 
     WIKI_RECOMMENDATION = 'Apply the [check-effects-interactions pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy).'
 
-    def _can_callback(self, irs):
+    @staticmethod
+    def _can_callback(irs):
         """
         Same as Reentrancy, but also consider Send and Transfer
 
@@ -51,18 +52,18 @@ Only report reentrancy that are based on `transfer` or `send`.'''
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
                     # dead code
-                    if not self.KEY in node.context:
+                    if self.KEY not in node.context:
                         continue
-                    if node.context[self.KEY]['calls']:
-                        if not any(n != node for n in node.context[self.KEY]['calls']):
+                    if node.context[self.KEY].calls:
+                        if not any(n != node for n in node.context[self.KEY].calls):
                             continue
 
                         # calls are ordered
                         finding_key = (node.function,
-                                       tuple(sorted(list(node.context[self.KEY]['calls']), key=lambda x: x.node_id)),
-                                       tuple(sorted(list(node.context[self.KEY]['send_eth']), key=lambda x: x.node_id)))
-                        finding_vars = [(v, node) for v in node.context[self.KEY]['written']]
-                        finding_vars += [(e, e.node) for e in node.context[self.KEY]['events']]
+                                       tuple(sorted(list(node.context[self.KEY].calls), key=lambda x: x.node_id)),
+                                       tuple(sorted(list(node.context[self.KEY].send_eth), key=lambda x: x.node_id)))
+                        finding_vars = [(v, node) for v in node.context[self.KEY].written]
+                        finding_vars += [(e, e.node) for e in node.context[self.KEY].events]
                         if finding_vars:
                             if finding_key not in result:
                                 result[finding_key] = set()

--- a/slither/detectors/reentrancy/reentrancy_read_before_write.py
+++ b/slither/detectors/reentrancy/reentrancy_read_before_write.py
@@ -46,19 +46,19 @@ Do not report reentrancies that involve ethers (see `reentrancy-eth`)'''
                     # dead code
                     if not self.KEY in node.context:
                         continue
-                    if node.context[self.KEY]['calls'] and not node.context[self.KEY]['send_eth']:
+                    if node.context[self.KEY].calls and not node.context[self.KEY].send_eth:
                         read_then_written = []
-                        for c in node.context[self.KEY]['calls']:
+                        for c in node.context[self.KEY].calls:
                             if c == node:
                                 continue
-                            read_then_written += [(v, node) for v in node.context[self.KEY]['written']
-                                                  if v in node.context[self.KEY]['read_prior_calls'][c]]
+                            read_then_written += [(v, node) for v in node.context[self.KEY].written
+                                                  if v in node.context[self.KEY].reads_prior_calls[c]]
 
                         # We found a potential re-entrancy bug
                         if read_then_written:
                             # calls are ordered
                             finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY]['calls']), key=lambda x:x.node_id)))
+                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)))
                             finding_vars = read_then_written
                             if finding_key not in result:
                                 result[finding_key] = []

--- a/slither/detectors/reentrancy/reentrancy_read_before_write.py
+++ b/slither/detectors/reentrancy/reentrancy_read_before_write.py
@@ -4,11 +4,15 @@
     Based on heuristics, it may lead to FP and FN
     Iterate over all the nodes of the graph until reaching a fixpoint
 """
+from collections import namedtuple, defaultdict
 
 from slither.detectors.abstract_detector import DetectorClassification
+from .reentrancy import Reentrancy, to_hashable
+
+FindingKey = namedtuple('FindingKey', ['function', 'calls'])
+FindingValue = namedtuple('FindingValue', ['variable', 'node', 'nodes'])
 
 
-from .reentrancy import Reentrancy
 
 class ReentrancyReadBeforeWritten(Reentrancy):
     ARGUMENT = 'reentrancy-no-eth'
@@ -39,30 +43,31 @@ Do not report reentrancies that involve ethers (see `reentrancy-eth`)'''
     STANDARD_JSON = False
 
     def find_reentrancies(self):
-        result = {}
+        result = defaultdict(set)
         for contract in self.contracts:
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
                     # dead code
-                    if not self.KEY in node.context:
+                    if self.KEY not in node.context:
                         continue
                     if node.context[self.KEY].calls and not node.context[self.KEY].send_eth:
-                        read_then_written = []
+                        read_then_written = set()
                         for c in node.context[self.KEY].calls:
                             if c == node:
                                 continue
-                            read_then_written += [(v, node) for v in node.context[self.KEY].written
-                                                  if v in node.context[self.KEY].reads_prior_calls[c]]
+                            read_then_written |= set([FindingValue(v,
+                                                                   node,
+                                                                   tuple(sorted(nodes, key=lambda x: x.node_id)))
+                                                      for (v, nodes)
+                                                      in node.context[self.KEY].written.items()
+                                                      if v in node.context[self.KEY].reads_prior_calls[c]])
 
                         # We found a potential re-entrancy bug
                         if read_then_written:
                             # calls are ordered
-                            finding_key = (node.function,
-                                           tuple(sorted(list(node.context[self.KEY].calls), key=lambda x:x.node_id)))
-                            finding_vars = read_then_written
-                            if finding_key not in result:
-                                result[finding_key] = []
-                            result[finding_key] = list(set(result[finding_key] + finding_vars))
+                            finding_key = FindingKey(function=node.function,
+                                                     calls=to_hashable(node.context[self.KEY].calls))
+                            result[finding_key] |= read_then_written
         return result
 
     def _detect(self):
@@ -74,18 +79,25 @@ Do not report reentrancies that involve ethers (see `reentrancy-eth`)'''
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x:x[0][0].name)
+        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
         for (func, calls), varsWritten in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x.node_id)
+            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            varsWritten = sorted(varsWritten, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ['Reentrancy in ', func, ':\n']
 
             info += ['\tExternal calls:\n']
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 info += ['\t- ', call_info, '\n']
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        info += ['\t\t- ', call_list_info, '\n']
             info += '\tState variables written after the call(s):\n'
-            for (v, node) in sorted(varsWritten, key=lambda x: (x[0].name, x[1].node_id)):
-                info += ['\t- ', v, ' in ', node, '\n']
+            for finding_value in varsWritten:
+                info += ['\t- ', finding_value.node, '\n']
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        info += ['\t\t- ', other_node, '\n']
 
             # Create our JSON result
             res = self.generate_result(info)
@@ -94,17 +106,28 @@ Do not report reentrancies that involve ethers (see `reentrancy-eth`)'''
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for call_info in calls:
+            for (call_info, calls_list) in calls:
                 res.add(call_info, {
                     "underlying_type": "external_calls"
                 })
+                for call_list_info in calls_list:
+                    if call_list_info != call_info:
+                        res.add(call_list_info, {
+                            "underlying_type": "external_calls_sending_eth"
+                        })
 
             # Add all variables written via nodes which write them.
-            for (v, node) in varsWritten:
-                res.add(node, {
+            for finding_value in varsWritten:
+                res.add(finding_value.node, {
                     "underlying_type": "variables_written",
-                    "variable_name": v.name
+                    "variable_name": finding_value.variable.name
                 })
+                for other_node in finding_value.nodes:
+                    if other_node != finding_value.node:
+                        res.add(other_node, {
+                            "underlying_type": "variables_written",
+                            "variable_name": finding_value.variable.name
+                        })
 
             # Append our result
             results.append(res)

--- a/tests/expected_json/reentrancy-0.5.1-events.reentrancy-events.json
+++ b/tests/expected_json/reentrancy-0.5.1-events.reentrancy-events.json
@@ -137,6 +137,84 @@
             "additional_fields": {
               "underlying_type": "external_calls"
             }
+          },
+          {
+            "type": "node",
+            "name": "E()",
+            "source_mapping": {
+              "start": 135,
+              "length": 8,
+              "filename_used": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+              "filename_relative": "tests/reentrancy-0.5.1-events.sol",
+              "filename_absolute": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+              "filename_short": "tests/reentrancy-0.5.1-events.sol",
+              "is_dependency": false,
+              "lines": [
+                16
+              ],
+              "starting_column": 9,
+              "ending_column": 17
+            },
+            "type_specific_fields": {
+              "parent": {
+                "type": "function",
+                "name": "bug",
+                "source_mapping": {
+                  "start": 86,
+                  "length": 68,
+                  "filename_used": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+                  "filename_relative": "tests/reentrancy-0.5.1-events.sol",
+                  "filename_absolute": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+                  "filename_short": "tests/reentrancy-0.5.1-events.sol",
+                  "is_dependency": false,
+                  "lines": [
+                    14,
+                    15,
+                    16,
+                    17
+                  ],
+                  "starting_column": 5,
+                  "ending_column": 6
+                },
+                "type_specific_fields": {
+                  "parent": {
+                    "type": "contract",
+                    "name": "Test",
+                    "source_mapping": {
+                      "start": 51,
+                      "length": 193,
+                      "filename_used": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+                      "filename_relative": "tests/reentrancy-0.5.1-events.sol",
+                      "filename_absolute": "/home/travis/build/crytic/slither/tests/reentrancy-0.5.1-events.sol",
+                      "filename_short": "tests/reentrancy-0.5.1-events.sol",
+                      "is_dependency": false,
+                      "lines": [
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24
+                      ],
+                      "starting_column": 1,
+                      "ending_column": 2
+                    }
+                  },
+                  "signature": "bug(C)"
+                }
+              }
+            },
+            "additional_fields": {
+              "underlying_type": "event"
+            }
           }
         ],
         "description": "Reentrancy in Test.bug(C) (tests/reentrancy-0.5.1-events.sol#14-17):\n\tExternal calls:\n\t- c.f() (tests/reentrancy-0.5.1-events.sol#15)\n\tEvent emitted after the call(s):\n\t- E() (tests/reentrancy-0.5.1-events.sol#16)\n",

--- a/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.json
@@ -347,9 +347,9 @@
             }
           }
         ],
-        "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy-0.5.1.sol#21)\n",
-        "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy-0.5.1.sol#L14-L22):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(userBalance[msg.sender])()](tests/reentrancy-0.5.1.sol#L17)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy-0.5.1.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy-0.5.1.sol#L21)\n",
-        "id": "90119c12446a44e514bb4ccd7a0e869f210d7c3ec349d24d4237ace685a75df9",
+        "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)\n\tState variables written after the call(s):\n\t- userBalance[msg.sender] = 0 (tests/reentrancy-0.5.1.sol#21)\n",
+        "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy-0.5.1.sol#L14-L22):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(userBalance[msg.sender])()](tests/reentrancy-0.5.1.sol#L17)\n\tState variables written after the call(s):\n\t- [userBalance[msg.sender] = 0](tests/reentrancy-0.5.1.sol#L21)\n",
+        "id": "ecea92bbcdec27c72f1343d38c817925ef469f75d94582927f53baa999e74c5e",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"
@@ -701,9 +701,9 @@
             }
           }
         ],
-        "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#44-53):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(amount)() (tests/reentrancy-0.5.1.sol#49)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = amount (tests/reentrancy-0.5.1.sol#51)\n",
-        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_fixed_3()](tests/reentrancy-0.5.1.sol#L44-L53):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(amount)()](tests/reentrancy-0.5.1.sol#L49)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy-0.5.1.sol#L4) in [userBalance[msg.sender] = amount](tests/reentrancy-0.5.1.sol#L51)\n",
-        "id": "048dce6132290bdee94cd1e52c330873fed4b1c9ad2f49df4ba3d6ef49266a41",
+        "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#44-53):\n\tExternal calls:\n\t- (ret,mem) = msg.sender.call.value(amount)() (tests/reentrancy-0.5.1.sol#49)\n\tState variables written after the call(s):\n\t- userBalance[msg.sender] = amount (tests/reentrancy-0.5.1.sol#51)\n",
+        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_fixed_3()](tests/reentrancy-0.5.1.sol#L44-L53):\n\tExternal calls:\n\t- [(ret,mem) = msg.sender.call.value(amount)()](tests/reentrancy-0.5.1.sol#L49)\n\tState variables written after the call(s):\n\t- [userBalance[msg.sender] = amount](tests/reentrancy-0.5.1.sol#L51)\n",
+        "id": "9ba67be9630482631f186a908634db6dddace3a2ddcbada65dad8b68e26023d1",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.txt
+++ b/tests/expected_json/reentrancy-0.5.1.reentrancy-eth.txt
@@ -3,11 +3,12 @@ Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy-0.5.1.sol#14-22):
 	External calls:
 	- (ret,mem) = msg.sender.call.value(userBalance[msg.sender])() (tests/reentrancy-0.5.1.sol#17)
 	State variables written after the call(s):
-	- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy-0.5.1.sol#21)
+	- userBalance[msg.sender] = 0 (tests/reentrancy-0.5.1.sol#21)
 Reentrancy in Reentrancy.withdrawBalance_fixed_3() (tests/reentrancy-0.5.1.sol#44-53):
 	External calls:
 	- (ret,mem) = msg.sender.call.value(amount)() (tests/reentrancy-0.5.1.sol#49)
 	State variables written after the call(s):
-	- Reentrancy.userBalance (tests/reentrancy-0.5.1.sol#4) in userBalance[msg.sender] = amount (tests/reentrancy-0.5.1.sol#51)
+	- userBalance[msg.sender] = amount (tests/reentrancy-0.5.1.sol#51)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities[0m
 tests/reentrancy-0.5.1.sol analyzed (1 contracts with 1 detectors), 2 result(s) found
+[94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m

--- a/tests/expected_json/reentrancy.reentrancy-eth.json
+++ b/tests/expected_json/reentrancy.reentrancy-eth.json
@@ -398,9 +398,9 @@
             }
           }
         ],
-        "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):\n\tExternal calls:\n\t- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#20)\n",
-        "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy.sol#L14-L21):\n\tExternal calls:\n\t- [! (msg.sender.call.value(userBalance[msg.sender])())](tests/reentrancy.sol#L17)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy.sol#L20)\n",
-        "id": "330f0fadcfdda2b4364ee67d3112ff00e0e369162004c451163f0663c9b01313",
+        "description": "Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):\n\tExternal calls:\n\t- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)\n\tState variables written after the call(s):\n\t- userBalance[msg.sender] = 0 (tests/reentrancy.sol#20)\n",
+        "markdown": "Reentrancy in [Reentrancy.withdrawBalance()](tests/reentrancy.sol#L14-L21):\n\tExternal calls:\n\t- [! (msg.sender.call.value(userBalance[msg.sender])())](tests/reentrancy.sol#L17)\n\tState variables written after the call(s):\n\t- [userBalance[msg.sender] = 0](tests/reentrancy.sol#L20)\n",
+        "id": "b3b9387cfe7869e6def2fa9396178163800fecf86ae59f7fd3132cc491050c65",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"
@@ -797,9 +797,9 @@
             }
           }
         ],
-        "description": "Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):\n\tExternal calls:\n\t- msg.sender.call.value(amount / 2)() (tests/reentrancy.sol#67)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#68)\n",
-        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_nested()](tests/reentrancy.sol#L64-L70):\n\tExternal calls:\n\t- [msg.sender.call.value(amount / 2)()](tests/reentrancy.sol#L67)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy.sol#L68)\n",
-        "id": "30220828bfef61c2377527c7cee2ae5be443001f8dd39992d6e5af67153c402f",
+        "description": "Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):\n\tExternal calls:\n\t- msg.sender.call.value(amount / 2)() (tests/reentrancy.sol#67)\n\tState variables written after the call(s):\n\t- userBalance[msg.sender] = 0 (tests/reentrancy.sol#68)\n",
+        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_nested()](tests/reentrancy.sol#L64-L70):\n\tExternal calls:\n\t- [msg.sender.call.value(amount / 2)()](tests/reentrancy.sol#L67)\n\tState variables written after the call(s):\n\t- [userBalance[msg.sender] = 0](tests/reentrancy.sol#L68)\n",
+        "id": "f3e8ebbca224362041700e67287009f59c297a79b79a32489ec71ad596e8ee7a",
         "check": "reentrancy-eth",
         "impact": "High",
         "confidence": "Medium"

--- a/tests/expected_json/reentrancy.reentrancy-eth.txt
+++ b/tests/expected_json/reentrancy.reentrancy-eth.txt
@@ -3,11 +3,12 @@ Reentrancy in Reentrancy.withdrawBalance() (tests/reentrancy.sol#14-21):
 	External calls:
 	- ! (msg.sender.call.value(userBalance[msg.sender])()) (tests/reentrancy.sol#17)
 	State variables written after the call(s):
-	- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#20)
+	- userBalance[msg.sender] = 0 (tests/reentrancy.sol#20)
 Reentrancy in Reentrancy.withdrawBalance_nested() (tests/reentrancy.sol#64-70):
 	External calls:
 	- msg.sender.call.value(amount / 2)() (tests/reentrancy.sol#67)
 	State variables written after the call(s):
-	- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#68)
+	- userBalance[msg.sender] = 0 (tests/reentrancy.sol#68)
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities[0m
-tests/reentrancy.sol analyzed (1 contracts with 1 detectors), 2 result(s) found
+tests/reentrancy.sol analyzed (3 contracts with 1 detectors), 2 result(s) found
+[94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m

--- a/tests/expected_json/reentrancy.reentrancy-unlimited-gas.json
+++ b/tests/expected_json/reentrancy.reentrancy-unlimited-gas.json
@@ -398,9 +398,9 @@
             }
           }
         ],
-        "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_2() (tests/reentrancy.sol#33-40):\n\tExternal calls:\n\t- msg.sender.transfer(userBalance[msg.sender]) (tests/reentrancy.sol#38)\n\tState variables written after the call(s):\n\t- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#39)\n",
-        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_fixed_2()](tests/reentrancy.sol#L33-L40):\n\tExternal calls:\n\t- [msg.sender.transfer(userBalance[msg.sender])](tests/reentrancy.sol#L38)\n\tState variables written after the call(s):\n\t- [Reentrancy.userBalance](tests/reentrancy.sol#L4) in [userBalance[msg.sender] = 0](tests/reentrancy.sol#L39)\n",
-        "id": "ff12b17dedf35fcd1f5b1286653a53430009f3689c46c06c1aba1f2d4b17d713",
+        "description": "Reentrancy in Reentrancy.withdrawBalance_fixed_2() (tests/reentrancy.sol#33-40):\n\tExternal calls:\n\t- msg.sender.transfer(userBalance[msg.sender]) (tests/reentrancy.sol#38)\n\tState variables written after the call(s):\n\t- userBalance[msg.sender] = 0 (tests/reentrancy.sol#39)\n",
+        "markdown": "Reentrancy in [Reentrancy.withdrawBalance_fixed_2()](tests/reentrancy.sol#L33-L40):\n\tExternal calls:\n\t- [msg.sender.transfer(userBalance[msg.sender])](tests/reentrancy.sol#L38)\n\tState variables written after the call(s):\n\t- [userBalance[msg.sender] = 0](tests/reentrancy.sol#L39)\n",
+        "id": "638cb8a1404e47854e9e03720ee9c612cca4cadc64974f9c42f122994540a17f",
         "check": "reentrancy-unlimited-gas",
         "impact": "Informational",
         "confidence": "Medium"

--- a/tests/expected_json/reentrancy.reentrancy-unlimited-gas.txt
+++ b/tests/expected_json/reentrancy.reentrancy-unlimited-gas.txt
@@ -3,6 +3,7 @@ Reentrancy in Reentrancy.withdrawBalance_fixed_2() (tests/reentrancy.sol#33-40):
 	External calls:
 	- msg.sender.transfer(userBalance[msg.sender]) (tests/reentrancy.sol#38)
 	State variables written after the call(s):
-	- Reentrancy.userBalance (tests/reentrancy.sol#4) in userBalance[msg.sender] = 0 (tests/reentrancy.sol#39)
-Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-3[0m
-tests/reentrancy.sol analyzed (1 contracts with 1 detectors), 1 result(s) found
+	- userBalance[msg.sender] = 0 (tests/reentrancy.sol#39)
+Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities-4[0m
+tests/reentrancy.sol analyzed (3 contracts with 1 detectors), 1 result(s) found
+[94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m


### PR DESCRIPTION
This PR introduces `AbstractState` in the reentrancy detectors, which is a generic class to maintain the abstract representation used to detect reentrancy.

As a result, the reentrancy core was significantly refactored and the detectors are now able to show the calls/variables written from an internal call (fix https://github.com/crytic/slither/issues/421)

Additionally, python types were introduced in these detectors