### PR TITLE
Add support for top level structures and enums

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -51,6 +51,8 @@ class Contract(ChildSlither, SourceMapping):
         self._is_upgradeable = None
         self._is_upgradeable_proxy = None
 
+        self._is_top_level = False
+
 
         self._initial_state_variables = [] # ssa
 
@@ -934,6 +936,19 @@ class Contract(ChildSlither, SourceMapping):
         :return:
         """
         return self._is_incorrectly_parsed
+
+    @property
+    def is_top_level(self) -> bool:
+        """
+        The "TopLevel" contract is used to hold structures and enums defined at the top level
+        ie. structures and enums that are represented outside of any contract
+        :return:
+        """
+        return self._is_top_level
+
+    @is_top_level.setter
+    def is_top_level(self, t: bool):
+        self._is_top_level = t
 
     # endregion
     ###################################################################################


### PR DESCRIPTION
- Internally create a contract named SlitherInternalTopLevelContractX per structure / enum
- Warm if user has a contract named SlitherInternalTopLevelContract

Fix #487