### PR TITLE
Fixed numpy error while running slither-simil test command

### DIFF
--- a/slither/tools/similarity/cache.py
+++ b/slither/tools/similarity/cache.py
@@ -9,7 +9,7 @@ except ImportError:
 
 def load_cache(infile, nsamples=None):
     cache = dict()
-    with np.load(infile) as data:
+    with np.load(infile, allow_pickle=True) as data:
         array = data['arr_0'][0]
         for i,(x,y) in enumerate(array):
             cache[x] = y


### PR DESCRIPTION
There was a numpy error while trying to run `slither-simil test` on a contract.
Changed the value for the argument `allow_pickle` in `numpy.load` from `False` to `True`.