### PR TITLE
Fix incorrect tuple type in case of low level call

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -763,7 +763,10 @@ def convert_to_low_level(ir):
         new_ir.call_gas = ir.call_gas
         new_ir.call_value = ir.call_value
         new_ir.arguments = ir.arguments
-        new_ir.lvalue.set_type(ElementaryType('bool'))
+        if ir.slither.solc_version >= "0.5":
+            new_ir.lvalue.set_type([ElementaryType('bool'), ElementaryType('bytes')])
+        else:
+            new_ir.lvalue.set_type(ElementaryType('bool'))
         new_ir.set_expression(ir.expression)
         new_ir.set_node(ir.node)
         return new_ir

--- a/slither/slithir/operations/low_level_call.py
+++ b/slither/slithir/operations/low_level_call.py
@@ -95,9 +95,14 @@ class LowLevelCall(Call, OperationWithLValue):
         arguments = []
         if self.arguments:
             arguments = self.arguments
+        return_type = self.lvalue.type
+
+        if return_type and isinstance(return_type, list):
+            return_type = ','.join(str(x) for x in return_type)
+
         txt = '{}({}) = LOW_LEVEL_CALL, dest:{}, function:{}, arguments:{} {} {}'
         return txt.format(self.lvalue,
-                          self.lvalue.type,
+                          return_type,
                           self.destination,
                           self.function_name,
                           [str(x) for x in arguments],

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -115,14 +115,11 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 set_val(expression, None)
             else:
                 assert isinstance(right, TupleVariable)
-                tuple_types = []
                 for idx in range(len(left)):
                     if not left[idx] is None:
                         operation = Unpack(left[idx], right, idx)
                         operation.set_expression(expression)
-                        tuple_types.append(left[idx].type)
                         self._result.append(operation)
-                right.set_type(tuple_types)
                 set_val(expression, None)
         else:
             # Init of array, like


### PR DESCRIPTION
The incorrect tuple types were only present for low level calls with solidity >= 0.5 (low level call return a tuple instead of a bool from 0.5)

Fix #529
Replace #536

Tested with
```solidity
library Lib{

    function t() public returns(uint, bool){

    }
}

contract Tuple {

  function f()
    public
  {
    bool success;
    address dest;
    bytes memory returnValue;
    (success, returnValue) = dest.call("");
  }

  function get() internal returns(uint, bool);

  function test() public{
        uint a;
        bool b;
        (a,b) = get();

        (a,b) = Lib.t();
  }

}

```
```
Contract Tuple	Function Tuple.f() (*)
		Expression: (success,returnValue) = dest.call()
		IRs:
			TUPLE_0(bool,bytes) = LOW_LEVEL_CALL, dest:dest, function:call, arguments:['']  
			success(bool)= UNPACK TUPLE_0 index: 0 
			returnValue(bytes)= UNPACK TUPLE_0 index: 1 
	Function Tuple.get() (*)
	Function Tuple.test() (*)
		Expression: (a,b) = get()
		IRs:
			TUPLE_1(uint256,bool) = INTERNAL_CALL, Tuple.get()()
			a(uint256)= UNPACK TUPLE_1 index: 0 
			b(bool)= UNPACK TUPLE_1 index: 1 
		Expression: (a,b) = Lib.t()
		IRs:
			TUPLE_2(uint256,bool) = LIBRARY_CALL, dest:Lib, function:t, arguments:[] 
			a(uint256)= UNPACK TUPLE_2 index: 0 
			b(bool)= UNPACK TUPLE_2 index: 1 

```