### PR TITLE
Node API: add true/false branchs for if statement 

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1111,8 +1111,16 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
             if node.irs:
                 label += '\nIRs:\n' + '\n'.join([str(ir) for ir in node.irs])
             content += '{}[label="{}"];\n'.format(node.node_id, label)
-            for son in node.sons:
-                content += '{}->{};\n'.format(node.node_id, son.node_id)
+            if node.type == NodeType.IF:
+                true_node = node.son_true
+                if true_node:
+                    content += '{}->{}[label="True"];\n'.format(node.node_id, true_node.node_id)
+                false_node = node.son_false
+                if false_node:
+                    content += '{}->{}[label="False"];\n'.format(node.node_id, false_node.node_id)
+            else:
+                for son in node.sons:
+                    content += '{}->{};\n'.format(node.node_id, son.node_id)
 
         content += "}\n"
         return content


### PR DESCRIPTION
And show true/false arrows in cfg export

Close #433

Example:
```solidity
contract C{

    function f(bool b, bool c, bool d) public returns(uint){
        if(b){
            return 0;
        }
        else if(c){
            return 1;
        }
        else{

            if(d){
                return 3;
            }

            return 2;
        }
    }

}
```

![image](https://user-images.githubusercontent.com/13798342/79566368-b9534e80-80b2-11ea-8920-94ac72007f16.png)

Note: this does not include IFLOOP statement