### PR TITLE
Implement support for calculating storage layout

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -54,7 +54,7 @@ class Contract(ChildSlither, SourceMapping):
         self._structures: Dict[str, "Structure"] = {}
         self._events: Dict[str, "Event"] = {}
         self._variables: Dict[str, "StateVariable"] = {}
-        self._variables_ordered: List["StateVariable"] = []  # contain also shadowed variables
+        self._variables_ordered: List["StateVariable"] = []
         self._modifiers: Dict[str, "Modifier"] = {}
         self._functions: Dict[str, "Function"] = {}
         self._linearizedBaseContracts = List[int]
@@ -255,7 +255,7 @@ class Contract(ChildSlither, SourceMapping):
     @property
     def state_variables_ordered(self) -> List["StateVariable"]:
         """
-            list(StateVariable): List of the state variables by order of declaration. Contains also shadowed variables
+            list(StateVariable): List of the state variables by order of declaration.
         """
         return list(self._variables_ordered)
 

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -7,7 +7,7 @@ import json
 import re
 import math
 from collections import defaultdict
-from typing import Optional, Dict, List, Set, Union
+from typing import Optional, Dict, List, Set, Union, Tuple
 
 from crytic_compile import CryticCompile
 
@@ -57,7 +57,7 @@ class SlitherCore(Context):
         self._contract_name_collisions = defaultdict(list)
         self._contract_with_missing_inheritance = set()
 
-        self._storage_layouts = {}
+        self._storage_layouts: Dict[str, Dict[str, Tuple[int, int]]] = {}
 
     ###################################################################################
     ###################################################################################
@@ -380,6 +380,6 @@ class SlitherCore(Context):
                 else:
                     offset += size
 
-    def storage_layout_of(self, contract, var):
+    def storage_layout_of(self, contract, var) -> Tuple[int, int]:
         return self._storage_layouts[contract.name][var.canonical_name]
     # endregion

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -5,6 +5,7 @@ import os
 import logging
 import json
 import re
+import math
 from collections import defaultdict
 from typing import Optional, Dict, List, Set, Union
 
@@ -55,6 +56,8 @@ class SlitherCore(Context):
 
         self._contract_name_collisions = defaultdict(list)
         self._contract_with_missing_inheritance = set()
+
+        self._storage_layouts = {}
 
     ###################################################################################
     ###################################################################################
@@ -344,4 +347,39 @@ class SlitherCore(Context):
     def contracts_with_missing_inheritance(self) -> Set:
         return self._contract_with_missing_inheritance
 
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Storage Layouts
+    ###################################################################################
+    ###################################################################################
+
+    def compute_storage_layout(self):
+        for contract in self.contracts_derived:
+            self._storage_layouts[contract.name] = {}
+
+            slot = 0
+            offset = 0
+            for var in contract.state_variables_ordered:
+                if var.is_constant:
+                    continue
+
+                size, new_slot = var.type.storage_size
+
+                if new_slot:
+                    if offset > 0:
+                        slot += 1
+                        offset = 0
+                elif size + offset > 32:
+                    slot += 1
+                    offset = 0
+
+                self._storage_layouts[contract.name][var.canonical_name] = (slot, offset)
+                if new_slot:
+                    slot += math.ceil(size / 32)
+                else:
+                    offset += size
+
+    def storage_layout_of(self, contract, var):
+        return self._storage_layouts[contract.name][var.canonical_name]
     # endregion

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Tuple
 
 from slither.core.expressions import Literal
 from slither.core.expressions.expression import Expression
@@ -38,7 +38,7 @@ class ArrayType(Type):
         return self._length_value
 
     @property
-    def storage_size(self):
+    def storage_size(self) -> Tuple[int, bool]:
         if self._length_value:
             elem_size, _ = self._type.storage_size
             return elem_size * int(self._length_value.value), True

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -37,6 +37,13 @@ class ArrayType(Type):
     def lenght_value(self) -> Optional[Literal]:
         return self._length_value
 
+    @property
+    def storage_size(self):
+        if self._length_value:
+            elem_size, _ = self._type.storage_size
+            return elem_size * int(self._length_value.value), True
+        return 32, True
+
     def __str__(self):
         if self._length:
             return str(self._type) + "[{}]".format(str(self._length_value))

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -172,6 +172,13 @@ class ElementaryType(Type):
             return int(t[len("bytes") :])
         return None
 
+    @property
+    def storage_size(self):
+        if self._type == 'string' or self._type == 'bytes':
+            return 32, True
+
+        return int(self.size / 8), False
+
     def __str__(self):
         return self._type
 

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Optional
+from typing import Optional, Tuple
 
 from slither.core.solidity_types.type import Type
 
@@ -173,7 +173,7 @@ class ElementaryType(Type):
         return None
 
     @property
-    def storage_size(self):
+    def storage_size(self) -> Tuple[int, bool]:
         if self._type == 'string' or self._type == 'bytes':
             return 32, True
 

--- a/slither/core/solidity_types/function_type.py
+++ b/slither/core/solidity_types/function_type.py
@@ -26,6 +26,10 @@ class FunctionType(Type):
     def return_type(self) -> List[Type]:
         return [x.type for x in self.return_values]
 
+    @property
+    def storage_size(self):
+        return 24, False
+
     def __str__(self):
         # Use x.type
         # x.name may be empty

--- a/slither/core/solidity_types/function_type.py
+++ b/slither/core/solidity_types/function_type.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from slither.core.solidity_types.type import Type
 from slither.core.variables.function_type_variable import FunctionTypeVariable
@@ -27,7 +27,7 @@ class FunctionType(Type):
         return [x.type for x in self.return_values]
 
     @property
-    def storage_size(self):
+    def storage_size(self) -> Tuple[int, bool]:
         return 24, False
 
     def __str__(self):

--- a/slither/core/solidity_types/mapping_type.py
+++ b/slither/core/solidity_types/mapping_type.py
@@ -17,6 +17,10 @@ class MappingType(Type):
     def type_to(self) -> Type:
         return self._to
 
+    @property
+    def storage_size(self):
+        return 32, True
+
     def __str__(self):
         return "mapping({} => {})".format(str(self._from), str(self._to))
 

--- a/slither/core/solidity_types/mapping_type.py
+++ b/slither/core/solidity_types/mapping_type.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 from slither.core.solidity_types.type import Type
 
 
@@ -18,7 +20,7 @@ class MappingType(Type):
         return self._to
 
     @property
-    def storage_size(self):
+    def storage_size(self) -> Tuple[int, bool]:
         return 32, True
 
     def __str__(self):

--- a/slither/core/solidity_types/type.py
+++ b/slither/core/solidity_types/type.py
@@ -1,5 +1,15 @@
+import abc
+from typing import Tuple
+
 from slither.core.source_mapping.source_mapping import SourceMapping
 
+class Type(SourceMapping,metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def storage_size(self) -> Tuple[int, bool]:
+        """
+        Computes and returns storage layout related metadata
 
-class Type(SourceMapping):
-    pass
+        :return: (int, bool) - the number of bytes this type will require, and whether it must start in
+        a new slot regardless of whether the current slot can still fit it
+        """

--- a/slither/core/solidity_types/user_defined_type.py
+++ b/slither/core/solidity_types/user_defined_type.py
@@ -1,4 +1,4 @@
-from typing import Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING, Tuple
 import math
 
 from slither.core.solidity_types.type import Type
@@ -24,7 +24,7 @@ class UserDefinedType(Type):
         return self._type
 
     @property
-    def storage_size(self):
+    def storage_size(self) -> Tuple[int, bool]:
         from slither.core.declarations.structure import Structure
         from slither.core.declarations.enum import Enum
         from slither.core.declarations.contract import Contract

--- a/slither/printers/summary/variable_order.py
+++ b/slither/printers/summary/variable_order.py
@@ -26,10 +26,11 @@ class VariableOrder(AbstractPrinter):
 
         for contract in self.slither.contracts_derived:
             txt += '\n{}:\n'.format(contract.name)
-            table = MyPrettyTable(['Name', 'Type'])
+            table = MyPrettyTable(['Name', 'Type', 'Slot', 'Offset'])
             for variable in contract.state_variables_ordered:
                 if not variable.is_constant:
-                    table.add_row([variable.canonical_name, str(variable.type)])
+                    slot, offset = self.slither.storage_layout_of(contract, variable)
+                    table.add_row([variable.canonical_name, str(variable.type), slot, offset])
 
             all_tables.append((contract.name, table))
             txt += str(table) + '\n'

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -277,7 +277,8 @@ class ContractSolc:
     def parse_state_variables(self):
         for father in self._contract.inheritance_reverse:
             self._contract.variables_as_dict.update(father.variables_as_dict)
-            self._contract.add_variables_ordered(father.state_variables_ordered)
+            self._contract.add_variables_ordered(
+                [var for var in father.state_variables_ordered if var not in self._contract.state_variables_ordered])
 
         for varNotParsed in self._variablesNotParsed:
             var = StateVariable()

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -344,6 +344,7 @@ Please rename it, this name is reserved for Slither's internals"""
         self._convert_to_slithir()
 
         compute_dependency(self._core)
+        self._core.compute_storage_layout()
 
     def _analyze_all_enums(self, contracts_to_be_analyzed: List[ContractSolc]):
         while contracts_to_be_analyzed:


### PR DESCRIPTION
Since some contracts can be extended by more than one derived contract, storage layout information can't be stored in the state variable itself.

Also, `state_variables_ordered` had duplicates which seemed kinda weird so I "fixed" that.

Tested by reading [this doc](https://github.com/ethereum/solidity/blob/develop/docs/internals/layout_in_storage.rst) and comparing the output with `solc --storage-layout`, but some automated tests would probably be nice