### PR TITLE
Fix: added json output support for PrettyTable objects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
     install_requires=['prettytable>=0.7.2',
                       'pysha3>=1.0.2',
 #                      'crytic-compile>=0.1.7'],
-                       'crytic-compile'],
+                       'crytic-compile'
+                       'bs4',
+                       'lxml'],
     dependency_links=['git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile'],
     license='AGPL-3.0',
     long_description=open('README.md').read(),

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=['prettytable>=0.7.2',
                       'pysha3>=1.0.2',
 #                      'crytic-compile>=0.1.7'],
-                       'crytic-compile'
+                       'crytic-compile',
                        'bs4',
                        'lxml'],
     dependency_links=['git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile'],

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -37,7 +37,7 @@ def output_to_json(filename, error, results):
     if "printers" in results :
         for i in results['printers'] :
             for k in i['elements'] :
-                if type(k['name']['content']) == PrettyTable:
+                if "content" in k['name'] and type(k['name']['content']) == PrettyTable:
                     table = k['name']['content'].get_html_string()
                     model = BeautifulSoup(table, features='lxml')
                     fields = []


### PR DESCRIPTION
I found that some printer options are not available to output result in json

which is because of PrettyTable objects that is used on some printers.

i fixed this by parsing result of prettyTable objects and make json object by PrettyTable.get_html_string() and BeautifulSoup

need to add requirement of
bs4,
lxml