### PR TITLE
[WIP] Fix incorrect solidity function signature

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -17,6 +17,7 @@ from slither.core.solidity_types import UserDefinedType
 from slither.core.solidity_types.type import Type
 from slither.core.source_mapping.source_mapping import SourceMapping
 from slither.core.variables.state_variable import StateVariable
+from slither.utils.type import convert_type_for_solidity_signature
 from slither.utils.utils import unroll
 
 logger = logging.getLogger("Function")
@@ -726,13 +727,6 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
     ###################################################################################
     ###################################################################################
 
-    @staticmethod
-    def _convert_type_for_solidity_signature(t: Type):
-        from slither.core.declarations import Contract
-        if isinstance(t, UserDefinedType) and isinstance(t.type, Contract):
-            return "address"
-        return str(t)
-
     @property
     def solidity_signature(self) -> str:
         """
@@ -740,7 +734,7 @@ class Function(ChildContract, ChildInheritance, SourceMapping):
         Contract and converted into address
         :return: the solidity signature
         """
-        parameters = [self._convert_type_for_solidity_signature(x.type) for x in self.parameters]
+        parameters = [str(convert_type_for_solidity_signature(x.type)) for x in self.parameters]
         return self.name + '(' + ','.join(parameters) + ')'
 
 

--- a/slither/core/variables/state_variable.py
+++ b/slither/core/variables/state_variable.py
@@ -1,6 +1,6 @@
-from .variable import Variable
 from slither.core.children.child_contract import ChildContract
-from slither.utils.type import export_nested_types_from_variable
+from .variable import Variable
+
 
 class StateVariable(ChildContract, Variable):
 
@@ -16,31 +16,6 @@ class StateVariable(ChildContract, Variable):
         """
         return self.contract == contract
 
-
-    ###################################################################################
-    ###################################################################################
-    # region Signature
-    ###################################################################################
-    ###################################################################################
-
-    @property
-    def signature(self):
-        """
-            Return the signature of the state variable as a function signature
-            :return: (str, list(str), list(str)), as (name, list parameters type, list return values type)
-        """
-        return self.name, [str(x) for x in export_nested_types_from_variable(self)], self.type
-
-    @property
-    def signature_str(self):
-        """
-            Return the signature of the state variable as a function signature
-            :return: str: func_name(type1,type2) returns(type3)
-        """
-        name, parameters, returnVars = self.signature
-        return name+'('+','.join(parameters)+') returns('+','.join(returnVars)+')'
-
-    # endregion
     ###################################################################################
     ###################################################################################
     # region Name

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -97,7 +97,7 @@ def _extract_constant_functions(slither: Slither) -> Dict[str, List[str]]:
     ret: Dict[str, List[str]] = {}
     for contract in slither.contracts:
         cst_functions = [_get_name(f) for f in contract.functions_entry_points if _is_constant(f)]
-        cst_functions += [v.function_name for v in contract.state_variables if v.visibility in ['public']]
+        cst_functions += [v.solidity_signature for v in contract.state_variables if v.visibility in ['public']]
         if cst_functions:
             ret[contract.name] = cst_functions
     return ret

--- a/slither/printers/summary/function_ids.py
+++ b/slither/printers/summary/function_ids.py
@@ -24,14 +24,19 @@ class FunctionIds(AbstractPrinter):
         all_tables = []
         for contract in self.slither.contracts_derived:
             txt += '\n{}:\n'.format(contract.name)
-            table = MyPrettyTable(['Name', 'ID'])
+            table = MyPrettyTable(['Solidity Signature', 'ID', 'Return types'])
             for function in contract.functions:
                 if function.visibility in ['public', 'external']:
-                    table.add_row([function.solidity_signature, hex(get_function_id(function.solidity_signature))])
+                    _, _, returns = function.signature
+                    table.add_row([function.solidity_signature,
+                                   hex(get_function_id(function.solidity_signature)),
+                                   ','.join(returns)])
             for variable in contract.state_variables:
                 if variable.visibility in ['public']:
-                    sig = variable.function_name
-                    table.add_row([sig, hex(get_function_id(sig))])
+                    _, _, returns = variable.signature
+                    table.add_row([variable.solidity_signature,
+                                   hex(get_function_id(variable.solidity_signature)),
+                                   ','.join(returns)])
             txt += str(table) + '\n'
             all_tables.append((contract.name, table))
 

--- a/slither/tools/erc_conformance/erc/ercs.py
+++ b/slither/tools/erc_conformance/erc/ercs.py
@@ -46,7 +46,7 @@ def _check_signature(erc_function, contract, ret):
             ret["missing_function"].append(missing_func.data)
             return
 
-        function_return_type = [export_return_type_from_variable(state_variable_as_function)]
+        function_return_type = export_return_type_from_variable(state_variable_as_function)
 
         function_view = True
     else:

--- a/slither/utils/type.py
+++ b/slither/utils/type.py
@@ -1,26 +1,53 @@
-from slither.core.solidity_types import (ArrayType, MappingType, ElementaryType)
+import math
+from typing import Union, List
+
+from slither.core.solidity_types import (ArrayType, MappingType, ElementaryType, UserDefinedType, FunctionType)
+from slither.core.solidity_types.type import Type
+from slither.core.variables.variable import Variable
 
 
-def _add_mapping_parameter(t, l):
+def _add_mapping_parameter(t: Type, l: List[Type]):
     while isinstance(t, MappingType):
-        l.append(t.type_from)
+        l.append(convert_type_for_solidity_signature(t.type_from))
         t = t.type_to
-    _add_array_parameter(t, l)
+
+    if isinstance(t, ArrayType):
+        _add_array_parameter(t, l)
 
 
-def _add_array_parameter(t, l):
+def _add_array_parameter(t: Type, l: List[Type]):
     while isinstance(t, ArrayType):
-        l.append(ElementaryType('uint256'))
+        l.append(ElementaryType("uint256"))
         t = t.type
 
+    if isinstance(t, MappingType):
+        _add_mapping_parameter(t, l)
 
-def export_nested_types_from_variable(variable):
+
+def convert_type_for_solidity_signature(t: Type) -> Type:
+    from slither.core.declarations import Contract, Enum
+    if isinstance(t, UserDefinedType) and isinstance(t.type, Contract):
+        return ElementaryType("address")
+    if isinstance(t, UserDefinedType) and isinstance(t.type, Enum):
+        number_values = len(t.type.values)
+        # IF below 65536, avoid calling log2
+        if number_values <= 256:
+            uint = "8"
+        elif number_values <= 65536:
+            uint = "16"
+        else:
+            uint = int(math.log2(number_values))
+        return ElementaryType(f"uint{uint}")
+    return t
+
+
+def export_nested_types_from_variable(variable: Variable) -> List[Type]:
     """
     Export the list of nested types (mapping/array)
     :param variable:
     :return: list(Type)
     """
-    l = []
+    l: List[Type] = []
     if isinstance(variable.type, MappingType):
         t = variable.type
         _add_mapping_parameter(t, l)
@@ -32,24 +59,52 @@ def export_nested_types_from_variable(variable):
     return l
 
 
-def export_return_type_from_variable(variable):
+def export_return_type_from_variable(variable_or_type: Union[Type, Variable], all_types: bool = True) -> List[Type]:
     """
-    Return the type returned by a variable
-    :param variable
+    Return the type returned by a variable.
+    If all_types set to false, filter array/mapping. This is useful as the mapping/array in a structure are not
+    returned by solidity
+
+    :param variable_or_type
+    :param all_types
     :return: Type
     """
-    if isinstance(variable, MappingType):
-        return export_return_type_from_variable(variable.type_to)
+    from slither.core.declarations import Structure
 
-    if isinstance(variable, ArrayType):
-        return variable.type
+    if isinstance(variable_or_type, Type):
+        if isinstance(variable_or_type, MappingType):
+            if not all_types:
+                return []
+            return export_return_type_from_variable(variable_or_type.type_to)
 
-    if isinstance(variable.type, MappingType):
-        return export_return_type_from_variable(variable.type.type_to)
+        if isinstance(variable_or_type, ArrayType):
+            if not all_types:
+                return []
+            return export_return_type_from_variable(variable_or_type.type)
 
-    if isinstance(variable.type, ArrayType):
-        return variable.type.type
+        if isinstance(variable_or_type, UserDefinedType) and isinstance(variable_or_type.type, Structure):
+            ret = []
+            for r in variable_or_type.type.elems_ordered:
+                ret += export_return_type_from_variable(r, all_types=False)
 
-    return variable.type
+            return ret
 
+        return [variable_or_type]
+    else:
+        if isinstance(variable_or_type.type, MappingType):
+            if not all_types:
+                return []
+            return export_return_type_from_variable(variable_or_type.type.type_to)
 
+        if isinstance(variable_or_type.type, ArrayType):
+            if not all_types:
+                return []
+            return export_return_type_from_variable(variable_or_type.type.type)
+
+        if isinstance(variable_or_type.type, UserDefinedType) and isinstance(variable_or_type.type.type, Structure):
+            ret = []
+            for r in variable_or_type.type.type.elems_ordered:
+                ret += export_return_type_from_variable(r, all_types=False)
+            return ret
+
+        return [variable_or_type.type]


### PR DESCRIPTION
- Remove variable.function_name
- Move state_variable.signature / signature_str to variable
- Add variable.solidity_signature
- Add better support for complex types in utils.type

Additionally, the function-id printer will now show the return types

Fix #482

Example:
```solidity
pragma experimental ABIEncoderV2;

contract A{}

contract C{

	mapping(uint => address)[] public arrayOfMappings;

	mapping(uint => address[]) public normalMappingArrayField;

	enum State{a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32,a33,a34,a35,a36,a37,a38,a39,a40,a41,a42,a43,a44,a45,a46,a47,a48,a49,a50,a51,a52,a53,a54,a55,a56,a57,a58,a59,a60,a61,a62,a63,a64,a65,a66,a67,a68,a69,a70,a71,a72,a73,a74,a75,a76,a77,a78,a79,a80,a81,a82,a83,a84,a85,a86,a87,a88,a89,a90,a91,a92,a93,a94,a95,a96,a97,a98,a99,a100,a101,a102,a103,a104,a105,a106,a107,a108,a109,a110,a111,a112,a113,a114,a115,a116,a117,a118,a119,a120,a121,a122,a123,a124,a125,a126,a127,a128,a129,a130,a131,a132,a133,a134,a135,a136,a137,a138,a139,a140,a141,a142,a143,a144,a145,a146,a147,a148,a149,a150,a151,a152,a153,a154,a155,a156,a157,a158,a159,a160,a161,a162,a163,a164,a165,a166,a167,a168,a169,a170,a171,a172,a173,a174,a175,a176,a177,a178,a179,a180,a181,a182,a183,a184,a185,a186,a187,a188,a189,a190,a191,a192,a193,a194,a195,a196,a197,a198,a199,a200,a201,a202,a203,a204,a205,a206,a207,a208,a209,a210,a211,a212,a213,a214,a215,a216,a217,a218,a219,a220,a221,a222,a223,a224,a225,a226,a227,a228,a229,a230,a231,a232,a233,a234,a235,a236,a237,a238,a239,a240,a241,a242,a243,a244,a245,a246,a247,a248,a249,a250,a251,a252,a253,a254,a255,a256}
	mapping(State => uint) public stateMap;

	mapping(A => uint) public contractMap;

	uint[][] public multiDimensionalArray;

	struct Simple {
	    uint a;
	    uint b;
	    mapping(uint => uint) c;
	    uint[] d;
	    function(uint) external returns (uint) e;
	}

	Simple public simple;

	struct Inner {
	    uint a;
	    uint b;
	}

	struct Outer {
	    Inner inner;
	    uint c;
	}

	Outer public outer;
}
```
```
+------------------------------------------+------------+----------------------------------------------------+
|            Solidity Signature            |     ID     |                    Return types                    |
+------------------------------------------+------------+----------------------------------------------------+
|     arrayOfMappings(uint256,uint256)     | 0x98fc2aa5 |                      address                       |
| normalMappingArrayField(uint256,uint256) | 0x9539e3c8 |                      address                       |
|             stateMap(uint16)             | 0x5a20851f |                      uint256                       |
|           contractMap(address)           | 0x3c0af344 |                      uint256                       |
|  multiDimensionalArray(uint256,uint256)  | 0xf29872a8 |                      uint256                       |
|                 simple()                 | 0xdf201a46 | uint256,uint256,function(uint256) returns(uint256) |
|                 outer()                  | 0x87c3dbb6 |              uint256,uint256,uint256               |
+------------------------------------------+------------+----------------------------------------------------+
```