### PR TITLE
Echidna printer: improve constant function detection

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -599,7 +599,7 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
         """
             list(SolidityFunction): List of Soldity calls
         """
-        return list(self._internal_calls)
+        return list(self._solidity_calls)
 
     @property
     def high_level_calls(self):

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -13,7 +13,7 @@ from slither.core.slither_core import Slither
 from slither.core.variables.state_variable import StateVariable
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.slithir.operations import Member, Operation, SolidityCall, LowLevelCall, HighLevelCall, EventCall, Send, \
-    Transfer, InternalDynamicCall
+    Transfer, InternalDynamicCall, InternalCall
 from slither.slithir.operations.binary import Binary, BinaryType
 from slither.slithir.variables import Constant
 
@@ -79,6 +79,10 @@ def _is_constant(f: Function) -> bool:
                 if f.contract.slither.crytic_compile.version.startswith('0.4'):
                     return False
             else:
+                return False
+        if isinstance(ir, InternalCall):
+            # Storage write are not properly handled by all_state_variables_written
+            if any(parameter.is_storage for parameter in ir.function.parameters):
                 return False
     return True
 

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -59,8 +59,10 @@ def _is_constant(f: Function) -> bool:
     :return:
     """
     if f.view or f.pure:
-        if not f.contract.slither.crytic_compile.version.startswith('0.4'):
+        if not f.contract.slither.crytic_compile.compiler_version.version.startswith('0.4'):
             return True
+    if f.payable:
+        return False
     if f.contains_assembly:
         return False
     if f.all_state_variables_written():
@@ -76,7 +78,7 @@ def _is_constant(f: Function) -> bool:
         if isinstance(ir, HighLevelCall):
             if ir.function.view or ir.function.pure:
                 # External call to constant functions are ensured to be constant only for solidity >= 0.5
-                if f.contract.slither.crytic_compile.version.startswith('0.4'):
+                if f.contract.slither.crytic_compile.compiler_version.version.startswith('0.4'):
                     return False
             else:
                 return False

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -184,10 +184,10 @@ def _extract_constants(slither: Slither) -> Tuple[Dict[str, Dict[str, List]], Di
             # Note: use list(set()) instead of set
             # As this is meant to be serialized in JSON, and JSON does not support set
             if all_cst_used:
-                ret_cst_used[contract.name][function.full_name] = list(set(all_cst_used))
+                ret_cst_used[contract.name][_get_name(function)] = list(set(all_cst_used))
             if all_cst_used_in_binary:
-                ret_cst_used_in_binary[contract.name][function.full_name] = {k: list(set(v)) for k, v in
-                                                                             all_cst_used_in_binary.items()}
+                ret_cst_used_in_binary[contract.name][_get_name(function)] = {k: list(set(v)) for k, v in
+                                                                              all_cst_used_in_binary.items()}
     return ret_cst_used, ret_cst_used_in_binary
 
 
@@ -196,19 +196,19 @@ def _extract_function_relations(slither: Slither) -> Dict[str, Dict[str, Dict[st
     ret: Dict[str, Dict[str, Dict[str, List[str]]]] = defaultdict(dict)
     for contract in slither.contracts:
         ret[contract.name] = defaultdict(dict)
-        written = {function.full_name: function.all_state_variables_written()
+        written = {_get_name(function): function.all_state_variables_written()
                    for function in contract.functions_entry_points}
-        read = {function.full_name: function.all_state_variables_read()
+        read = {_get_name(function): function.all_state_variables_read()
                 for function in contract.functions_entry_points}
         for function in contract.functions_entry_points:
-            ret[contract.name][function.full_name] = {"impacts": [],
+            ret[contract.name][_get_name(function)] = {"impacts": [],
                                                       "is_impacted_by": []}
             for candidate, varsWritten in written.items():
                 if any((r in varsWritten for r in function.all_state_variables_read())):
-                    ret[contract.name][function.full_name]["is_impacted_by"].append(candidate)
+                    ret[contract.name][_get_name(function)]["is_impacted_by"].append(candidate)
             for candidate, varsRead in read.items():
                 if any((r in varsRead for r in function.all_state_variables_written())):
-                    ret[contract.name][function.full_name]["impacts"].append(candidate)
+                    ret[contract.name][_get_name(function)]["impacts"].append(candidate)
     return ret
 
 


### PR DESCRIPTION
Heuristic:
- If view/pure with Solidity >= 0.5 -> Return true
- If it contains assembly -> Return false (Slither doesn't analyze asm)
- Otherwise, check the rules from
    https://solidity.readthedocs.io/en/v0.5.0/contracts.html?highlight=pure#view-functions
- One exception: internal dynamic calls are not correctly handled, so we consider them as non-constant