### PR TITLE
Add support for ternary on unary operator

### DIFF
--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -3,6 +3,8 @@
     as they should be immutable
 """
 import copy
+
+from slither.core.expressions import UnaryOperation
 from slither.core.expressions.assignment_operation import AssignmentOperation
 from slither.core.expressions.binary_operation import BinaryOperation
 from slither.core.expressions.call_expression import CallExpression
@@ -106,6 +108,13 @@ class SplitTernaryExpression(object):
                                          false_expression.arguments[-1])
 
         elif isinstance(expression, TypeConversion):
+            next_expr = expression.expression
+            if self.apply_copy(next_expr, true_expression, false_expression, f_expression):
+                self.copy_expression(expression.expression,
+                                     true_expression.expression,
+                                     false_expression.expression)
+
+        elif isinstance(expression, UnaryOperation):
             next_expr = expression.expression
             if self.apply_copy(next_expr, true_expression, false_expression, f_expression):
                 self.copy_expression(expression.expression,


### PR DESCRIPTION
Example:
```solidity
contract C{

    function f(bool a, bool b) public{
        require(!a, b? "x" : "y");
    }
}
```