### PR TITLE
Add storage_size for TypeInformation

### DIFF
--- a/slither/core/solidity_types/type_information.py
+++ b/slither/core/solidity_types/type_information.py
@@ -20,6 +20,18 @@ class TypeInformation(Type):
     def type(self) -> "Contract":
         return self._type
 
+    @property
+    def storage_size(self) -> Tuple[int, bool]:
+        """
+        32 is incorrect, as Type(x) return a kind of structure that can contain
+        an arbitrary number of value
+        As Type(x) cannot be directly stored, we are assuming that the correct storage size
+        will be handled by the fields access
+
+        :return:
+        """
+        return 32, True
+
     def __str__(self):
         return f"type({self.type.name})"
 

--- a/slither/core/solidity_types/type_information.py
+++ b/slither/core/solidity_types/type_information.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 from slither.core.solidity_types.type import Type
 


### PR DESCRIPTION
The type was missing in https://github.com/crytic/slither/pull/507