### PR TITLE
Fixing DOS large exponent in scientific notation constants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ See the [Printer documentation](https://github.com/crytic/slither/wiki/Printer-d
 - `slither-check-upgradeability`: [Review `delegatecall`-based upgradeability](https://github.com/crytic/slither/wiki/Upgradeability-Checks)
 - `slither-prop`: [Automatic unit tests and properties generation](https://github.com/crytic/slither/wiki/Properties-generation)
 - `slither-flat`: [Flatten a codebase](https://github.com/crytic/slither/wiki/Contract-Flattening)
-- `slither-erc`: [Check the ERC's conformance](https://github.com/crytic/slither/wiki/ERC-Conformance)
+- `slither-check-erc`: [Check the ERC's conformance](https://github.com/crytic/slither/wiki/ERC-Conformance)
 - `slither-format`: [Automatic patches generation](https://github.com/crytic/slither/wiki/Slither-format)
 
 See the [Tool documentation](https://github.com/crytic/slither/wiki/Tool-Documentation) for additional tools.

--- a/slither/slithir/variables/constant.py
+++ b/slither/slithir/variables/constant.py
@@ -34,7 +34,7 @@ class Constant(SlithIRVariable):
                             else:
                                 self._val = 0
                         else:
-                            self._val = int(Decimal(base) * (10 ** expo))
+                            self._val = int(Decimal(base) * Decimal(10 ** expo))
                     else:
                         self._val = int(Decimal(val))
             elif type.type == 'bool':

--- a/slither/slithir/variables/constant.py
+++ b/slither/slithir/variables/constant.py
@@ -25,18 +25,16 @@ class Constant(SlithIRVariable):
                 if val.startswith('0x') or val.startswith('0X'):
                     self._val = int(val, 16)
                 else:
-                    if 'e' in val:
-                        base, expo = val.split('e')
-                        expo = int(expo)
+                    if 'e' in val or 'E' in val:
+                        base, expo = val.split('e') if 'e' in val else val.split('E')
+                        base, expo = Decimal(base), int(expo)
                         if expo > 80:
-                            raise ValueError("exponent is too large to fit in any Solidity integer size")
-                        self._val = int(Decimal(base) * (10 ** expo))
-                    elif 'E' in val:
-                        base, expo = val.split('E')
-                        expo = int(expo)
-                        if expo > 80:
-                            raise ValueError("exponent is too large to fit in any Solidity integer size")
-                        self._val = int(Decimal(base) * (10 ** expo)) 
+                            if base != Decimal(0):
+                                raise ValueError("exponent is too large to fit in any Solidity integer size")
+                            else:
+                                self._val = 0
+                        else:
+                            self._val = int(Decimal(base) * (10 ** expo))
                     else:
                         self._val = int(Decimal(val))
             elif type.type == 'bool':

--- a/slither/slithir/variables/constant.py
+++ b/slither/slithir/variables/constant.py
@@ -27,10 +27,16 @@ class Constant(SlithIRVariable):
                 else:
                     if 'e' in val:
                         base, expo = val.split('e')
-                        self._val = int(Decimal(base) * (10 ** int(expo)))
+                        expo = int(expo)
+                        if expo > 80:
+                            raise ValueError("exponent is too large to fit in any Solidity integer size")
+                        self._val = int(Decimal(base) * (10 ** expo))
                     elif 'E' in val:
                         base, expo = val.split('E')
-                        self._val = int(Decimal(base) * (10 ** int(expo)))
+                        expo = int(expo)
+                        if expo > 80:
+                            raise ValueError("exponent is too large to fit in any Solidity integer size")
+                        self._val = int(Decimal(base) * (10 ** expo)) 
                     else:
                         self._val = int(Decimal(val))
             elif type.type == 'bool':

--- a/slither/tools/erc_conformance/__main__.py
+++ b/slither/tools/erc_conformance/__main__.py
@@ -31,7 +31,7 @@ def parse_args():
     :return: Returns the arguments for the program.
     """
     parser = argparse.ArgumentParser(
-        description="Check the ERC 20 conformance", usage="slither-erc project contractName"
+        description="Check the ERC 20 conformance", usage="slither-check-erc project contractName"
     )
 
     parser.add_argument("project", help="The codebase to be tested.")


### PR DESCRIPTION
Fixes issue #579.

The issue was that slither was computing 10**HUGE_NUMBER eagerly in order to multiply it with the first part of the scientific notation.... which takes a while, and eats up lots of memory, because we're using bignums for this. I changed the behavior so that, if the first part is zero, just return zero. Otherwise, if the exponent is greater than 80, raise a ValueError, because there's no way the result will fit into a solidity integer type unless they're just writing it out in a really really troll-y way.

This will raise on something like `0.{80 zeros}1E80`. Not sure if solc supports that, but if we wanted to, we could add some sort of behavior with alternately multiplying the base by 10 and decrementing the exponent until it's zero... but that'd require some checks too to make sure the exponent isn't still too large.