### PR TITLE
Fix missing str conversion on reentrancy event

### DIFF
--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -78,7 +78,7 @@ If `d.()` reenters, the `Counter` events will be showed in an incorrect order, w
         for (func, calls, send_eth), events in result_sorted:
             calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
             send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
-            events = sorted(events, key=lambda x: (x.variable.name, x.node.node_id))
+            events = sorted(events, key=lambda x: (str(x.variable.name), x.node.node_id))
 
             info = ['Reentrancy in ', func, ':\n']
             info += ['\tExternal calls:\n']


### PR DESCRIPTION
`variable.name` is now a `Constant`, which lacks the ordering operator