### PR TITLE
Upgradeabily: use 'check' instead of 'detector' in the json

### DIFF
--- a/slither/tools/upgradeability/utils/command_line.py
+++ b/slither/tools/upgradeability/utils/command_line.py
@@ -69,12 +69,6 @@ def output_to_markdown(detector_classes, filter_wiki):
         require_proxy = detector.REQUIRE_PROXY
         require_v2 = detector.REQUIRE_CONTRACT_V2
         detectors_list.append((argument, help_info, impact, require_proxy, require_v2))
-    table = PrettyTable(["Num",
-                         "Check",
-                         "What it Detects",
-                         "Impact",
-                         "Proxy",
-                         "Contract V2"])
 
     # Sort by impact, confidence, and name
     detectors_list = sorted(detectors_list, key=lambda element: (element[2], element[0]))
@@ -113,7 +107,7 @@ def output_detectors_json(detector_classes):
     table = []
     for (argument, help_info, impact, wiki_url, description, exploit, recommendation) in detectors_list:
         table.append({'index': idx,
-                      'detector': argument,
+                      'check': argument,
                       'title': help_info,
                       'impact': classification_txt[impact],
                       'wiki_url': wiki_url,


### PR DESCRIPTION
Such that `--list-detectors-json` for upgradeability follows the same standard than for the security issues