### PR TITLE
Improve type support for tuple 

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -115,11 +115,14 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 set_val(expression, None)
             else:
                 assert isinstance(right, TupleVariable)
+                tuple_types = []
                 for idx in range(len(left)):
                     if not left[idx] is None:
                         operation = Unpack(left[idx], right, idx)
                         operation.set_expression(expression)
+                        tuple_types.append(left[idx].type)
                         self._result.append(operation)
+                right.set_type(tuple_types)
                 set_val(expression, None)
         else:
             # Init of array, like


### PR DESCRIPTION
Use the type of the left variables to deduce the types of the tuple variables during the expression -> slithIR conversion.

This might not be enough if the types of the left variables are unknown at this step, but I am not sure that this situation can happen for tuples.

Fix #529

