### PR TITLE
Fixed cfg_to_dot printing to file

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1065,7 +1065,7 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
                     content += '{}->{};\n'.format(node.node_id, son.node_id)
 
             content += "}\n"
-        return content
+            f.write(content)
 
     def dominator_tree_to_dot(self, filename):
         """


### PR DESCRIPTION
Fixed a small error that caused contents of dot file not to be written to the specified file. For an example usage see `examples/scripts/export_to_dot.py`.