### PR TITLE
Remove etherscan test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        type: ["4", "5", "cli", "dapp", "data_dependency", "embark", "erc", "etherlime", "etherscan", "find_paths", "kspec", "printers", "simil", "slither_config", "truffle", "upgradability", "prop"]
+        type: ["4", "5", "cli", "dapp", "data_dependency", "embark", "erc", "etherlime", "find_paths", "kspec", "printers", "simil", "slither_config", "truffle", "upgradability", "prop"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.6


### PR DESCRIPTION
This PR removes the etherscan test. The reason is that etherscan requires an API, which is provided as a github action private variable. As a result, PR from external users wont work anymore (example: https://github.com/crytic/slither/pull/459)

I will investigate how to prevent it, but in the meantime this test is disabled 