### PR TITLE
Resolve state variables in Yul

### DIFF
--- a/slither/solc_parsing/yul/parse_yul.py
+++ b/slither/solc_parsing/yul/parse_yul.py
@@ -611,6 +611,10 @@ def parse_yul_identifier(root: YulScope, node: YulNode, ast: Dict) -> Optional[E
         if variable:
             return Identifier(variable)
 
+        variable = root.parent_func.contract.get_state_variable_from_name(name)
+        if variable:
+            return Identifier(variable)
+
     # check yul-scoped variable
     variable = root.get_yul_local_variable_from_name(name)
     if variable:


### PR DESCRIPTION
Forgot to check state variables during resolution. Fixes #574.

Testcase:
```solidity
contract Parent {
    uint internal constant a = 5;
}

contract Child is Parent {
    function test() public view returns (uint x) {
        assembly {
            x := a
        }
    }
}
```