### PR TITLE
Fix incorrect types to list conversion

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1040,6 +1040,29 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
         for v in return_type.type.elems_ordered:
             ret += _convert_to_structure_to_list(v.type)
         return ret
+    # Mapping and arrays are not included in external call
+    #
+    # contract A{
+    #
+    #     struct St{
+    #         uint a;
+    #         uint b;
+    #         mapping(uint => uint) map;
+    #         uint[] array;
+    #     }
+    #
+    #     mapping (uint => St) public st;
+    #
+    # }
+    #
+    # contract B{
+    #
+    #     function f(A a) public{
+    #         (uint a, uint b) = a.st(0);
+    #     }
+    # }
+    if isinstance(return_type, (MappingType, ArrayType)):
+        return []
     return [return_type.type]
 
 


### PR DESCRIPTION
The tuple resulting from a high level calls to a structure, where the structure has mapping or array will not contain the mapping or array.

Example
```solidity
contract A{

    struct St{
        uint a;
        uint b;
        mapping(uint => uint) map;
        uint[] array;
    }

    mapping (uint => St) public st;
    
}

contract B{

    function f(A a) public{
        (uint a, uint b) = a.st(0);
    }
}

```