### PR TITLE
Update solc recommended versions

### DIFF
--- a/scripts/travis_test_embark.sh
+++ b/scripts/travis_test_embark.sh
@@ -17,7 +17,7 @@ cd embark_demo || exit 255
 npm install
 slither . --embark-overwrite-config
 
-if [ $? -eq 3 ]
+if [ $? -eq 4 ]
 then
     exit 0
 fi

--- a/scripts/travis_test_etherlime.sh
+++ b/scripts/travis_test_etherlime.sh
@@ -15,7 +15,7 @@ npm i -g etherlime
 etherlime init
 slither .
 
-if [ $? -eq 6 ]
+if [ $? -eq 7 ]
 then
     exit 0
 fi

--- a/scripts/travis_test_truffle.sh
+++ b/scripts/travis_test_truffle.sh
@@ -15,7 +15,7 @@ npm install -g truffle
 truffle unbox metacoin
 slither .
 
-if [ $? -eq 5 ]
+if [ $? -eq 8 ]
 then
     exit 0
 fi

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -38,7 +38,8 @@ Deploy with any of the following Solidity versions:
 - 0.5.15 - 0.5.17,
 - 0.6.8,
 - 0.6.10 - 0.6.11.
-Consider using the latest version of Solidity for testing the compilation.'''
+Use a simple pragma version that allows any of these versions.
+Consider using the latest version of Solidity for testing.'''
 
     COMPLEX_PRAGMA_TXT = "is too complex"
     OLD_VERSION_TXT = "allows old versions"
@@ -121,7 +122,7 @@ Consider using the latest version of Solidity for testing the compilation.'''
                 if self.slither.crytic_compile.compiler_version.version not in self.ALLOWED_VERSIONS:
                     info = ["solc-",
                             self.slither.crytic_compile.compiler_version.version,
-                            " is not recommended for deployement"]
+                            " is not recommended for deployement\n"]
 
                     json = self.generate_result(info)
 

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -33,23 +33,25 @@ class IncorrectSolc(AbstractDetector):
 `solc` frequently releases new compiler versions. Using an old version prevents access to new Solidity security checks.
 We also recommend avoiding complex `pragma` statement.'''
     WIKI_RECOMMENDATION = '''
-Use Solidity 0.4.25 or 0.5.11. Consider using the latest version of Solidity for testing the compilation, and a trusted version for deploying.'''
+Use Solidity 0.5.11 - 0.5.13, 0.5.15-0.5.17, or 0.6.8, 0.6.10-0.6.11.
+Consider using the latest version of Solidity for testing the compilation, and a trusted version for deploying.'''
 
     COMPLEX_PRAGMA_TXT = "is too complex"
     OLD_VERSION_TXT = "allows old versions"
     LESS_THAN_TXT = "uses lesser than"
 
-    TOO_RECENT_VERSION_TXT = "necessitates versions too recent to be trusted. Consider deploying with 0.5.11"
-    BUGGY_VERSION_TXT = "is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)"
+    TOO_RECENT_VERSION_TXT = "necessitates a version too recent to be trusted. Consider deploying with 0.6.11"
+    BUGGY_VERSION_TXT = "is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)"
 
     # Indicates the allowed versions. Must be formatted in increasing order.
-    ALLOWED_VERSIONS = ["0.4.25", "0.4.26", "0.5.11"]
+    ALLOWED_VERSIONS = ["0.5.11", "0.5.12", "0.5.13", "0.5.15", "0.5.16", "0.5.17", "0.6.8", "0.6.10", "0.6.11"]
 
     # Indicates the versions that should not be used.
     BUGGY_VERSIONS = ["0.4.22", "^0.4.22",
                       "0.5.5", "^0.5.5",
                       "0.5.6", "^0.5.6",
-                      "0.5.14", "^0.5.14"]
+                      "0.5.14", "^0.5.14",
+                      "0.6.9", "^0.6.9"]
 
     def _check_version(self, version):
         op = version[0]

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -33,8 +33,12 @@ class IncorrectSolc(AbstractDetector):
 `solc` frequently releases new compiler versions. Using an old version prevents access to new Solidity security checks.
 We also recommend avoiding complex `pragma` statement.'''
     WIKI_RECOMMENDATION = '''
-Use Solidity 0.5.11 - 0.5.13, 0.5.15-0.5.17, or 0.6.8, 0.6.10-0.6.11.
-Consider using the latest version of Solidity for testing the compilation, and a trusted version for deploying.'''
+Deploy with any of the following Solidity versions:
+- 0.5.11 - 0.5.13,
+- 0.5.15 - 0.5.17,
+- 0.6.8,
+- 0.6.10 - 0.6.11.
+Consider using the latest version of Solidity for testing the compilation.'''
 
     COMPLEX_PRAGMA_TXT = "is too complex"
     OLD_VERSION_TXT = "allows old versions"
@@ -111,6 +115,17 @@ Consider using the latest version of Solidity for testing the compilation, and a
                 json = self.generate_result(info)
 
                 results.append(json)
+
+        if self.slither.crytic_compile:
+            if self.slither.crytic_compile.compiler_version:
+                if self.slither.crytic_compile.compiler_version.version not in self.ALLOWED_VERSIONS:
+                    info = ["solc-",
+                            self.slither.crytic_compile.compiler_version.version,
+                            " is not recommended for deployement"]
+
+                    json = self.generate_result(info)
+
+                    results.append(json)
 
         return results
 

--- a/tests/expected_json/old_solc.sol.json.solc-version.txt
+++ b/tests/expected_json/old_solc.sol.json.solc-version.txt
@@ -3,4 +3,3 @@ Pragma version0.4.21 (None) allows old versions
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
 tests/old_solc.sol.json analyzed (1 contracts with 1 detectors), 1 result(s) found
 [94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m
-INFO:Slither:[93m/home/travis/build/crytic/slither/scripts/../tests/expected_json/old_solc.sol.json.solc-version.json exists already, the overwrite is prevented[0m

--- a/tests/expected_json/solc_version_incorrect.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect.solc-version.json
@@ -80,9 +80,9 @@
       },
       {
         "elements": [],
-        "description": "solc-0.4.25 is not recommended for deployement",
-        "markdown": "solc-0.4.25 is not recommended for deployement",
-        "id": "3d2fbcb2fa2b79dac83c4860aea6ba0bfbf9128d2a982f465feb6846a692626b",
+        "description": "solc-0.4.25 is not recommended for deployement\n",
+        "markdown": "solc-0.4.25 is not recommended for deployement\n",
+        "id": "5a4264386059605a5ac36e3f7dbc853e89e337be5bfbd8b05a64964a81d73790",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/solc_version_incorrect.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect.solc-version.json
@@ -77,6 +77,15 @@
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"
+      },
+      {
+        "elements": [],
+        "description": "solc-0.4.25 is not recommended for deployement",
+        "markdown": "solc-0.4.25 is not recommended for deployement",
+        "id": "3d2fbcb2fa2b79dac83c4860aea6ba0bfbf9128d2a982f465feb6846a692626b",
+        "check": "solc-version",
+        "impact": "Informational",
+        "confidence": "High"
       }
     ]
   }

--- a/tests/expected_json/solc_version_incorrect.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect.solc-version.txt
@@ -1,6 +1,7 @@
 [92m
 Pragma version^0.4.23 (tests/solc_version_incorrect.sol#2) allows old versions
 Pragma version>=0.4.0<0.6.0 (tests/solc_version_incorrect.sol#3) allows old versions
-solc-0.4.25 is not recommended for deployementReference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
+solc-0.4.25 is not recommended for deployement
+Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
 tests/solc_version_incorrect.sol analyzed (1 contracts with 1 detectors), 3 result(s) found
 [94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m

--- a/tests/expected_json/solc_version_incorrect.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect.solc-version.txt
@@ -1,6 +1,6 @@
 [92m
 Pragma version^0.4.23 (tests/solc_version_incorrect.sol#2) allows old versions
 Pragma version>=0.4.0<0.6.0 (tests/solc_version_incorrect.sol#3) allows old versions
-Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
-tests/solc_version_incorrect.sol analyzed (1 contracts with 1 detectors), 2 result(s) found
+solc-0.4.25 is not recommended for deployementReference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
+tests/solc_version_incorrect.sol analyzed (1 contracts with 1 detectors), 3 result(s) found
 [94mUse https://crytic.io/ to get access to additional detectors and Github integration[0m

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.json
@@ -30,9 +30,9 @@
             }
           }
         ],
-        "description": "Pragma version^0.5.5 (None) is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)\n",
-        "markdown": "Pragma version[^0.5.5](None) is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)\n",
-        "id": "fa84bcbd40d52d8846dcd54be4cada287e43c5461898c9acbf089ca8a478f6e5",
+        "description": "Pragma version^0.5.5 (None) is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n",
+        "markdown": "Pragma version[^0.5.5](None) is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)\n",
+        "id": "b27987b5c734b3ac9a18d3aef5c96a20911b71fb0ffd8d222a1052252fea4151",
         "check": "solc-version",
         "impact": "Informational",
         "confidence": "High"

--- a/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
+++ b/tests/expected_json/solc_version_incorrect_05.ast.json.solc-version.txt
@@ -1,5 +1,5 @@
 [92m
-Pragma version^0.5.5 (None) is known to contain severe issue (https://solidity.readthedocs.io/en/v0.5.8/bugs.html)
+Pragma version^0.5.5 (None) is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
 Pragma version0.5.7 (None) allows old versions
 Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity[0m
 tests/solc_version_incorrect_05.ast.json analyzed (1 contracts with 1 detectors), 2 result(s) found


### PR DESCRIPTION
New versions recommended:
- 0.5.11 - 0.5.13
- 0.5.15 - 0.5.17
- 0.6.8
- 0.6.10 - 0.6.11
 
Additionally the text generated with the issue was improved. This will lead to prevent previously triaged `solc-version` issues to not be recognized.

Fix #57