### PR TITLE
Improve support for type()

### DIFF
--- a/slither/core/declarations/solidity_variables.py
+++ b/slither/core/declarations/solidity_variables.py
@@ -66,6 +66,7 @@ SOLIDITY_FUNCTIONS: Dict[str, List[str]] = {
     # abi.decode returns an a list arbitrary types
     "abi.decode()": [],
     "type(address)": [],
+    "type()": [], # 0.6.8 changed type(address) to type()
 }
 
 

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -581,7 +581,7 @@ def propagate_types(ir, node):
             elif isinstance(ir, Send):
                 ir.lvalue.set_type(ElementaryType('bool'))
             elif isinstance(ir, SolidityCall):
-                if ir.function.name == 'type(address)':
+                if ir.function.name in ['type(address)', 'type()']:
                     ir.function.return_type = [TypeInformation(ir.arguments[0])]
                 return_type = ir.function.return_type
                 if len(return_type) == 1:


### PR DESCRIPTION
Solidity 0.6.8 changed the function signature from `type(address)`  to `type()` 

Fix #547

