### PR TITLE
[wip] solc parser rewrite

### DIFF
--- a/slither/core/expressions/assignment_operation.py
+++ b/slither/core/expressions/assignment_operation.py
@@ -26,7 +26,7 @@ class AssignmentOperationType(Enum):
     ASSIGN_MODULO = 10  # %=
 
     @staticmethod
-    def get_type(operation_type: "AssignmentOperationType"):
+    def get_type(operation_type: str):
         if operation_type == "=":
             return AssignmentOperationType.ASSIGN
         if operation_type == "|=":

--- a/slither/core/expressions/binary_operation.py
+++ b/slither/core/expressions/binary_operation.py
@@ -41,7 +41,7 @@ class BinaryOperationType(Enum):
     RIGHT_SHIFT_ARITHMETIC = 23
 
     @staticmethod
-    def get_type(operation_type: "BinaryOperation"):  # pylint: disable=too-many-branches
+    def get_type(operation_type: str):  # pylint: disable=too-many-branches
         if operation_type == "**":
             return BinaryOperationType.POWER
         if operation_type == "*":

--- a/slither/solc_parsing/cfg/node.py
+++ b/slither/solc_parsing/cfg/node.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional
 
 from slither.core.cfg.node import Node
 from slither.core.cfg.node import NodeType
@@ -8,6 +8,7 @@ from slither.core.expressions.assignment_operation import (
 )
 from slither.core.expressions.identifier import Identifier
 from slither.solc_parsing.expressions.expression_parsing import parse_expression
+from slither.solc_parsing.types.types import Expression
 from slither.visitors.expression.find_calls import FindCalls
 from slither.visitors.expression.read_var import ReadVar
 from slither.visitors.expression.write_var import WriteVar
@@ -15,14 +16,14 @@ from slither.visitors.expression.write_var import WriteVar
 
 class NodeSolc:
     def __init__(self, node: Node):
-        self._unparsed_expression: Optional[Dict] = None
+        self._unparsed_expression: Optional[Expression] = None
         self._node = node
 
     @property
     def underlying_node(self) -> Node:
         return self._node
 
-    def add_unparsed_expression(self, expression: Dict):
+    def add_unparsed_expression(self, expression: Expression):
         assert self._unparsed_expression is None
         self._unparsed_expression = expression
 

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -10,22 +10,24 @@ from slither.core.declarations.function import (
 )
 
 from slither.core.expressions import AssignmentOperation
+from slither.core.source_mapping.source_mapping import SourceMapping
 from slither.core.variables.local_variable import LocalVariable
 from slither.core.variables.local_variable_init_from_tuple import LocalVariableInitFromTuple
-
 from slither.solc_parsing.cfg.node import NodeSolc
+from slither.solc_parsing.exceptions import ParsingError
 from slither.solc_parsing.expressions.expression_parsing import parse_expression
+from slither.solc_parsing.types.types import ASTNode, Block, IfStatement, ForStatement, WhileStatement, \
+    VariableDeclarationStatement, TryStatement, TryCatchClause, VariableDeclaration, ExpressionStatement, \
+    TupleExpression, Identifier, Assignment, ParameterList, Return, Continue, Break, EmitStatement, Throw, \
+    FunctionDefinition, ModifierInvocation, InlineAssembly
 from slither.solc_parsing.variables.local_variable import LocalVariableSolc
 from slither.solc_parsing.variables.local_variable_init_from_tuple import (
     LocalVariableInitFromTupleSolc,
 )
-from slither.solc_parsing.variables.variable_declaration import MultipleVariablesDeclaration
 from slither.solc_parsing.yul.parse_yul import YulBlock
 from slither.utils.expression_manipulations import SplitTernaryExpression
 from slither.visitors.expression.export_values import ExportValues
 from slither.visitors.expression.has_conditional import HasConditional
-from slither.solc_parsing.exceptions import ParsingError
-from slither.core.source_mapping.source_mapping import SourceMapping
 
 if TYPE_CHECKING:
     from slither.core.expressions.expression import Expression
@@ -45,12 +47,10 @@ def link_underlying_nodes(node1: NodeSolc, node2: NodeSolc):
 
 class FunctionSolc:
 
-    # elems = [(type, name)]
-
     def __init__(
         self,
         function: Function,
-        function_data: Dict,
+        function_data: FunctionDefinition,
         contract_parser: "ContractSolc",
     ):
         self._slither_parser: "SlitherSolc" = contract_parser.slither_parser
@@ -59,13 +59,8 @@ class FunctionSolc:
 
         # Only present if compact AST
         self._referenced_declaration: Optional[int] = None
-        if self.is_compact_ast:
-            self._function.name = function_data["name"]
-            if "id" in function_data:
-                self._referenced_declaration = function_data["id"]
-                self._function.id = function_data["id"]
-        else:
-            self._function.name = function_data["attributes"][self.get_key()]
+        self._function.name = function_data.name
+        self._function.id = function_data.id
         self._functionNotParsed = function_data
         self._params_was_analyzed = False
         self._content_was_analyzed = False
@@ -115,18 +110,6 @@ class FunctionSolc:
     ###################################################################################
     ###################################################################################
 
-    def get_key(self) -> str:
-        return self._slither_parser.get_key()
-
-    def get_children(self, key: str) -> str:
-        if self.is_compact_ast:
-            return key
-        return "children"
-
-    @property
-    def is_compact_ast(self):
-        return self._slither_parser.is_compact_ast
-
     @property
     def referenced_declaration(self) -> Optional[str]:
         """
@@ -143,12 +126,12 @@ class FunctionSolc:
 
     @property
     def variables_renamed(
-        self,
+            self,
     ) -> Dict[int, Union[LocalVariableSolc, LocalVariableInitFromTupleSolc]]:
         return self._variables_renamed
 
     def _add_local_variable(
-        self, local_var_parser: Union[LocalVariableSolc, LocalVariableInitFromTupleSolc]
+            self, local_var_parser: Union[LocalVariableSolc, LocalVariableInitFromTupleSolc]
     ):
         # If two local variables have the same name
         # We add a suffix to the new variable
@@ -178,7 +161,7 @@ class FunctionSolc:
     ###################################################################################
 
     @property
-    def function_not_parsed(self) -> Dict:
+    def function_not_parsed(self) -> FunctionDefinition:
         return self._functionNotParsed
 
     def _analyze_type(self):
@@ -188,18 +171,13 @@ class FunctionSolc:
         For example both the fallback and the receiver will have an empty name
         :return:
         """
-        if self.is_compact_ast:
-            attributes = self._functionNotParsed
-        else:
-            attributes = self._functionNotParsed["attributes"]
 
         if self._function.name == "":
             self._function.function_type = FunctionType.FALLBACK
             # 0.6.x introduced the receiver function
             # It has also an empty name, so we need to check the kind attribute
-            if "kind" in attributes:
-                if attributes["kind"] == "receive":
-                    self._function.function_type = FunctionType.RECEIVE
+            if self._functionNotParsed.kind == "receive":
+                self._function.function_type = FunctionType.RECEIVE
         else:
             self._function.function_type = FunctionType.NORMAL
 
@@ -207,45 +185,19 @@ class FunctionSolc:
             self._function.function_type = FunctionType.CONSTRUCTOR
 
     def _analyze_attributes(self):
-        if self.is_compact_ast:
-            attributes = self._functionNotParsed
-        else:
-            attributes = self._functionNotParsed["attributes"]
-
-        if "payable" in attributes:
-            self._function.payable = attributes["payable"]
-        if "stateMutability" in attributes:
-            if attributes["stateMutability"] == "payable":
+        if isinstance(self._functionNotParsed, FunctionDefinition):
+            if self._functionNotParsed.mutability == 'payable':
                 self._function.payable = True
-            elif attributes["stateMutability"] == "pure":
+            elif self._functionNotParsed.mutability == 'pure':
                 self._function.pure = True
                 self._function.view = True
-            elif attributes["stateMutability"] == "view":
+            elif self._functionNotParsed.mutability == 'view':
                 self._function.view = True
 
-        if "constant" in attributes:
-            self._function.view = attributes["constant"]
-
-        if "isConstructor" in attributes and attributes["isConstructor"]:
-            self._function.function_type = FunctionType.CONSTRUCTOR
-
-        if "kind" in attributes:
-            if attributes["kind"] == "constructor":
+            if self._functionNotParsed.kind == "constructor":
                 self._function.function_type = FunctionType.CONSTRUCTOR
 
-        if "visibility" in attributes:
-            self._function.visibility = attributes["visibility"]
-        # old solc
-        elif "public" in attributes:
-            if attributes["public"]:
-                self._function.visibility = "public"
-            else:
-                self._function.visibility = "private"
-        else:
-            self._function.visibility = "public"
-
-        if "payable" in attributes:
-            self._function.payable = attributes["payable"]
+        self._function.visibility = self._functionNotParsed.visibility
 
     def analyze_params(self):
         # Can be re-analyzed due to inheritance
@@ -256,18 +208,10 @@ class FunctionSolc:
 
         self._analyze_attributes()
 
-        if self.is_compact_ast:
-            params = self._functionNotParsed["parameters"]
-            returns = self._functionNotParsed["returnParameters"]
-        else:
-            children = self._functionNotParsed[self.get_children("children")]
-            params = children[0]
-            returns = children[1]
-
-        if params:
-            self._parse_params(params)
-        if returns:
-            self._parse_returns(returns)
+        if self._functionNotParsed.params:
+            self._parse_params(self._functionNotParsed.params)
+        if self._functionNotParsed.rets:
+            self._parse_returns(self._functionNotParsed.rets)
 
     def analyze_content(self):
         if self._content_was_analyzed:
@@ -275,29 +219,12 @@ class FunctionSolc:
 
         self._content_was_analyzed = True
 
-        if self.is_compact_ast:
-            body = self._functionNotParsed.get("body", None)
+        if self._functionNotParsed.body:
+            self._function.is_implemented = True
+            self._parse_cfg(self._functionNotParsed.body)
 
-            if body and body[self.get_key()] == "Block":
-                self._function.is_implemented = True
-                self._parse_cfg(body)
-
-            for modifier in self._functionNotParsed["modifiers"]:
-                self._parse_modifier(modifier)
-
-        else:
-            children = self._functionNotParsed[self.get_children("children")]
-            self._function.is_implemented = False
-            for child in children[2:]:
-                if child[self.get_key()] == "Block":
-                    self._function.is_implemented = True
-                    self._parse_cfg(child)
-
-            # Parse modifier after parsing all the block
-            # In the case a local variable is used in the modifier
-            for child in children[2:]:
-                if child[self.get_key()] == "ModifierInvocation":
-                    self._parse_modifier(child)
+        for modifier in self._functionNotParsed.modifiers:
+            self._parse_modifier(modifier)
 
         for local_var_parser in self._local_variables_parser:
             local_var_parser.analyze(self)
@@ -343,33 +270,18 @@ class FunctionSolc:
     ###################################################################################
     ###################################################################################
 
-    def _parse_if(self, if_statement: Dict, node: NodeSolc) -> NodeSolc:
-        # IfStatement = 'if' '(' Expression ')' Statement ( 'else' Statement )?
-        falseStatement = None
+    def _parse_if(self, stmt: IfStatement, node: NodeSolc) -> NodeSolc:
+        condition_node = self._new_node(NodeType.IF, stmt.condition.src)
+        condition_node.add_unparsed_expression(stmt.condition)
+        link_underlying_nodes(node, condition_node)
+        trueStatement = self._parse(stmt.true_body, condition_node)
 
-        if self.is_compact_ast:
-            condition = if_statement["condition"]
-            # Note: check if the expression could be directly
-            # parsed here
-            condition_node = self._new_node(NodeType.IF, condition["src"])
-            condition_node.add_unparsed_expression(condition)
-            link_underlying_nodes(node, condition_node)
-            trueStatement = self._parse_statement(if_statement["trueBody"], condition_node)
-            if "falseBody" in if_statement and if_statement["falseBody"]:
-                falseStatement = self._parse_statement(if_statement["falseBody"], condition_node)
+        if stmt.false_body:
+            falseStatement = self._parse(stmt.false_body, condition_node)
         else:
-            children = if_statement[self.get_children("children")]
-            condition = children[0]
-            # Note: check if the expression could be directly
-            # parsed here
-            condition_node = self._new_node(NodeType.IF, condition["src"])
-            condition_node.add_unparsed_expression(condition)
-            link_underlying_nodes(node, condition_node)
-            trueStatement = self._parse_statement(children[1], condition_node)
-            if len(children) == 3:
-                falseStatement = self._parse_statement(children[2], condition_node)
+            falseStatement = None
 
-        endIf_node = self._new_node(NodeType.ENDIF, if_statement["src"])
+        endIf_node = self._new_node(NodeType.ENDIF, stmt.src)
         link_underlying_nodes(trueStatement, endIf_node)
 
         if falseStatement:
@@ -378,49 +290,43 @@ class FunctionSolc:
             link_underlying_nodes(condition_node, endIf_node)
         return endIf_node
 
-    def _parse_while(self, whilte_statement: Dict, node: NodeSolc) -> NodeSolc:
-        # WhileStatement = 'while' '(' Expression ')' Statement
+    def _parse_while(self, stmt: WhileStatement, node: NodeSolc) -> NodeSolc:
+        node_startWhile = self._new_node(NodeType.STARTLOOP, stmt.src)
 
-        node_startWhile = self._new_node(NodeType.STARTLOOP, whilte_statement["src"])
+        node_condition = self._new_node(NodeType.IFLOOP, stmt.condition.src)
+        node_condition.add_unparsed_expression(stmt.condition)
+        statement = self._parse(stmt.body, node_condition)
 
-        if self.is_compact_ast:
-            node_condition = self._new_node(NodeType.IFLOOP, whilte_statement["condition"]["src"])
-            node_condition.add_unparsed_expression(whilte_statement["condition"])
-            statement = self._parse_statement(whilte_statement["body"], node_condition)
-        else:
-            children = whilte_statement[self.get_children("children")]
-            expression = children[0]
-            node_condition = self._new_node(NodeType.IFLOOP, expression["src"])
-            node_condition.add_unparsed_expression(expression)
-            statement = self._parse_statement(children[1], node_condition)
-
-        node_endWhile = self._new_node(NodeType.ENDLOOP, whilte_statement["src"])
+        node_endWhile = self._new_node(NodeType.ENDLOOP, stmt.src)
 
         link_underlying_nodes(node, node_startWhile)
-        link_underlying_nodes(node_startWhile, node_condition)
+
+        if stmt.is_do_while:
+            # empty block, loop from the start to the condition
+            if not node_condition.underlying_node.sons:
+                link_underlying_nodes(node_startWhile, node_condition)
+            else:
+                link_nodes(node_startWhile.underlying_node, node_condition.underlying_node.sons[0])
+        else:
+            link_underlying_nodes(node_startWhile, node_condition)
         link_underlying_nodes(statement, node_condition)
         link_underlying_nodes(node_condition, node_endWhile)
 
         return node_endWhile
 
-    def _parse_for_compact_ast(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        body = statement["body"]
-        init_expression = statement.get("initializationExpression", None)
-        condition = statement.get("condition", None)
-        loop_expression = statement.get("loopExpression", None)
+    def _parse_for(self, stmt: ForStatement, node: NodeSolc) -> NodeSolc:
+        node_startLoop = self._new_node(NodeType.STARTLOOP, stmt.src)
+        node_endLoop = self._new_node(NodeType.ENDLOOP, stmt.src)
 
-        node_startLoop = self._new_node(NodeType.STARTLOOP, statement["src"])
-        node_endLoop = self._new_node(NodeType.ENDLOOP, statement["src"])
-
-        if init_expression:
-            node_init_expression = self._parse_statement(init_expression, node)
+        if stmt.init:
+            node_init_expression = self._parse(stmt.init, node)
             link_underlying_nodes(node_init_expression, node_startLoop)
         else:
             link_underlying_nodes(node, node_startLoop)
 
-        if condition:
-            node_condition = self._new_node(NodeType.IFLOOP, condition["src"])
-            node_condition.add_unparsed_expression(condition)
+        if stmt.cond:
+            node_condition = self._new_node(NodeType.IFLOOP, stmt.cond.src)
+            node_condition.add_unparsed_expression(stmt.cond)
             link_underlying_nodes(node_startLoop, node_condition)
 
             node_beforeBody = node_condition
@@ -429,20 +335,20 @@ class FunctionSolc:
 
             node_beforeBody = node_startLoop
 
-        node_body = self._parse_statement(body, node_beforeBody)
+        node_body = self._parse(stmt.body, node_beforeBody)
 
         if node_condition:
             link_underlying_nodes(node_condition, node_endLoop)
 
         node_LoopExpression = None
-        if loop_expression:
-            node_LoopExpression = self._parse_statement(loop_expression, node_body)
+        if stmt.loop:
+            node_LoopExpression = self._parse(stmt.loop, node_body)
             link_underlying_nodes(node_LoopExpression, node_beforeBody)
         else:
             link_underlying_nodes(node_body, node_beforeBody)
 
-        if not condition:
-            if not loop_expression:
+        if not stmt.cond:
+            if not stmt.loop:
                 # TODO: fix case where loop has no expression
                 link_underlying_nodes(node_startLoop, node_endLoop)
             elif node_LoopExpression:
@@ -450,506 +356,223 @@ class FunctionSolc:
 
         return node_endLoop
 
-    def _parse_for(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        # ForStatement = 'for' '(' (SimpleStatement)? ';' (Expression)? ';' (ExpressionStatement)? ')' Statement
-
-        # the handling of loop in the legacy ast is too complex
-        # to integrate the comapct ast
-        # its cleaner to do it separately
-        if self.is_compact_ast:
-            return self._parse_for_compact_ast(statement, node)
-
-        hasInitExession = True
-        hasCondition = True
-        hasLoopExpression = True
-
-        # Old solc version do not prevent in the attributes
-        # if the loop has a init value /condition or expression
-        # There is no way to determine that for(a;;) and for(;a;) are different with old solc
-        if "attributes" in statement:
-            attributes = statement["attributes"]
-            if "initializationExpression" in statement:
-                if not statement["initializationExpression"]:
-                    hasInitExession = False
-            elif "initializationExpression" in attributes:
-                if not attributes["initializationExpression"]:
-                    hasInitExession = False
-
-            if "condition" in statement:
-                if not statement["condition"]:
-                    hasCondition = False
-            elif "condition" in attributes:
-                if not attributes["condition"]:
-                    hasCondition = False
-
-            if "loopExpression" in statement:
-                if not statement["loopExpression"]:
-                    hasLoopExpression = False
-            elif "loopExpression" in attributes:
-                if not attributes["loopExpression"]:
-                    hasLoopExpression = False
-
-        node_startLoop = self._new_node(NodeType.STARTLOOP, statement["src"])
-        node_endLoop = self._new_node(NodeType.ENDLOOP, statement["src"])
-
-        children = statement[self.get_children("children")]
-
-        if hasInitExession:
-            if len(children) >= 2:
-                if children[0][self.get_key()] in [
-                    "VariableDefinitionStatement",
-                    "VariableDeclarationStatement",
-                    "ExpressionStatement",
-                ]:
-                    node_initExpression = self._parse_statement(children[0], node)
-                    link_underlying_nodes(node_initExpression, node_startLoop)
-                else:
-                    hasInitExession = False
-            else:
-                hasInitExession = False
-
-        if not hasInitExession:
-            link_underlying_nodes(node, node_startLoop)
-        node_condition = node_startLoop
-
-        if hasCondition:
-            if hasInitExession and len(children) >= 2:
-                candidate = children[1]
-            else:
-                candidate = children[0]
-            if candidate[self.get_key()] not in [
-                "VariableDefinitionStatement",
-                "VariableDeclarationStatement",
-                "ExpressionStatement",
-            ]:
-                expression = candidate
-                node_condition = self._new_node(NodeType.IFLOOP, expression["src"])
-                # expression = parse_expression(candidate, self)
-                node_condition.add_unparsed_expression(expression)
-                link_underlying_nodes(node_startLoop, node_condition)
-                hasCondition = True
-            else:
-                hasCondition = False
-
-        node_statement = self._parse_statement(children[-1], node_condition)
-
-        if hasCondition:
-            link_underlying_nodes(node_condition, node_endLoop)
-
-        node_LoopExpression = node_statement
-        if hasLoopExpression:
-            if len(children) > 2:
-                if children[-2][self.get_key()] == "ExpressionStatement":
-                    node_LoopExpression = self._parse_statement(children[-2], node_statement)
-            if not hasCondition:
-                link_underlying_nodes(node_LoopExpression, node_endLoop)
-
-        if not hasCondition and not hasLoopExpression:
-            link_underlying_nodes(node, node_endLoop)
-
-        link_underlying_nodes(node_LoopExpression, node_condition)
-
-        return node_endLoop
-
-    def _parse_dowhile(self, do_while_statement: Dict, node: NodeSolc) -> NodeSolc:
-
-        node_startDoWhile = self._new_node(NodeType.STARTLOOP, do_while_statement["src"])
-
-        if self.is_compact_ast:
-            node_condition = self._new_node(NodeType.IFLOOP, do_while_statement["condition"]["src"])
-            node_condition.add_unparsed_expression(do_while_statement["condition"])
-            statement = self._parse_statement(do_while_statement["body"], node_condition)
-        else:
-            children = do_while_statement[self.get_children("children")]
-            # same order in the AST as while
-            expression = children[0]
-            node_condition = self._new_node(NodeType.IFLOOP, expression["src"])
-            node_condition.add_unparsed_expression(expression)
-            statement = self._parse_statement(children[1], node_condition)
-
-        node_endDoWhile = self._new_node(NodeType.ENDLOOP, do_while_statement["src"])
-
-        link_underlying_nodes(node, node_startDoWhile)
-        # empty block, loop from the start to the condition
-        if not node_condition.underlying_node.sons:
-            link_underlying_nodes(node_startDoWhile, node_condition)
-        else:
-            link_nodes(
-                node_startDoWhile.underlying_node,
-                node_condition.underlying_node.sons[0],
-            )
-        link_underlying_nodes(statement, node_condition)
-        link_underlying_nodes(node_condition, node_endDoWhile)
-        return node_endDoWhile
-
-    def _parse_try_catch(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        externalCall = statement.get("externalCall", None)
-
-        if externalCall is None:
-            raise ParsingError("Try/Catch not correctly parsed by Slither %s" % statement)
-
-        new_node = self._new_node(NodeType.TRY, statement["src"])
-        new_node.add_unparsed_expression(externalCall)
+    def _parse_try_catch(self, stmt: TryStatement, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.TRY, stmt.src)
+        new_node.add_unparsed_expression(stmt.external_call)
         link_underlying_nodes(node, new_node)
         node = new_node
 
-        for clause in statement.get("clauses", []):
-            self._parse_catch(clause, node)
+        for clause in stmt.clauses:
+            self._parse(clause, node)
         return node
 
-    def _parse_catch(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        block = statement.get("block", None)
-
-        if block is None:
-            raise ParsingError("Catch not correctly parsed by Slither %s" % statement)
-        try_node = self._new_node(NodeType.CATCH, statement["src"])
+    def _parse_catch(self, stmt: TryCatchClause, node: NodeSolc) -> NodeSolc:
+        try_node = self._new_node(NodeType.CATCH, stmt.src)
         link_underlying_nodes(node, try_node)
 
-        if self.is_compact_ast:
-            params = statement.get("parameters", None)
-        else:
-            params = statement[self.get_children("children")]
-
-        if params:
-            for param in params.get("parameters", []):
-                assert param[self.get_key()] == "VariableDeclaration"
+        if stmt.params:
+            for param in stmt.params.params:
                 self._add_param(param)
 
-        return self._parse_statement(block, try_node)
+        return self._parse(stmt.block, try_node)
 
-    def _parse_variable_definition(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        try:
+    def _parse_variable_definition(self, stmt: VariableDeclarationStatement, node: NodeSolc) -> NodeSolc:
+        if len(stmt.variables) == 1:
             local_var = LocalVariable()
             local_var.set_function(self._function)
-            local_var.set_offset(statement["src"], self._function.slither)
+            local_var.set_offset(stmt.src, self._function.slither)
 
-            local_var_parser = LocalVariableSolc(local_var, statement)
+            local_var_parser = LocalVariableSolc(local_var, stmt)
             self._add_local_variable(local_var_parser)
-            # local_var.analyze(self)
 
-            new_node = self._new_node(NodeType.VARIABLE, statement["src"])
+            new_node = self._new_node(NodeType.VARIABLE, stmt.src)
             new_node.underlying_node.add_variable_declaration(local_var)
             link_underlying_nodes(node, new_node)
             return new_node
-        except MultipleVariablesDeclaration:
-            # Custom handling of var (a,b) = .. style declaration
-            if self.is_compact_ast:
-                variables = statement["declarations"]
-                count = len(variables)
+        else:
+            """
+            There are 2 cases we need to handle
+            
+            1)  Initializing multiple vars with multiple individual values:
+                    var (a, b) = (1,2);
+                In this case, we convert to the following code:
+                    var a = 1;
+                    var b = 2;
+                    
+            2)  Initializing multiple vars with any other method (function call, skipped args, etc):
+                    var (a, , c) = f();
+                In this case, we convert to the following code:
+                    var a;
+                    var c;
+                    (a, , c) = f();
+            """
 
-                if (
-                    statement["initialValue"]["nodeType"] == "TupleExpression"
-                    and len(statement["initialValue"]["components"]) == count
-                ):
-                    inits = statement["initialValue"]["components"]
-                    i = 0
-                    new_node = node
-                    for variable in variables:
-                        if variable is None:
-                            continue
-                        init = inits[i]
-                        src = variable["src"]
-                        i = i + 1
+            if isinstance(stmt.initial_value, TupleExpression) \
+                    and len(stmt.initial_value.components) == len(stmt.variables):
 
-                        new_statement = {
-                            "nodeType": "VariableDefinitionStatement",
-                            "src": src,
-                            "declarations": [variable],
-                            "initialValue": init,
-                        }
-                        new_node = self._parse_variable_definition(new_statement, new_node)
+                for i, variable in enumerate(stmt.variables):
+                    if variable is None:
+                        continue
 
-                else:
-                    # If we have
-                    # var (a, b) = f()
-                    # we can split in multiple declarations, without init
-                    # Then we craft one expression that does the assignment
-                    variables = []
-                    i = 0
-                    new_node = node
-                    for variable in statement["declarations"]:
-                        if variable:
-                            src = variable["src"]
-                            # Create a fake statement to be consistent
-                            new_statement = {
-                                "nodeType": "VariableDefinitionStatement",
-                                "src": src,
-                                "declarations": [variable],
-                            }
-                            variables.append(variable)
+                    node = self._parse_variable_definition(VariableDeclarationStatement(
+                        [variable],
+                        stmt.initial_value.components[i],
+                        src=variable.src,
+                        id=variable.id,
+                    ), node)
 
-                            new_node = self._parse_variable_definition_init_tuple(
-                                new_statement, i, new_node
-                            )
-                        i = i + 1
-
-                    var_identifiers = []
-                    # craft of the expression doing the assignement
-                    for v in variables:
-                        identifier = {
-                            "nodeType": "Identifier",
-                            "src": v["src"],
-                            "name": v["name"],
-                            "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},
-                        }
-                        var_identifiers.append(identifier)
-
-                    tuple_expression = {
-                        "nodeType": "TupleExpression",
-                        "src": statement["src"],
-                        "components": var_identifiers,
-                    }
-
-                    expression = {
-                        "nodeType": "Assignment",
-                        "src": statement["src"],
-                        "operator": "=",
-                        "type": "tuple()",
-                        "leftHandSide": tuple_expression,
-                        "rightHandSide": statement["initialValue"],
-                        "typeDescriptions": {"typeString": "tuple()"},
-                    }
-                    node = new_node
-                    new_node = self._new_node(NodeType.EXPRESSION, statement["src"])
-                    new_node.add_unparsed_expression(expression)
-                    link_underlying_nodes(node, new_node)
-
+                return node
             else:
-                count = 0
-                children = statement[self.get_children("children")]
-                child = children[0]
-                while child[self.get_key()] == "VariableDeclaration":
-                    count = count + 1
-                    child = children[count]
+                for i, variable in enumerate(stmt.variables):
+                    if not variable:
+                        continue
 
-                assert len(children) == (count + 1)
-                tuple_vars = children[count]
+                    node = self._parse_variable_definition_init_tuple(VariableDeclarationStatement(
+                        [variable],
+                        None,
+                        src=variable.src,
+                        id=variable.id,
+                    ), i, node)
 
-                variables_declaration = children[0:count]
-                i = 0
-                new_node = node
-                if tuple_vars[self.get_key()] == "TupleExpression":
-                    assert len(tuple_vars[self.get_children("children")]) == count
-                    for variable in variables_declaration:
-                        init = tuple_vars[self.get_children("children")][i]
-                        src = variable["src"]
-                        i = i + 1
-                        # Create a fake statement to be consistent
-                        new_statement = {
-                            self.get_key(): "VariableDefinitionStatement",
-                            "src": src,
-                            self.get_children("children"): [variable, init],
-                        }
-
-                        new_node = self._parse_variable_definition(new_statement, new_node)
-                else:
-                    # If we have
-                    # var (a, b) = f()
-                    # we can split in multiple declarations, without init
-                    # Then we craft one expression that does the assignment
-                    assert tuple_vars[self.get_key()] in ["FunctionCall", "Conditional"]
-                    variables = []
-                    for variable in variables_declaration:
-                        src = variable["src"]
-                        # Create a fake statement to be consistent
-                        new_statement = {
-                            self.get_key(): "VariableDefinitionStatement",
-                            "src": src,
-                            self.get_children("children"): [variable],
-                        }
-                        variables.append(variable)
-
-                        new_node = self._parse_variable_definition_init_tuple(
-                            new_statement, i, new_node
-                        )
-                        i = i + 1
-                    var_identifiers = []
-                    # craft of the expression doing the assignement
-                    for v in variables:
-                        identifier = {
-                            self.get_key(): "Identifier",
-                            "src": v["src"],
-                            "attributes": {
-                                "value": v["attributes"][self.get_key()],
-                                "type": v["attributes"]["type"],
-                            },
-                        }
-                        var_identifiers.append(identifier)
-
-                    expression = {
-                        self.get_key(): "Assignment",
-                        "src": statement["src"],
-                        "attributes": {"operator": "=", "type": "tuple()"},
-                        self.get_children("children"): [
-                            {
-                                self.get_key(): "TupleExpression",
-                                "src": statement["src"],
-                                self.get_children("children"): var_identifiers,
-                            },
-                            tuple_vars,
-                        ],
-                    }
-                    node = new_node
-                    new_node = self._new_node(NodeType.EXPRESSION, statement["src"])
-                    new_node.add_unparsed_expression(expression)
-                    link_underlying_nodes(node, new_node)
-
-            return new_node
+                new_node = self._new_node(NodeType.EXPRESSION, stmt.src)
+                new_node.add_unparsed_expression(Assignment(
+                    TupleExpression(
+                        [Identifier(v.name, type_str=v.type_str, constant=False, pure=False, src=v.src,
+                                    id=v.id) if v else None for v in stmt.variables],
+                        False,
+                        type_str="tuple()",
+                        constant=False,
+                        pure=False,
+                        src=stmt.src,
+                        id=stmt.id,
+                    ),
+                    "=",
+                    stmt.initial_value,
+                    type_str="tuple()",
+                    constant=False,
+                    pure=False,
+                    src=stmt.src,
+                    id=stmt.id,
+                ))
+                link_underlying_nodes(node, new_node)
+                return new_node
 
     def _parse_variable_definition_init_tuple(
-        self, statement: Dict, index: int, node: NodeSolc
+            self, stmt: VariableDeclarationStatement, index: int, node: NodeSolc
     ) -> NodeSolc:
         local_var = LocalVariableInitFromTuple()
         local_var.set_function(self._function)
-        local_var.set_offset(statement["src"], self._function.slither)
+        local_var.set_offset(stmt.src, self._function.slither)
 
-        local_var_parser = LocalVariableInitFromTupleSolc(local_var, statement, index)
+        local_var_parser = LocalVariableInitFromTupleSolc(local_var, stmt, index)
 
         self._add_local_variable(local_var_parser)
 
-        new_node = self._new_node(NodeType.VARIABLE, statement["src"])
+        new_node = self._new_node(NodeType.VARIABLE, stmt.src)
         new_node.underlying_node.add_variable_declaration(local_var)
         link_underlying_nodes(node, new_node)
         return new_node
 
-    def _parse_statement(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        """
+    def _parse_continue(self, stmt: Continue, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.CONTINUE, stmt.src)
+        link_underlying_nodes(node, new_node)
+        return new_node
 
-        Return:
-            node
-        """
-        # Statement = IfStatement | WhileStatement | ForStatement | Block | InlineAssemblyStatement |
-        #            ( DoWhileStatement | PlaceholderStatement | Continue | Break | Return |
-        #                          Throw | EmitStatement | SimpleStatement ) ';'
-        # SimpleStatement = VariableDefinition | ExpressionStatement
+    def _parse_break(self, stmt: Break, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.BREAK, stmt.src)
+        link_underlying_nodes(node, new_node)
+        return new_node
 
-        name = statement[self.get_key()]
-        # SimpleStatement = VariableDefinition | ExpressionStatement
-        if name == "IfStatement":
-            node = self._parse_if(statement, node)
-        elif name == "WhileStatement":
-            node = self._parse_while(statement, node)
-        elif name == "ForStatement":
-            node = self._parse_for(statement, node)
-        elif name == "Block":
-            node = self._parse_block(statement, node)
-        elif name == "InlineAssembly":
-            # Added with solc 0.6 - the yul code is an AST
-            if "AST" in statement:
-                self._function.contains_assembly = True
-                yul_object = self._new_yul_block(statement["src"])
+    def _parse_throw(self, stmt: Throw, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.THROW, stmt.src)
+        link_underlying_nodes(node, new_node)
+        return new_node
+
+    def _parse_emit_statement(self, stmt: EmitStatement, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.EXPRESSION, stmt.src)
+        new_node.add_unparsed_expression(stmt.event_call)
+        link_underlying_nodes(node, new_node)
+        return new_node
+
+    def _parse_block(self, stmt: Block, node: NodeSolc) -> NodeSolc:
+        for statement in stmt.statements:
+            node = self._parse(statement, node)
+        return node
+
+    def _parse_expression_statement(self, stmt: ExpressionStatement, node: NodeSolc) -> NodeSolc:
+        new_node = self._new_node(NodeType.EXPRESSION, stmt.src)
+        new_node.add_unparsed_expression(stmt.expression)
+        link_underlying_nodes(node, new_node)
+        return new_node
+
+    def _parse_return(self, stmt: Return, node: NodeSolc) -> NodeSolc:
+        return_node = self._new_node(NodeType.RETURN, stmt.src)
+        link_underlying_nodes(node, return_node)
+
+        if stmt.expression:
+            return_node.add_unparsed_expression(stmt.expression)
+
+        return return_node
+
+    def _parse_inline_assembly(self, stmt: InlineAssembly, node: NodeSolc) -> NodeSolc:
+        self._function.contains_assembly = True
+
+        if stmt.ast:
+            if isinstance(stmt.ast, dict):
+                # Added with solc 0.6 - the yul code is an AST
+                yul_object = self._new_yul_block(stmt.src)
                 entrypoint = yul_object.entrypoint
-                exitpoint = yul_object.convert(statement["AST"])
+                exitpoint = yul_object.convert(stmt.ast)
 
                 # technically, entrypoint and exitpoint are YulNodes and we should be returning a NodeSolc here
                 # but they both expose an underlying_node so oh well
                 link_underlying_nodes(node, entrypoint)
-                node = exitpoint
+                return exitpoint
             else:
-                asm_node = self._new_node(NodeType.ASSEMBLY, statement["src"])
-                self._function.contains_assembly = True
                 # Added with solc 0.4.12
-                if "operations" in statement:
-                    asm_node.underlying_node.add_inline_asm(statement["operations"])
+                asm_node = self._new_node(NodeType.ASSEMBLY, stmt.src)
+                asm_node.underlying_node.add_inline_asm(stmt.ast)
                 link_underlying_nodes(node, asm_node)
-                node = asm_node
-        elif name == "DoWhileStatement":
-            node = self._parse_dowhile(statement, node)
-        # For Continue / Break / Return / Throw
-        # The is fixed later
-        elif name == "Continue":
-            continue_node = self._new_node(NodeType.CONTINUE, statement["src"])
-            link_underlying_nodes(node, continue_node)
-            node = continue_node
-        elif name == "Break":
-            break_node = self._new_node(NodeType.BREAK, statement["src"])
-            link_underlying_nodes(node, break_node)
-            node = break_node
-        elif name == "Return":
-            return_node = self._new_node(NodeType.RETURN, statement["src"])
-            link_underlying_nodes(node, return_node)
-            if self.is_compact_ast:
-                if statement["expression"]:
-                    return_node.add_unparsed_expression(statement["expression"])
-            else:
-                if (
-                    self.get_children("children") in statement
-                    and statement[self.get_children("children")]
-                ):
-                    assert len(statement[self.get_children("children")]) == 1
-                    expression = statement[self.get_children("children")][0]
-                    return_node.add_unparsed_expression(expression)
-            node = return_node
-        elif name == "Throw":
-            throw_node = self._new_node(NodeType.THROW, statement["src"])
-            link_underlying_nodes(node, throw_node)
-            node = throw_node
-        elif name == "EmitStatement":
-            # expression = parse_expression(statement[self.get_children('children')][0], self)
-            if self.is_compact_ast:
-                expression = statement["eventCall"]
-            else:
-                expression = statement[self.get_children("children")][0]
-            new_node = self._new_node(NodeType.EXPRESSION, statement["src"])
-            new_node.add_unparsed_expression(expression)
-            link_underlying_nodes(node, new_node)
-            node = new_node
-        elif name in ["VariableDefinitionStatement", "VariableDeclarationStatement"]:
-            node = self._parse_variable_definition(statement, node)
-        elif name == "ExpressionStatement":
-            # assert len(statement[self.get_children('expression')]) == 1
-            # assert not 'attributes' in statement
-            # expression = parse_expression(statement[self.get_children('children')][0], self)
-            if self.is_compact_ast:
-                expression = statement[self.get_children("expression")]
-            else:
-                expression = statement[self.get_children("expression")][0]
-            new_node = self._new_node(NodeType.EXPRESSION, statement["src"])
-            new_node.add_unparsed_expression(expression)
-            link_underlying_nodes(node, new_node)
-            node = new_node
-        elif name == "TryStatement":
-            node = self._parse_try_catch(statement, node)
-        # elif name == 'TryCatchClause':
-        #     self._parse_catch(statement, node)
+                return node
         else:
-            raise ParsingError("Statement not parsed %s" % name)
+            asm_node = self._new_node(NodeType.ASSEMBLY, stmt.src)
+            link_underlying_nodes(node, asm_node)
+            return node
 
-        return node
+    def _parse_unhandled(self, stmt: ASTNode, node: NodeSolc) -> NodeSolc:
+        raise Exception("unhandled ast node", stmt.__class__)
 
-    def _parse_block(self, block: Dict, node: NodeSolc):
-        """
-        Return:
-            Node
-        """
-        assert block[self.get_key()] == "Block"
+    def _parse(self, stmt: ASTNode, node: NodeSolc) -> NodeSolc:
+        return FunctionSolc.PARSERS.get(stmt.__class__, FunctionSolc._parse_unhandled)(self, stmt, node)
 
-        if self.is_compact_ast:
-            statements = block["statements"]
-        else:
-            statements = block[self.get_children("children")]
+    PARSERS = {
+        VariableDeclarationStatement: _parse_variable_definition,
+        WhileStatement: _parse_while,
+        Block: _parse_block,
+        TryStatement: _parse_try_catch,
+        TryCatchClause: _parse_catch,
+        ExpressionStatement: _parse_expression_statement,
+        ForStatement: _parse_for,
+        IfStatement: _parse_if,
+        Return: _parse_return,
+        Continue: _parse_continue,
+        Break: _parse_break,
+        Throw: _parse_throw,
+        EmitStatement: _parse_emit_statement,
+        InlineAssembly: _parse_inline_assembly,
+    }
 
-        for statement in statements:
-            node = self._parse_statement(statement, node)
-        return node
+    def _parse_cfg(self, cfg: ASTNode):
+        assert isinstance(cfg, Block)
 
-    def _parse_cfg(self, cfg: Dict):
-
-        assert cfg[self.get_key()] == "Block"
-
-        node = self._new_node(NodeType.ENTRYPOINT, cfg["src"])
+        node = self._new_node(NodeType.ENTRYPOINT, cfg.src)
         self._function.entry_point = node.underlying_node
 
-        if self.is_compact_ast:
-            statements = cfg["statements"]
-        else:
-            statements = cfg[self.get_children("children")]
-
-        if not statements:
+        if not cfg.statements:
             self._function.is_empty = True
         else:
             self._function.is_empty = False
-            self._parse_block(cfg, node)
+            self._parse(cfg, node)
             self._remove_incorrect_edges()
             self._remove_alone_endif()
 
@@ -1039,11 +662,11 @@ class FunctionSolc:
                 if son != end_node:
                     self._fix_catch(son, end_node)
 
-    def _add_param(self, param: Dict) -> LocalVariableSolc:
+    def _add_param(self, param: VariableDeclaration) -> LocalVariableSolc:
 
         local_var = LocalVariable()
         local_var.set_function(self._function)
-        local_var.set_offset(param["src"], self._function.slither)
+        local_var.set_offset(param.src, self._function.slither)
 
         local_var_parser = LocalVariableSolc(local_var, param)
 
@@ -1056,38 +679,21 @@ class FunctionSolc:
         self._add_local_variable(local_var_parser)
         return local_var_parser
 
-    def _parse_params(self, params: Dict):
-        assert params[self.get_key()] == "ParameterList"
+    def _parse_params(self, params: ParameterList):
+        self.parameters_src.set_offset(params.src, self._function.slither)
 
-        self.parameters_src.set_offset(params["src"], self._function.slither)
-
-        if self.is_compact_ast:
-            params = params["parameters"]
-        else:
-            params = params[self.get_children("children")]
-
-        for param in params:
-            assert param[self.get_key()] == "VariableDeclaration"
+        for param in params.params:
             local_var = self._add_param(param)
             self._function.add_parameters(local_var.underlying_variable)
 
-    def _parse_returns(self, returns: Dict):
+    def _parse_returns(self, returns: ParameterList):
+        self.returns_src.set_offset(returns.src, self._function.slither)
 
-        assert returns[self.get_key()] == "ParameterList"
-
-        self.returns_src.set_offset(returns["src"], self._function.slither)
-
-        if self.is_compact_ast:
-            returns = returns["parameters"]
-        else:
-            returns = returns[self.get_children("children")]
-
-        for ret in returns:
-            assert ret[self.get_key()] == "VariableDeclaration"
+        for ret in returns.params:
             local_var = self._add_param(ret)
             self._function.add_return(local_var.underlying_variable)
 
-    def _parse_modifier(self, modifier: Dict):
+    def _parse_modifier(self, modifier: ModifierInvocation):
         m = parse_expression(modifier, self)
         # self._expression_modifiers.append(m)
 
@@ -1097,7 +703,7 @@ class FunctionSolc:
 
         for m in ExportValues(m).result():
             if isinstance(m, Function):
-                node_parser = self._new_node(NodeType.EXPRESSION, modifier["src"])
+                node_parser = self._new_node(NodeType.EXPRESSION, modifier.src)
                 node_parser.add_unparsed_expression(modifier)
                 # The latest entry point is the entry point, or the latest modifier call
                 if self._function.modifiers:
@@ -1114,7 +720,7 @@ class FunctionSolc:
                 )
 
             elif isinstance(m, Contract):
-                node_parser = self._new_node(NodeType.EXPRESSION, modifier["src"])
+                node_parser = self._new_node(NodeType.EXPRESSION, modifier.src)
                 node_parser.add_unparsed_expression(modifier)
                 # The latest entry point is the entry point, or the latest constructor call
                 if self._function.explicit_base_constructor_calls_statements:
@@ -1216,11 +822,11 @@ class FunctionSolc:
         return updated
 
     def _split_ternary_node(
-        self,
-        node: Node,
-        condition: "Expression",
-        true_expr: "Expression",
-        false_expr: "Expression",
+            self,
+            node: Node,
+            condition: "Expression",
+            true_expr: "Expression",
+            false_expr: "Expression",
     ):
         condition_node = self._new_node(NodeType.IF, node.source_mapping)
         condition_node.underlying_node.add_expression(condition)

--- a/slither/solc_parsing/declarations/modifier.py
+++ b/slither/solc_parsing/declarations/modifier.py
@@ -1,20 +1,21 @@
 """
     Event module
 """
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from slither.core.cfg.node import NodeType
 from slither.core.cfg.node import link_nodes
 from slither.core.declarations.modifier import Modifier
 from slither.solc_parsing.cfg.node import NodeSolc
 from slither.solc_parsing.declarations.function import FunctionSolc
+from slither.solc_parsing.types.types import ModifierDefinition, ASTNode, PlaceholderStatement
 
 if TYPE_CHECKING:
     from slither.solc_parsing.declarations.contract import ContractSolc
 
 
 class ModifierSolc(FunctionSolc):
-    def __init__(self, modifier: Modifier, function_data: Dict, contract_parser: "ContractSolc"):
+    def __init__(self, modifier: Modifier, function_data: ModifierDefinition, contract_parser: "ContractSolc"):
         super().__init__(modifier, function_data, contract_parser)
         # _modifier is equal to _function, but keep it here to prevent
         # confusion for mypy in underlying_function
@@ -33,14 +34,8 @@ class ModifierSolc(FunctionSolc):
 
         self._analyze_attributes()
 
-        if self.is_compact_ast:
-            params = self._functionNotParsed["parameters"]
-        else:
-            children = self._functionNotParsed["children"]
-            params = children[0]
-
-        if params:
-            self._parse_params(params)
+        if self._functionNotParsed.params:
+            self._parse_params(self._functionNotParsed.params)
 
     def analyze_content(self):
         if self._content_was_analyzed:
@@ -48,23 +43,8 @@ class ModifierSolc(FunctionSolc):
 
         self._content_was_analyzed = True
 
-        if self.is_compact_ast:
-            body = self._functionNotParsed["body"]
-
-            if body and body[self.get_key()] == "Block":
-                self._function.is_implemented = True
-                self._parse_cfg(body)
-
-        else:
-            children = self._functionNotParsed["children"]
-
-            self._function.is_implemented = False
-            if len(children) > 1:
-                assert len(children) == 2
-                block = children[1]
-                assert block["name"] == "Block"
-                self._function.is_implemented = True
-                self._parse_cfg(block)
+        self._function.is_implemented = True
+        self._parse_cfg(self._functionNotParsed.body)
 
         for local_var_parser in self._local_variables_parser:
             local_var_parser.analyze(self)
@@ -75,13 +55,9 @@ class ModifierSolc(FunctionSolc):
         self._filter_ternary()
         self._remove_alone_endif()
 
-        # self._analyze_read_write()
-        # self._analyze_calls()
-
-    def _parse_statement(self, statement: Dict, node: NodeSolc) -> NodeSolc:
-        name = statement[self.get_key()]
-        if name == "PlaceholderStatement":
-            placeholder_node = self._new_node(NodeType.PLACEHOLDER, statement["src"])
+    def _parse(self, stmt: ASTNode, node: NodeSolc) -> NodeSolc:
+        if isinstance(stmt, PlaceholderStatement):
+            placeholder_node = self._new_node(NodeType.PLACEHOLDER, stmt.src)
             link_nodes(node.underlying_node, placeholder_node.underlying_node)
             return placeholder_node
-        return super()._parse_statement(statement, node)
+        return super()._parse(stmt, node)

--- a/slither/solc_parsing/declarations/structure.py
+++ b/slither/solc_parsing/declarations/structure.py
@@ -4,6 +4,7 @@
 from typing import List, TYPE_CHECKING
 
 from slither.core.variables.structure_variable import StructureVariable
+from slither.solc_parsing.types.types import VariableDeclaration
 from slither.solc_parsing.variables.structure_variable import StructureVariableSolc
 from slither.core.declarations.structure import Structure
 
@@ -23,7 +24,7 @@ class StructureSolc:  # pylint: disable=too-few-public-methods
         st: Structure,
         name: str,
         canonicalName: str,
-        elems: List[str],
+        elems: List[VariableDeclaration],
         contract_parser: "ContractSolc",
     ):
         self._structure = st
@@ -37,11 +38,12 @@ class StructureSolc:  # pylint: disable=too-few-public-methods
         for elem_to_parse in self._elemsNotParsed:
             elem = StructureVariable()
             elem.set_structure(self._structure)
-            elem.set_offset(elem_to_parse["src"], self._structure.contract.slither)
+            elem.set_offset(elem_to_parse.src, self._structure.contract.slither)
 
             elem_parser = StructureVariableSolc(elem, elem_to_parse)
             elem_parser.analyze(self._contract_parser)
 
             self._structure.elems[elem.name] = elem
             self._structure.add_elem_in_order(elem.name)
-        self._elemsNotParsed = []
+
+        self._elemsNotParsed.clear()

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, TYPE_CHECKING, Optional, Union
+from typing import Dict, TYPE_CHECKING, Optional, Union, Callable
 
 from slither.core.declarations import Event, Enum, Structure
 from slither.core.declarations.contract import Contract
@@ -44,7 +44,24 @@ from slither.core.solidity_types import (
 )
 from slither.core.variables.variable import Variable
 from slither.solc_parsing.exceptions import ParsingError, VariableNotFound
-from slither.solc_parsing.solidity_types.type_parsing import UnknownType, parse_type
+from slither.solc_parsing.solidity_types.type_parsing import parse_type
+from slither.solc_parsing.types.types import \
+    Expression as ExpressionT, \
+    Literal as LiteralT, \
+    FunctionCallOptions as FunctionCallOptionsT, \
+    NewExpression as NewExpressionT, \
+    ModifierInvocation as ModifierInvocationT, \
+    IndexAccess as IndexAccessT, \
+    IndexRangeAccess as IndexRangeAccessT, \
+    ElementaryTypeNameExpression as ElementaryTypeNameExpressionT, \
+    Conditional as ConditionalT, \
+    TupleExpression as TupleExpressionT, \
+    Assignment as AssignmentT, \
+    UnaryOperation as UnaryOperationT, \
+    BinaryOperation as BinaryOperationT, \
+    Identifier as IdentifierT, \
+    MemberAccess as MemberAccessT, \
+    FunctionCall as FunctionCallT, ArrayTypeName, ElementaryTypeName, UserDefinedTypeName
 
 if TYPE_CHECKING:
     from slither.core.expressions.expression import Expression
@@ -238,6 +255,21 @@ def find_variable(  # pylint: disable=too-many-locals,too-many-statements
     raise VariableNotFound("Variable not found: {} (context {})".format(var_name, caller_context))
 
 
+def parse_super_name(expression: MemberAccessT) -> str:
+    arguments = expression.type_str
+    base_name = expression.member_name
+
+    assert arguments.startswith("function ")
+    # remove function (...()
+    arguments = arguments[len("function "):]
+
+    arguments = filter_name(arguments)
+    if " " in arguments:
+        arguments = arguments[: arguments.find(" ")]
+
+    return base_name + arguments
+
+
 # endregion
 ###################################################################################
 ###################################################################################
@@ -282,7 +314,6 @@ def filter_name(value: str) -> str:
 
 
 # endregion
-
 ###################################################################################
 ###################################################################################
 # region Parsing
@@ -290,77 +321,96 @@ def filter_name(value: str) -> str:
 ###################################################################################
 
 
-def parse_call(expression: Dict, caller_context):  # pylint: disable=too-many-statements
-    src = expression["src"]
-    if caller_context.is_compact_ast:
-        attributes = expression
-        type_conversion = expression["kind"] == "typeConversion"
-        type_return = attributes["typeDescriptions"]["typeString"]
+def parse_conditional(expr: ConditionalT, ctx: CallerContext) -> "Expression":
+    cond = parse_expression(expr.condition, ctx)
+    true_expr = parse_expression(expr.true_expr, ctx)
+    false_expr = parse_expression(expr.false_expr, ctx)
+    conditional = ConditionalExpression(cond, true_expr, false_expr)
+    conditional.set_offset(expr.src, ctx.slither)
+    return conditional
 
-    else:
-        attributes = expression["attributes"]
-        type_conversion = attributes["type_conversion"]
-        type_return = attributes["type"]
+
+def parse_assignment(expr: AssignmentT, ctx: CallerContext) -> "Expression":
+    lhs = parse_expression(expr.left, ctx)
+    rhs = parse_expression(expr.right, ctx)
+    op = AssignmentOperationType.get_type(expr.operator)
+    op_type = expr.type_str
+
+    assignement = AssignmentOperation(lhs, rhs, op, op_type)
+    assignement.set_offset(expr.src, ctx.slither)
+    return assignement
+
+
+def parse_tuple_expression(expr: TupleExpressionT, ctx: CallerContext) -> "Expression":
+    expressions = [parse_expression(e, ctx) if e else None for e in expr.components]
+
+    t = TupleExpression(expressions)
+    t.set_offset(expr.src, ctx.slither)
+    return t
+
+
+def parse_unary_operation(expr: UnaryOperationT, ctx: CallerContext) -> "Expression":
+    operation_type = UnaryOperationType.get_type(expr.operator, expr.is_prefix)
+    expression = parse_expression(expr.expression, ctx)
+
+    unary_op = UnaryOperation(expression, operation_type)
+    unary_op.set_offset(expr.src, ctx.slither)
+    return unary_op
+
+
+def parse_binary_operation(expr: BinaryOperationT, ctx: CallerContext) -> "Expression":
+    operation_type = BinaryOperationType.get_type(expr.operator)
+    left = parse_expression(expr.left, ctx)
+    right = parse_expression(expr.right, ctx)
+
+    binary_op = BinaryOperation(left, right, operation_type)
+    binary_op.set_offset(expr.src, ctx.slither)
+    return binary_op
+
+
+def parse_function_call(expr: FunctionCallT, ctx: CallerContext) -> "Expression":
+    src = expr.src
+    type_conversion = expr.kind == "typeConversion"
+    type_return = expr.type_str
 
     if type_conversion:
-        type_call = parse_type(UnknownType(type_return), caller_context)
+        type_call = parse_type(type_return, ctx)
+        expression_to_parse = expr.arguments[0]
 
-        if caller_context.is_compact_ast:
-            assert len(expression["arguments"]) == 1
-            expression_to_parse = expression["arguments"][0]
-        else:
-            children = expression["children"]
-            assert len(children) == 2
-            type_info = children[0]
-            expression_to_parse = children[1]
-            assert type_info["name"] in [
-                "ElementaryTypenameExpression",
-                "ElementaryTypeNameExpression",
-                "Identifier",
-                "TupleExpression",
-                "IndexAccess",
-                "MemberAccess",
-            ]
-
-        expression = parse_expression(expression_to_parse, caller_context)
+        expression = parse_expression(expression_to_parse, ctx)
         t = TypeConversion(expression, type_call)
-        t.set_offset(src, caller_context.slither)
+        t.set_offset(src, ctx.slither)
         return t
 
     call_gas = None
     call_value = None
     call_salt = None
-    if caller_context.is_compact_ast:
-        called = parse_expression(expression["expression"], caller_context)
-        # If the next expression is a FunctionCallOptions
-        # We can here the gas/value information
-        # This is only available if the syntax is {gas: , value: }
-        # For the .gas().value(), the member are considered as function call
-        # And converted later to the correct info (convert.py)
-        if expression["expression"][caller_context.get_key()] == "FunctionCallOptions":
-            call_with_options = expression["expression"]
-            for idx, name in enumerate(call_with_options.get("names", [])):
-                option = parse_expression(call_with_options["options"][idx], caller_context)
-                if name == "value":
-                    call_value = option
-                if name == "gas":
-                    call_gas = option
-                if name == "salt":
-                    call_salt = option
-        arguments = []
-        if expression["arguments"]:
-            arguments = [parse_expression(a, caller_context) for a in expression["arguments"]]
-    else:
-        children = expression["children"]
-        called = parse_expression(children[0], caller_context)
-        arguments = [parse_expression(a, caller_context) for a in children[1::]]
+    called = parse_expression(expr.expression, ctx)
+
+    # If the next expression is a FunctionCallOptions
+    # We can here the gas/value information
+    # This is only available if the syntax is {gas: , value: }
+    # For the .gas().value(), the member are considered as function call
+    # And converted later to the correct info (convert.py)
+    if isinstance(expr.expression, FunctionCallOptionsT):
+        call_with_options = expr.expression
+        for idx, name in enumerate(call_with_options.names):
+            option = parse_expression(call_with_options.options[idx], ctx)
+            if name == "value":
+                call_value = option
+            if name == "gas":
+                call_gas = option
+            if name == "salt":
+                call_salt = option
+
+    arguments = [parse_expression(a, ctx) for a in expr.arguments]
 
     if isinstance(called, SuperCallExpression):
         sp = SuperCallExpression(called, arguments, type_return)
-        sp.set_offset(expression["src"], caller_context.slither)
+        sp.set_offset(expr.src, ctx.slither)
         return sp
     call_expression = CallExpression(called, arguments, type_return)
-    call_expression.set_offset(src, caller_context.slither)
+    call_expression.set_offset(src, ctx.slither)
 
     # Only available if the syntax {gas:, value:} was used
     call_expression.call_gas = call_gas
@@ -369,423 +419,180 @@ def parse_call(expression: Dict, caller_context):  # pylint: disable=too-many-st
     return call_expression
 
 
-def parse_super_name(expression: Dict, is_compact_ast: bool) -> str:
-    if is_compact_ast:
-        assert expression["nodeType"] == "MemberAccess"
-        base_name = expression["memberName"]
-        arguments = expression["typeDescriptions"]["typeString"]
+def parse_function_call_options(expr: FunctionCallOptionsT, ctx: CallerContext) -> "Expression":
+    # call/gas info are handled in parse_call
+    called = parse_expression(expr.expression, ctx)
+    assert isinstance(called, (MemberAccess, NewContract))
+    return called
+
+
+def parse_new_expression(expr: NewExpressionT, ctx: CallerContext) -> "Expression":
+    typename = expr.typename
+
+    if isinstance(typename, ArrayTypeName):
+        depth = 0
+        while isinstance(typename, ArrayTypeName):
+            typename = typename.base
+            depth += 1
+
+        array_type = parse_type(typename, ctx)
+        array = NewArray(depth, array_type)
+        array.set_offset(expr.src, ctx.slither)
+        return array
+    elif isinstance(typename, ElementaryTypeName):
+        new_elem = NewElementaryType(typename.name)
+        new_elem.set_offset(expr.src, ctx.slither)
+        return new_elem
+    elif isinstance(typename, UserDefinedTypeName):
+        new = NewContract(typename.name)
+        new.set_offset(expr.src, ctx.slither)
+        return new
     else:
-        assert expression["name"] == "MemberAccess"
-        attributes = expression["attributes"]
-        base_name = attributes["member_name"]
-        arguments = attributes["type"]
-
-    assert arguments.startswith("function ")
-    # remove function (...()
-    arguments = arguments[len("function ") :]
-
-    arguments = filter_name(arguments)
-    if " " in arguments:
-        arguments = arguments[: arguments.find(" ")]
-
-    return base_name + arguments
+        raise ParsingError("unexpected new type", typename)
 
 
-def _parse_elementary_type_name_expression(
-    expression: Dict, is_compact_ast: bool, caller_context
-) -> ElementaryTypeNameExpression:
-    # nop exression
-    # uint;
-    if is_compact_ast:
-        value = expression["typeName"]
-    else:
-        assert "children" not in expression
-        value = expression["attributes"]["value"]
-    if isinstance(value, dict):
-        t = parse_type(value, caller_context)
-    else:
-        t = parse_type(UnknownType(value), caller_context)
+def parse_member_access(expr: MemberAccessT, ctx: CallerContext) -> "Expression":
+    member_name = expr.member_name
+    member_type = expr.type_str
+    member_expression = parse_expression(expr.expression, ctx)
+
+    if str(member_expression) == "super":
+        super_name = parse_super_name(expr)
+        var = find_variable(super_name, ctx, is_super=True)
+        if var is None:
+            raise VariableNotFound("Variable not found: {}".format(super_name))
+        sup = SuperIdentifier(var)
+        sup.set_offset(expr.src, ctx.slither)
+        return sup
+
+    member_access = MemberAccess(member_name, member_type, member_expression)
+    member_access.set_offset(expr.src, ctx.slither)
+    if str(member_access) in SOLIDITY_VARIABLES_COMPOSED:
+        idx = Identifier(SolidityVariableComposed(str(member_access)))
+        idx.set_offset(expr.src, ctx.slither)
+        return idx
+    return member_access
+
+
+def parse_index_access(expr: IndexAccessT, ctx: CallerContext) -> "Expression":
+    # IndexAccess is used to describe ElementaryTypeNameExpression
+    # if abi.decode is used
+    # For example, abi.decode(data, ...(uint[]) )
+    if expr.index is None:
+        ret = parse_expression(expr.base, ctx)
+        # Nested array are not yet available in abi.decode
+        if isinstance(ret, ElementaryTypeNameExpression):
+            old_type = ret.type
+            ret.type = ArrayType(old_type, None)
+        return ret
+
+    left_expression = parse_expression(expr.base, ctx)
+    right_expression = parse_expression(expr.index, ctx)
+    index = IndexAccess(left_expression, right_expression, expr.type_str)
+    index.set_offset(expr.src, ctx.slither)
+    return index
+
+
+def parse_index_range_access(expr: IndexRangeAccessT, ctx: CallerContext) -> "Expression":
+    # For now, we convert array slices to a direct array access
+    # As a result the generated IR will lose the slices information
+    # As far as I understand, array slice are only used in abi.decode
+    # https://solidity.readthedocs.io/en/v0.6.12/types.html
+    # TODO: Investigate array slices usage and implication for the IR
+    return parse_expression(expr.base, ctx)
+
+
+def parse_identifier(expr: IdentifierT, ctx: CallerContext) -> "Expression":
+    value = expr.name
+    t = expr.type_str
+
+    if t:
+        found = re.findall("[struct|enum|function|modifier] \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
+        assert len(found) <= 1
+        if found:
+            value = value + "(" + found[0] + ")"
+            value = filter_name(value)
+
+    referenced_declaration = None  # expr.referenced_declaration
+
+    var = find_variable(value, ctx, referenced_declaration)
+
+    identifier = Identifier(var)
+    identifier.set_offset(expr.src, ctx.slither)
+    return identifier
+
+
+def parse_elementary_type_name_expression(expr: ElementaryTypeNameExpressionT, ctx: CallerContext) -> "Expression":
+    t = parse_type(expr.typename, ctx)
     e = ElementaryTypeNameExpression(t)
-    e.set_offset(expression["src"], caller_context.slither)
+    e.set_offset(expr.src, ctx.slither)
     return e
 
+def parse_literal(expr: LiteralT, ctx: CallerContext) -> "Expression":
+    subdenomination = None
 
-def parse_expression(expression: Dict, caller_context: CallerContext) -> "Expression":
-    # pylint: disable=too-many-nested-blocks,too-many-statements
-    """
+    value = expr.value
+    if value:
+        subdenomination = expr.subdenomination
+    elif not value and value != "":
+        value = "0x" + expr.hex_value
+    type_candidate = expr.type_str
 
-    Returns:
-        str: expression
-    """
-    #  Expression
-    #    = Expression ('++' | '--')
-    #    | NewExpression
-    #    | IndexAccess
-    #    | MemberAccess
-    #    | FunctionCall
-    #    | '(' Expression ')'
-    #    | ('!' | '~' | 'delete' | '++' | '--' | '+' | '-') Expression
-    #    | Expression '**' Expression
-    #    | Expression ('*' | '/' | '%') Expression
-    #    | Expression ('+' | '-') Expression
-    #    | Expression ('<<' | '>>') Expression
-    #    | Expression '&' Expression
-    #    | Expression '^' Expression
-    #    | Expression '|' Expression
-    #    | Expression ('<' | '>' | '<=' | '>=') Expression
-    #    | Expression ('==' | '!=') Expression
-    #    | Expression '&&' Expression
-    #    | Expression '||' Expression
-    #    | Expression '?' Expression ':' Expression
-    #    | Expression ('=' | '|=' | '^=' | '&=' | '<<=' | '>>=' | '+=' | '-=' | '*=' | '/=' | '%=') Expression
-    #    | PrimaryExpression
-    # The AST naming does not follow the spec
-    name = expression[caller_context.get_key()]
-    is_compact_ast = caller_context.is_compact_ast
-    src = expression["src"]
+    # Length declaration for array was None until solc 0.5.5
+    if type_candidate is None:
+        if expr.kind == "number":
+            type_candidate = "int_const"
 
-    if name == "UnaryOperation":
-        if is_compact_ast:
-            attributes = expression
-        else:
-            attributes = expression["attributes"]
-        assert "prefix" in attributes
-        operation_type = UnaryOperationType.get_type(attributes["operator"], attributes["prefix"])
-
-        if is_compact_ast:
-            expression = parse_expression(expression["subExpression"], caller_context)
-        else:
-            assert len(expression["children"]) == 1
-            expression = parse_expression(expression["children"][0], caller_context)
-        unary_op = UnaryOperation(expression, operation_type)
-        unary_op.set_offset(src, caller_context.slither)
-        return unary_op
-
-    if name == "BinaryOperation":
-        if is_compact_ast:
-            attributes = expression
-        else:
-            attributes = expression["attributes"]
-        operation_type = BinaryOperationType.get_type(attributes["operator"])
-
-        if is_compact_ast:
-            left_expression = parse_expression(expression["leftExpression"], caller_context)
-            right_expression = parse_expression(expression["rightExpression"], caller_context)
-        else:
-            assert len(expression["children"]) == 2
-            left_expression = parse_expression(expression["children"][0], caller_context)
-            right_expression = parse_expression(expression["children"][1], caller_context)
-        binary_op = BinaryOperation(left_expression, right_expression, operation_type)
-        binary_op.set_offset(src, caller_context.slither)
-        return binary_op
-
-    if name in "FunctionCall":
-        return parse_call(expression, caller_context)
-
-    if name == "FunctionCallOptions":
-        # call/gas info are handled in parse_call
-        called = parse_expression(expression["expression"], caller_context)
-        assert isinstance(called, (MemberAccess, NewContract))
-        return called
-
-    if name == "TupleExpression":
-        #     For expression like
-        #     (a,,c) = (1,2,3)
-        #     the AST provides only two children in the left side
-        #     We check the type provided (tuple(uint256,,uint256))
-        #     To determine that there is an empty variable
-        #     Otherwhise we would not be able to determine that
-        #     a = 1, c = 3, and 2 is lost
-        #
-        #     Note: this is only possible with Solidity >= 0.4.12
-        if is_compact_ast:
-            expressions = [
-                parse_expression(e, caller_context) if e else None for e in expression["components"]
-            ]
-        else:
-            if "children" not in expression:
-                attributes = expression["attributes"]
-                components = attributes["components"]
-                expressions = [
-                    parse_expression(c, caller_context) if c else None for c in components
-                ]
-            else:
-                expressions = [parse_expression(e, caller_context) for e in expression["children"]]
-        # Add none for empty tuple items
-        if "attributes" in expression:
-            if "type" in expression["attributes"]:
-                t = expression["attributes"]["type"]
-                if ",," in t or "(," in t or ",)" in t:
-                    t = t[len("tuple(") : -1]
-                    elems = t.split(",")
-                    for idx, _ in enumerate(elems):
-                        if elems[idx] == "":
-                            expressions.insert(idx, None)
-        t = TupleExpression(expressions)
-        t.set_offset(src, caller_context.slither)
-        return t
-
-    if name == "Conditional":
-        if is_compact_ast:
-            if_expression = parse_expression(expression["condition"], caller_context)
-            then_expression = parse_expression(expression["trueExpression"], caller_context)
-            else_expression = parse_expression(expression["falseExpression"], caller_context)
-        else:
-            children = expression["children"]
-            assert len(children) == 3
-            if_expression = parse_expression(children[0], caller_context)
-            then_expression = parse_expression(children[1], caller_context)
-            else_expression = parse_expression(children[2], caller_context)
-        conditional = ConditionalExpression(if_expression, then_expression, else_expression)
-        conditional.set_offset(src, caller_context.slither)
-        return conditional
-
-    if name == "Assignment":
-        if is_compact_ast:
-            left_expression = parse_expression(expression["leftHandSide"], caller_context)
-            right_expression = parse_expression(expression["rightHandSide"], caller_context)
-
-            operation_type = AssignmentOperationType.get_type(expression["operator"])
-
-            operation_return_type = expression["typeDescriptions"]["typeString"]
-        else:
-            attributes = expression["attributes"]
-            children = expression["children"]
-            assert len(expression["children"]) == 2
-            left_expression = parse_expression(children[0], caller_context)
-            right_expression = parse_expression(children[1], caller_context)
-
-            operation_type = AssignmentOperationType.get_type(attributes["operator"])
-            operation_return_type = attributes["type"]
-
-        assignement = AssignmentOperation(
-            left_expression, right_expression, operation_type, operation_return_type
-        )
-        assignement.set_offset(src, caller_context.slither)
-        return assignement
-
-    if name == "Literal":
-
-        subdenomination = None
-
-        assert "children" not in expression
-
-        if is_compact_ast:
-            value = expression["value"]
-            if value:
-                if "subdenomination" in expression and expression["subdenomination"]:
-                    subdenomination = expression["subdenomination"]
-            elif not value and value != "":
-                value = "0x" + expression["hexValue"]
-            type_candidate = expression["typeDescriptions"]["typeString"]
-
-            # Length declaration for array was None until solc 0.5.5
-            if type_candidate is None:
-                if expression["kind"] == "number":
-                    type_candidate = "int_const"
-        else:
-            value = expression["attributes"]["value"]
-            if value:
-                if (
-                    "subdenomination" in expression["attributes"]
-                    and expression["attributes"]["subdenomination"]
-                ):
-                    subdenomination = expression["attributes"]["subdenomination"]
-            elif value is None:
-                # for literal declared as hex
-                # see https://solidity.readthedocs.io/en/v0.4.25/types.html?highlight=hex#hexadecimal-literals
-                assert "hexvalue" in expression["attributes"]
-                value = "0x" + expression["attributes"]["hexvalue"]
-            type_candidate = expression["attributes"]["type"]
-
-        if type_candidate is None:
-            if value.isdecimal():
-                type_candidate = ElementaryType("uint256")
-            else:
-                type_candidate = ElementaryType("string")
-        elif type_candidate.startswith("int_const "):
+    if type_candidate is None:
+        if value.isdecimal():
             type_candidate = ElementaryType("uint256")
-        elif type_candidate.startswith("bool"):
-            type_candidate = ElementaryType("bool")
-        elif type_candidate.startswith("address"):
-            type_candidate = ElementaryType("address")
         else:
             type_candidate = ElementaryType("string")
-        literal = Literal(value, type_candidate, subdenomination)
-        literal.set_offset(src, caller_context.slither)
-        return literal
+    elif type_candidate.startswith("int_const "):
+        type_candidate = ElementaryType("uint256")
+    elif type_candidate.startswith("bool"):
+        type_candidate = ElementaryType("bool")
+    elif type_candidate.startswith("address"):
+        type_candidate = ElementaryType("address")
+    else:
+        type_candidate = ElementaryType("string")
+    literal = Literal(value, type_candidate, subdenomination)
+    literal.set_offset(expr.src, ctx.slither)
+    return literal
 
-    if name == "Identifier":
-        assert "children" not in expression
+def parse_modifier_invocation(expr: ModifierInvocationT, ctx: CallerContext) -> "Expression":
+    called = parse_expression(expr.modifier, ctx)
+    args = [parse_expression(a, ctx) for a in expr.args] if expr.args else []
 
-        t = None
+    call = CallExpression(called, args, "Modifier")
+    call.set_offset(expr.src, ctx.slither)
+    return call
 
-        if caller_context.is_compact_ast:
-            value = expression["name"]
-            t = expression["typeDescriptions"]["typeString"]
-        else:
-            value = expression["attributes"]["value"]
-            if "type" in expression["attributes"]:
-                t = expression["attributes"]["type"]
 
-        if t:
-            found = re.findall("[struct|enum|function|modifier] \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
-            assert len(found) <= 1
-            if found:
-                value = value + "(" + found[0] + ")"
-                value = filter_name(value)
+def parse_unhandled(expr: ExpressionT, ctx: CallerContext) -> "Expression":
+    raise Exception("unhandled expr", type(expr))
 
-        if "referencedDeclaration" in expression:
-            referenced_declaration = expression["referencedDeclaration"]
-        else:
-            referenced_declaration = None
 
-        var = find_variable(value, caller_context, referenced_declaration)
+def parse_expression(expr: ExpressionT, ctx: CallerContext) -> "Expression":
+    return PARSERS.get(type(expr), parse_unhandled)(expr, ctx)
 
-        identifier = Identifier(var)
-        identifier.set_offset(src, caller_context.slither)
-        return identifier
 
-    if name == "IndexAccess":
-        if is_compact_ast:
-            index_type = expression["typeDescriptions"]["typeString"]
-            left = expression["baseExpression"]
-            right = expression["indexExpression"]
-        else:
-            index_type = expression["attributes"]["type"]
-            children = expression["children"]
-            assert len(children) == 2
-            left = children[0]
-            right = children[1]
-        # IndexAccess is used to describe ElementaryTypeNameExpression
-        # if abi.decode is used
-        # For example, abi.decode(data, ...(uint[]) )
-        if right is None:
-            ret = parse_expression(left, caller_context)
-            # Nested array are not yet available in abi.decode
-            if isinstance(ret, ElementaryTypeNameExpression):
-                old_type = ret.type
-                ret.type = ArrayType(old_type, None)
-            return ret
+PARSERS: Dict[type, Callable[[ExpressionT, CallerContext], "Expression"]] = {
+    ConditionalT: parse_conditional,
+    AssignmentT: parse_assignment,
+    TupleExpressionT: parse_tuple_expression,
+    UnaryOperationT: parse_unary_operation,
+    BinaryOperationT: parse_binary_operation,
+    FunctionCallT: parse_function_call,
+    FunctionCallOptionsT: parse_function_call_options,
+    NewExpressionT: parse_new_expression,
+    MemberAccessT: parse_member_access,
+    IndexAccessT: parse_index_access,
+    IndexRangeAccessT: parse_index_range_access,
+    IdentifierT: parse_identifier,
+    ElementaryTypeNameExpressionT: parse_elementary_type_name_expression,
+    LiteralT: parse_literal,
 
-        left_expression = parse_expression(left, caller_context)
-        right_expression = parse_expression(right, caller_context)
-        index = IndexAccess(left_expression, right_expression, index_type)
-        index.set_offset(src, caller_context.slither)
-        return index
-
-    if name == "MemberAccess":
-        if caller_context.is_compact_ast:
-            member_name = expression["memberName"]
-            member_type = expression["typeDescriptions"]["typeString"]
-            member_expression = parse_expression(expression["expression"], caller_context)
-        else:
-            member_name = expression["attributes"]["member_name"]
-            member_type = expression["attributes"]["type"]
-            children = expression["children"]
-            assert len(children) == 1
-            member_expression = parse_expression(children[0], caller_context)
-        if str(member_expression) == "super":
-            super_name = parse_super_name(expression, is_compact_ast)
-            var = find_variable(super_name, caller_context, is_super=True)
-            if var is None:
-                raise VariableNotFound("Variable not found: {}".format(super_name))
-            sup = SuperIdentifier(var)
-            sup.set_offset(src, caller_context.slither)
-            return sup
-        member_access = MemberAccess(member_name, member_type, member_expression)
-        member_access.set_offset(src, caller_context.slither)
-        if str(member_access) in SOLIDITY_VARIABLES_COMPOSED:
-            idx = Identifier(SolidityVariableComposed(str(member_access)))
-            idx.set_offset(src, caller_context.slither)
-            return idx
-        return member_access
-
-    if name == "ElementaryTypeNameExpression":
-        return _parse_elementary_type_name_expression(expression, is_compact_ast, caller_context)
-
-    # NewExpression is not a root expression, it's always the child of another expression
-    if name == "NewExpression":
-
-        if is_compact_ast:
-            type_name = expression["typeName"]
-        else:
-            children = expression["children"]
-            assert len(children) == 1
-            type_name = children[0]
-
-        if type_name[caller_context.get_key()] == "ArrayTypeName":
-            depth = 0
-            while type_name[caller_context.get_key()] == "ArrayTypeName":
-                # Note: dont conserve the size of the array if provided
-                # We compute it directly
-                if is_compact_ast:
-                    type_name = type_name["baseType"]
-                else:
-                    type_name = type_name["children"][0]
-                depth += 1
-            if type_name[caller_context.get_key()] == "ElementaryTypeName":
-                if is_compact_ast:
-                    array_type = ElementaryType(type_name["name"])
-                else:
-                    array_type = ElementaryType(type_name["attributes"]["name"])
-            elif type_name[caller_context.get_key()] == "UserDefinedTypeName":
-                if is_compact_ast:
-                    array_type = parse_type(UnknownType(type_name["name"]), caller_context)
-                else:
-                    array_type = parse_type(
-                        UnknownType(type_name["attributes"]["name"]), caller_context
-                    )
-            elif type_name[caller_context.get_key()] == "FunctionTypeName":
-                array_type = parse_type(type_name, caller_context)
-            else:
-                raise ParsingError("Incorrect type array {}".format(type_name))
-            array = NewArray(depth, array_type)
-            array.set_offset(src, caller_context.slither)
-            return array
-
-        if type_name[caller_context.get_key()] == "ElementaryTypeName":
-            if is_compact_ast:
-                elem_type = ElementaryType(type_name["name"])
-            else:
-                elem_type = ElementaryType(type_name["attributes"]["name"])
-            new_elem = NewElementaryType(elem_type)
-            new_elem.set_offset(src, caller_context.slither)
-            return new_elem
-
-        assert type_name[caller_context.get_key()] == "UserDefinedTypeName"
-
-        if is_compact_ast:
-            contract_name = type_name["name"]
-        else:
-            contract_name = type_name["attributes"]["name"]
-        new = NewContract(contract_name)
-        new.set_offset(src, caller_context.slither)
-        return new
-
-    if name == "ModifierInvocation":
-
-        if is_compact_ast:
-            called = parse_expression(expression["modifierName"], caller_context)
-            arguments = []
-            if expression.get("arguments", None):
-                arguments = [parse_expression(a, caller_context) for a in expression["arguments"]]
-        else:
-            children = expression["children"]
-            called = parse_expression(children[0], caller_context)
-            arguments = [parse_expression(a, caller_context) for a in children[1::]]
-
-        call = CallExpression(called, arguments, "Modifier")
-        call.set_offset(src, caller_context.slither)
-        return call
-
-    if name == "IndexRangeAccess":
-        # For now, we convert array slices to a direct array access
-        # As a result the generated IR will lose the slices information
-        # As far as I understand, array slice are only used in abi.decode
-        # https://solidity.readthedocs.io/en/v0.6.12/types.html
-        # TODO: Investigate array slices usage and implication for the IR
-        base = parse_expression(expression["baseExpression"], caller_context)
-        return base
-
-    raise ParsingError("Expression not parsed %s" % name)
+    ModifierInvocationT: parse_modifier_invocation,
+}
+# endregion

--- a/slither/solc_parsing/types/compact_json.py
+++ b/slither/solc_parsing/types/compact_json.py
@@ -1,0 +1,792 @@
+from typing import Callable
+
+from slither.solc_parsing.exceptions import ParsingError
+from slither.solc_parsing.types.types import * # lgtm[py/polluting-import]
+
+"""
+The compact AST format was introduced in Solidity 0.4.12. In general, each node contains the following properties:
+
+id (int): internal node id
+nodeType (string): type of node
+src (string): src offset
+
+A node may also contain common properties depending on its type. All expressions, declarations, and calls share
+similar properties, which are extracted below
+"""
+
+
+def _extract_base_props(raw: Dict) -> Dict:
+    return {
+        'src': raw['src'],
+        'id': raw['id'],
+    }
+
+
+def _extract_expr_props(raw: Dict) -> Dict:
+    return {
+        **_extract_base_props(raw),
+        'type_str': raw['typeDescriptions']['typeString'],
+        'constant': raw.get("isConstant", False),  # Identifier doesn't expose this
+        'pure': raw.get('isPure', False),  # Identifier doesn't expose this
+    }
+
+
+def _extract_decl_props(raw: Dict) -> Dict:
+    return {
+        **_extract_base_props(raw),
+        'name': raw.get('name', None),
+        'canonical_name': raw.get('canonicalName', ''),
+        'visibility': raw.get('visibility', None),
+    }
+
+
+def _extract_call_props(raw: Dict) -> Dict:
+    params = parse(raw['parameters'])
+
+    if 'returnParameters' in raw:
+        rets = parse(raw['returnParameters'])
+    else:
+        rets = None
+
+    return {
+        **_extract_decl_props(raw),
+        'params': params,
+        'rets': rets,
+    }
+
+
+def parse_source_unit(raw: Dict) -> SourceUnit:
+    nodes_parsed: List[ASTNode] = []
+
+    for node in raw['nodes']:
+        nodes_parsed.append(parse(node))
+
+    return SourceUnit(nodes_parsed, **_extract_base_props(raw))
+
+
+def parse_pragma_directive(raw: Dict) -> PragmaDirective:
+    return PragmaDirective(raw['literals'], **_extract_base_props(raw))
+
+
+def parse_import_directive(raw: Dict) -> ImportDirective:
+    return ImportDirective(raw['absolutePath'], **_extract_decl_props(raw))
+
+
+def parse_contract_definition(raw: Dict) -> ContractDefinition:
+    nodes_parsed: List[ASTNode] = []
+    for child in raw['nodes']:
+        nodes_parsed.append(parse(child))
+
+    base_contracts: List[InheritanceSpecifier] = []
+    for child in raw['baseContracts']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, InheritanceSpecifier)
+
+        base_contracts.append(child_parsed)
+
+    return ContractDefinition(raw['contractKind'], raw['linearizedBaseContracts'], base_contracts, nodes_parsed,
+                              **_extract_decl_props(raw))
+
+
+def parse_inheritance_specifier(raw: Dict) -> InheritanceSpecifier:
+    basename_parsed = parse(raw['baseName'])
+    assert isinstance(basename_parsed, UserDefinedTypeName)
+
+    if raw['arguments']:
+        args_parsed = []
+        for child in raw['arguments']:
+            child_parsed = parse(child)
+            assert isinstance(child_parsed, Expression)
+            args_parsed.append(child_parsed)
+    else:
+        args_parsed = None
+
+    return InheritanceSpecifier(basename_parsed, args_parsed, **_extract_base_props(raw))
+
+
+def parse_using_for_directive(raw: Dict) -> UsingForDirective:
+    library_name_parsed = parse(raw['libraryName'])
+    assert isinstance(library_name_parsed, UserDefinedTypeName)
+
+    typename_parsed = parse(raw['typeName'])
+    assert isinstance(typename_parsed, TypeName)
+
+    return UsingForDirective(library_name_parsed, typename_parsed, **_extract_base_props(raw))
+
+
+def parse_struct_definition(raw: Dict) -> StructDefinition:
+    members_parsed: List[VariableDeclaration] = []
+    for child in raw['members']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, VariableDeclaration)
+        members_parsed.append(child_parsed)
+
+    return StructDefinition(members_parsed, **_extract_decl_props(raw))
+
+
+def parse_enum_definition(raw: Dict) -> EnumDefinition:
+    members_parsed: List[EnumValue] = []
+    for child in raw['members']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, EnumValue)
+
+    return EnumDefinition(members_parsed, **_extract_decl_props(raw))
+
+
+def parse_enum_value(raw: Dict) -> EnumValue:
+    return EnumValue(**_extract_decl_props(raw))
+
+
+def parse_parameter_list(raw: Dict) -> ParameterList:
+    """
+    parameters (VariableDeclaration[])
+    """
+
+    parameters_parsed = []
+    for child in raw['parameters']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, VariableDeclaration)
+        parameters_parsed.append(child_parsed)
+
+    return ParameterList(parameters_parsed, **_extract_base_props(raw))
+
+
+def parse_function_definition(raw: Dict) -> FunctionDefinition:
+    if raw['body']:
+        body_parsed = parse(raw['body'])
+        assert isinstance(body_parsed, Block)
+    else:
+        body_parsed = None
+
+    modifiers_parsed = []
+    for child in raw['modifiers']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, ModifierInvocation)
+        modifiers_parsed.append(child_parsed)
+
+    if 'stateMutability' in raw:
+        # >=0.4.16
+        mutability = raw['stateMutability']
+    elif 'payable' in raw:
+        # >=0.4.5
+        mutability = "payable" if raw['payable'] else "nonpayable"
+    else:
+        raise ParsingError("don't know how to extract state mutability")
+
+    if 'kind' in raw:
+        # >= 0.5.0
+        kind = raw['kind']
+    elif 'isConstructor' in raw and raw['isConstructor']:
+        # >= 0.4.12
+        kind = "constructor"
+    else:
+        # >= 0.4.0
+        kind = 'fallback' if raw['name'] == '' else 'function'
+
+    return FunctionDefinition(mutability, kind, modifiers_parsed, body_parsed,
+                              **_extract_call_props(raw))
+
+
+def parse_variable_declaration(raw: Dict) -> VariableDeclaration:
+    """
+    name (string)
+    typeName (ElementaryTypeName)
+    constant (boolean)
+    mutability (string)
+    stateVariable (boolean)
+    storageLocation (string)
+    overrides (OverrideSpecifier[]?)
+    visibility (string)
+    value (Expression?)
+    scope (int)
+    typeDescriptions (TypeDescription)
+    functionSelector (string): only if public state variable
+    indexed (bool): only if event variable
+    baseFunctions (int[]): only if overriding function
+    """
+
+    type_parsed = parse(raw['typeName'])
+    assert isinstance(type_parsed, TypeName)
+
+    if 'value' in raw and raw['value']:
+        value_parsed = parse(raw['value'])
+        assert isinstance(value_parsed, Expression)
+    else:
+        value_parsed = None
+
+    indexed = raw['indexed'] if 'indexed' in raw else None
+
+    storage_location = raw['storageLocation']
+
+    return VariableDeclaration(type_parsed, value_parsed, raw['typeDescriptions']['typeString'],
+                               raw['constant'], indexed, storage_location, **_extract_decl_props(raw))
+
+
+def parse_modifier_definition(raw: Dict) -> ModifierDefinition:
+    body_parsed = parse(raw['body'])
+    assert isinstance(body_parsed, Block)
+
+    return ModifierDefinition(body_parsed, **_extract_call_props(raw))
+
+
+def parse_modifier_invocation(raw: Dict) -> ModifierInvocation:
+    if raw['arguments']:
+        arguments_parsed: Optional[List[Expression]] = []
+        for child in raw['arguments']:
+            child_parsed = parse(child)
+            assert isinstance(child_parsed, Expression)
+            arguments_parsed.append(child_parsed)
+    else:
+        arguments_parsed = None
+
+    name_parsed = parse(raw['modifierName'])
+    assert isinstance(name_parsed, Identifier)
+
+    return ModifierInvocation(name_parsed, arguments_parsed, **_extract_base_props(raw))
+
+
+def parse_event_definition(raw: Dict) -> EventDefinition:
+    return EventDefinition(raw['anonymous'], **_extract_call_props(raw))
+
+
+def parse_elementary_type_name(raw: Dict) -> ElementaryTypeName:
+    """
+    name (string)
+    """
+
+    name = raw['name']
+
+    mutability = None
+    if 'stateMutability' in raw:
+        mutability = raw['stateMutability']
+
+    return ElementaryTypeName(name, mutability, **_extract_base_props(raw))
+
+
+def parse_user_defined_type_name(raw: Dict) -> UserDefinedTypeName:
+    return UserDefinedTypeName(raw['name'], raw['referencedDeclaration'], **_extract_base_props(raw))
+
+
+def parse_function_type_name(raw: Dict) -> FunctionTypeName:
+    params = parse(raw['parameterTypes'])
+    assert isinstance(params, ParameterList)
+
+    rets = parse(raw['returnParameterTypes'])
+    assert isinstance(rets, ParameterList)
+
+    return FunctionTypeName(params, rets, raw['stateMutability'], raw['visibility'], **_extract_base_props(raw))
+
+
+def parse_mapping(raw: Dict) -> Mapping:
+    key_parsed = parse(raw['keyType'])
+    assert isinstance(key_parsed, TypeName)
+
+    val_parsed = parse(raw['valueType'])
+    assert isinstance(val_parsed, TypeName)
+
+    return Mapping(key_parsed, val_parsed, **_extract_base_props(raw))
+
+
+def parse_array_type_name(raw: Dict) -> ArrayTypeName:
+    base_parsed = parse(raw['baseType'])
+    assert isinstance(base_parsed, TypeName)
+
+    if raw['length']:
+        len_parsed = parse(raw['length'])
+        assert isinstance(len_parsed, Expression)
+    else:
+        len_parsed = None
+
+    return ArrayTypeName(base_parsed, len_parsed, **_extract_base_props(raw))
+
+
+def parse_inline_assembly(raw: Dict) -> InlineAssembly:
+    if 'AST' in raw:
+        # >= 0.6.0
+        ast = raw['AST']
+        assert isinstance(ast, dict)
+    elif 'operations' in raw:
+        # >= 0.4.12
+        ast = raw['operations']
+        assert isinstance(ast, str)
+    else:
+        raise ParsingError("not sure now to extract inline assembly")
+    return InlineAssembly(ast, **_extract_base_props(raw))
+
+
+def parse_block(raw: Dict) -> Block:
+    """
+    statements (Statement[]): list of statements
+    """
+
+    parsed_statements: List[Statement] = []
+    for statement in raw['statements']:
+        parsed_statement = parse(statement)
+        assert isinstance(parsed_statement, Statement)
+        parsed_statements.append(parsed_statement)
+
+    return Block(parsed_statements, **_extract_base_props(raw))
+
+
+def parse_placeholder_statement(raw: Dict) -> PlaceholderStatement:
+    return PlaceholderStatement(**_extract_base_props(raw))
+
+
+def parse_if_statement(raw: Dict) -> IfStatement:
+    """
+    condition (Expression)
+    trueBody (Statement)
+    falseBody (Statement)
+    """
+
+    condition_parsed = parse(raw['condition'])
+    true_body_parsed = parse(raw['trueBody'])
+
+    if 'falseBody' in raw and raw['falseBody']:
+        false_body_parsed = parse(raw['falseBody'])
+        assert isinstance(false_body_parsed, Statement)
+    else:
+        false_body_parsed = None
+
+    assert isinstance(condition_parsed, Expression)
+    assert isinstance(true_body_parsed, Statement)
+
+    return IfStatement(condition_parsed, true_body_parsed, false_body_parsed, **_extract_base_props(raw))
+
+
+def parse_try_catch_clause(raw: Dict) -> TryCatchClause:
+    """
+    errorName (string)
+    parameters (ParameterList?)
+    block (Block)
+    """
+
+    error_name = raw['errorName']
+    if raw['parameters']:
+        parameters_parsed = parse(raw['parameters'])
+        assert isinstance(parameters_parsed, ParameterList)
+    else:
+        parameters_parsed = None
+    block_parsed = parse(raw['block'])
+    assert isinstance(block_parsed, Block)
+
+    return TryCatchClause(error_name, parameters_parsed, block_parsed, **_extract_base_props(raw))
+
+
+def parse_try_statement(raw: Dict) -> TryStatement:
+    """
+    externalCall (Expression)
+    clauses (TryCatchClause[])
+    """
+
+    external_call_parsed = parse(raw['externalCall'])
+    assert isinstance(external_call_parsed, Expression)
+
+    clauses_parsed = []
+    for child in raw['clauses']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, TryCatchClause)
+        clauses_parsed.append(child_parsed)
+
+    return TryStatement(external_call_parsed, clauses_parsed, **_extract_base_props(raw))
+
+
+def parse_while_statement_internal(raw: Dict, is_do_while: bool) -> WhileStatement:
+    """
+    condition (Expression)
+    body (Statement)
+    """
+
+    condition_parsed = parse(raw['condition'])
+    assert isinstance(condition_parsed, Expression)
+
+    body_parsed = parse(raw['body'])
+    assert isinstance(body_parsed, Statement)
+
+    return WhileStatement(condition_parsed, body_parsed, is_do_while, **_extract_base_props(raw))
+
+
+def parse_while_statement(raw: Dict) -> WhileStatement:
+    return parse_while_statement_internal(raw, False)
+
+
+def parse_do_while_statement(raw: Dict) -> WhileStatement:
+    return parse_while_statement_internal(raw, True)
+
+
+def parse_for_statement(raw: Dict) -> ForStatement:
+    """
+    initializationExpression (Statement)
+    condition (Expression)
+    loopExpression (ExpressionStatement)
+    body (Statement)
+    """
+
+    init_parsed = parse(raw['initializationExpression'])
+    assert isinstance(init_parsed, Statement)
+
+    cond_parsed = parse(raw['condition'])
+    assert isinstance(cond_parsed, Expression)
+
+    loop_parsed = parse(raw['loopExpression'])
+    assert isinstance(loop_parsed, ExpressionStatement)
+
+    body_parsed = parse(raw['body'])
+    assert isinstance(body_parsed, Statement)
+
+    return ForStatement(init_parsed, cond_parsed, loop_parsed, body_parsed, **_extract_base_props(raw))
+
+
+def parse_continue(raw: Dict) -> Continue:
+    return Continue(**_extract_base_props(raw))
+
+
+def parse_break(raw: Dict) -> Break:
+    return Break(**_extract_base_props(raw))
+
+
+def parse_return(raw: Dict) -> Return:
+    """
+    expression (Expression?)
+    functionReturnParameters (int)
+    """
+    if raw['expression']:
+        expr_parsed = parse(raw['expression'])
+    else:
+        expr_parsed = None
+
+    return Return(expr_parsed, **_extract_base_props(raw))
+
+
+def parse_throw(raw: Dict) -> Throw:
+    return Throw(**_extract_base_props(raw))
+
+
+def parse_emit_statement(raw: Dict) -> EmitStatement:
+    """
+    eventCall (FunctionCall)
+    """
+    call_parsed = parse(raw['eventCall'])
+    assert isinstance(call_parsed, FunctionCall)
+
+    return EmitStatement(call_parsed, **_extract_base_props(raw))
+
+
+def parse_variable_declaration_statement(raw: Dict) -> VariableDeclarationStatement:
+    """
+    assignments (int[]): ids of variables declared
+    declarations (VariableDeclaration[]): variables declared
+    initialValue (Expression?): initial value, if any
+    """
+
+    parsed_variables: List[Optional[VariableDeclaration]] = []
+    for declaration in raw['declarations']:
+        if declaration:
+            parsed_variable = parse(declaration)
+            assert isinstance(parsed_variable, VariableDeclaration)
+            parsed_variables.append(parsed_variable)
+        else:
+            parsed_variables.append(None)
+
+    if raw['initialValue']:
+        initial_value = parse(raw['initialValue'])
+        assert isinstance(initial_value, Expression)
+    else:
+        initial_value = None
+
+    return VariableDeclarationStatement(parsed_variables, initial_value, **_extract_base_props(raw))
+
+
+def parse_expression_statement(raw: Dict) -> ExpressionStatement:
+    """
+    expression (Statement)
+    """
+
+    expression_parsed = parse(raw['expression'])
+
+    assert isinstance(expression_parsed, Expression)
+
+    return ExpressionStatement(expression_parsed, **_extract_base_props(raw))
+
+
+def parse_conditional(raw: Dict) -> Conditional:
+    true_expr_parsed = parse(raw['trueExpression'])
+    assert isinstance(true_expr_parsed, Expression)
+
+    false_expr_parsed = parse(raw['falseExpression'])
+    assert isinstance(false_expr_parsed, Expression)
+
+    cond_parsed = parse(raw['condition'])
+    assert isinstance(cond_parsed, Expression)
+
+    return Conditional(cond_parsed, true_expr_parsed, false_expr_parsed, **_extract_expr_props(raw))
+
+
+def parse_assignment(raw: Dict) -> Assignment:
+    """
+    operator (string)
+    leftHandSide (Expression)
+    rightHandSide (Expression)
+
+    +Attributes
+    """
+
+    operator = raw['operator']
+    left_parsed = parse(raw['leftHandSide'])
+    right_parsed = parse(raw['rightHandSide'])
+
+    assert isinstance(operator, str)
+    assert isinstance(left_parsed, Expression)
+    assert isinstance(right_parsed, Expression)
+
+    return Assignment(left_parsed, operator, right_parsed, **_extract_expr_props(raw))
+
+
+def parse_tuple_expression(raw: Dict) -> TupleExpression:
+    """
+    isInlineArray (bool)
+    components (Expression[])
+    """
+
+    is_array = raw['isInlineArray']
+    components_parsed = []
+    for component in raw['components']:
+        if component:
+            components_parsed.append(parse(component))
+        else:
+            components_parsed.append(None)
+
+    return TupleExpression(components_parsed, is_array, **_extract_expr_props(raw))
+
+
+def parse_unary_operation(raw: Dict) -> UnaryOperation:
+    """
+    prefix (bool)
+    operator (string)
+    subExpression (Expression)
+    """
+
+    expression_parsed = parse(raw['subExpression'])
+    assert isinstance(expression_parsed, Expression)
+
+    return UnaryOperation(raw['operator'], expression_parsed, raw['prefix'], **_extract_expr_props(raw))
+
+
+def parse_binary_operation(raw: Dict) -> BinaryOperation:
+    """
+    leftExpression (Expression)
+    operator (string)
+    rightExpression (Expression)
+    """
+
+    left_parsed = parse(raw['leftExpression'])
+    operator = raw['operator']
+    right_parsed = parse(raw['rightExpression'])
+
+    assert isinstance(left_parsed, Expression)
+    assert isinstance(operator, str)
+    assert isinstance(right_parsed, Expression)
+
+    return BinaryOperation(left_parsed, operator, right_parsed, **_extract_expr_props(raw))
+
+
+def parse_function_call(raw: Dict) -> FunctionCall:
+    """
+    expression (Expression)
+    names (string[])
+    arguments (Expression[])
+    tryCall (bool)
+    kind (string)
+
+    +Annotation
+    """
+
+    expression_parsed = parse(raw['expression'])
+    assert isinstance(expression_parsed, Expression)
+
+    names = raw['names']
+    arguments_parsed = []
+    for child in raw['arguments']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, Expression)
+        arguments_parsed.append(child_parsed)
+
+    return FunctionCall(raw['kind'], expression_parsed, names, arguments_parsed, **_extract_expr_props(raw))
+
+
+def parse_function_call_options(raw: Dict) -> FunctionCallOptions:
+    expression_parsed = parse(raw['expression'])
+    assert isinstance(expression_parsed, Expression)
+
+    names = raw['names']
+    assert isinstance(names, list)
+    for name in names:
+        assert isinstance(name, str)
+
+    options_parsed: List[Expression] = []
+    for child in raw['options']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, Expression)
+        options_parsed.append(child_parsed)
+
+    return FunctionCallOptions(expression_parsed, names, options_parsed, **_extract_expr_props(raw))
+
+
+def parse_new_expression(raw: Dict) -> NewExpression:
+    typename_parsed = parse(raw['typeName'])
+    assert isinstance(typename_parsed, TypeName)
+
+    return NewExpression(typename_parsed, **_extract_expr_props(raw))
+
+
+def parse_member_access(raw: Dict) -> MemberAccess:
+    """
+    memberName (string)
+    expression (Expression)
+    """
+
+    expression_parsed = parse(raw['expression'])
+    assert isinstance(expression_parsed, Expression)
+
+    member_name = raw['memberName']
+
+    return MemberAccess(expression_parsed, member_name, **_extract_expr_props(raw))
+
+
+def parse_index_access(raw: Dict) -> IndexAccess:
+    base_parsed = parse(raw['baseExpression'])
+    assert isinstance(base_parsed, Expression)
+
+    if raw['indexExpression']:
+        index_parsed = parse(raw['indexExpression'])
+        assert isinstance(index_parsed, Expression)
+    else:
+        index_parsed = None
+
+    return IndexAccess(base_parsed, index_parsed, **_extract_expr_props(raw))
+
+
+def parse_index_range_access(raw: Dict) -> IndexRangeAccess:
+    base_parsed = parse(raw['baseExpression'])
+    assert isinstance(base_parsed, Expression)
+
+    start_parsed = parse(raw['startExpression'])
+    assert isinstance(start_parsed, Expression)
+
+    if raw['endExpression']:
+        end_parsed = parse(raw['endExpression'])
+        assert isinstance(end_parsed, Expression)
+    else:
+        end_parsed = None
+
+    return IndexRangeAccess(base_parsed, start_parsed, end_parsed, **_extract_expr_props(raw))
+
+
+def parse_identifier(raw: Dict) -> Identifier:
+    """
+    name (string)
+    """
+
+    name = raw['name']
+
+    assert isinstance(name, str)
+
+    return Identifier(name, **_extract_expr_props(raw))
+
+
+def parse_elementary_type_name_expression(raw: Dict) -> ElementaryTypeNameExpression:
+    if isinstance(raw['typeName'], dict):
+        # >= 0.6.0
+        typename_parsed = parse(raw['typeName'])
+    else:
+        # >= 0.4.12
+        typename_parsed = ElementaryTypeName(
+            raw['typeName'],
+            "default",
+            **_extract_base_props(raw),
+        )
+
+    assert isinstance(typename_parsed, ElementaryTypeName)
+
+    return ElementaryTypeNameExpression(typename_parsed, **_extract_expr_props(raw))
+
+
+def parse_literal(raw: Dict) -> Literal:
+    """
+    kind (string)
+    value (string)
+    hexValue (string)
+    subdenomination (string?)
+
+    +ExpressionAnnotation
+    """
+    subdenomination = raw.get('subdenomination', None)
+
+    return Literal(raw['kind'], raw['value'], raw['hexValue'], subdenomination, **_extract_expr_props(raw))
+
+
+def parse_unsupported(raw: Dict) -> ASTNode:
+    raise ParsingError("unsupported compact json node", raw['nodeType'], raw.keys(), raw)
+
+
+def parse(raw: Dict) -> ASTNode:
+    try:
+        return PARSERS.get(raw['nodeType'], parse_unsupported)(raw)
+    except ParsingError as e:
+        raise e
+    except Exception as e:
+        raise ParsingError("failed to parse compact json node", raw['nodeType'], e, raw.keys(), raw)
+
+
+PARSERS: Dict[str, Callable[[Dict], ASTNode]] = {
+    'SourceUnit': parse_source_unit,
+    'PragmaDirective': parse_pragma_directive,
+    'ImportDirective': parse_import_directive,
+    'ContractDefinition': parse_contract_definition,
+    'InheritanceSpecifier': parse_inheritance_specifier,
+    'UsingForDirective': parse_using_for_directive,
+    'StructDefinition': parse_struct_definition,
+    'EnumDefinition': parse_enum_definition,
+    'EnumValue': parse_enum_value,
+    'ParameterList': parse_parameter_list,
+    'FunctionDefinition': parse_function_definition,
+    'VariableDeclaration': parse_variable_declaration,
+    'ModifierDefinition': parse_modifier_definition,
+    'ModifierInvocation': parse_modifier_invocation,
+    'EventDefinition': parse_event_definition,
+    'ElementaryTypeName': parse_elementary_type_name,
+    'UserDefinedTypeName': parse_user_defined_type_name,
+    'FunctionTypeName': parse_function_type_name,
+    'Mapping': parse_mapping,
+    'ArrayTypeName': parse_array_type_name,
+    'InlineAssembly': parse_inline_assembly,
+    'Block': parse_block,
+    'PlaceholderStatement': parse_placeholder_statement,
+    'IfStatement': parse_if_statement,
+    'TryCatchClause': parse_try_catch_clause,
+    'TryStatement': parse_try_statement,
+    'WhileStatement': parse_while_statement,
+    'DoWhileStatement': parse_do_while_statement,
+    'ForStatement': parse_for_statement,
+    'Continue': parse_continue,
+    'Break': parse_break,
+    'Return': parse_return,
+    'Throw': parse_throw,
+    'EmitStatement': parse_emit_statement,
+    'VariableDeclarationStatement': parse_variable_declaration_statement,
+    'ExpressionStatement': parse_expression_statement,
+    'Conditional': parse_conditional,
+    'Assignment': parse_assignment,
+    'TupleExpression': parse_tuple_expression,
+    'UnaryOperation': parse_unary_operation,
+    'BinaryOperation': parse_binary_operation,
+    'FunctionCall': parse_function_call,
+    'FunctionCallOptions': parse_function_call_options,
+    'NewExpression': parse_new_expression,
+    'MemberAccess': parse_member_access,
+    'IndexAccess': parse_index_access,
+    'IndexRangeAccess': parse_index_range_access,
+    'Identifier': parse_identifier,
+    'ElementaryTypeNameExpression': parse_elementary_type_name_expression,
+    'Literal': parse_literal,
+}

--- a/slither/solc_parsing/types/dump.py
+++ b/slither/solc_parsing/types/dump.py
@@ -1,0 +1,15 @@
+import json
+
+from slither.solc_parsing.types.types import ASTNode
+
+
+def dumps(node: ASTNode) -> str:
+    def default(x):
+        slots = x.__slots__
+        if isinstance(slots, str):
+            slots = [slots]
+        res = {slot: getattr(x, slot, None) for slot in slots}
+        res['nodeType'] = type(x).__name__
+        return res
+
+    return json.dumps(node, indent=2, default=default)

--- a/slither/solc_parsing/types/legacy_json.py
+++ b/slither/solc_parsing/types/legacy_json.py
@@ -1,0 +1,885 @@
+from typing import Callable
+
+from slither.solc_parsing.exceptions import ParsingError
+from slither.solc_parsing.types.types import * # lgtm[py/polluting-import]
+
+"""
+The legacy AST format is used by all versions of Solidity that Slither currently supports (i.e. >=0.4.0), but it must
+be manually enabled for versions >=0.4.12. In general, all nodes contain the following properties:
+
+id (int): internal node id, randomly generated
+name (string): type of node
+src (string): src offset
+
+A node may also contain an array of children. This array is simply the concatenation of every child node and does
+not contain nulls if a child node is unset. As a result, this results in ambiguities when parsing constructs like
+a for loop.
+
+A node may, for Solidity >=0.4.12, contain an optional attributes dictionary, which contains additional
+properties about the node
+"""
+
+
+def _extract_base_props(raw: Dict) -> Dict:
+    return {
+        'src': raw.get('src', ''),
+        'id': raw.get('id', -1),
+    }
+
+
+def _extract_decl_props(raw: Dict) -> Dict:
+    return {
+        **_extract_base_props(raw),
+        'name': raw['attributes']['name'],
+        'canonical_name': raw.get('canonicalName', ''),
+        'visibility': raw['attributes'].get('visibility', 'public'),
+    }
+
+
+def _extract_expr_props(raw: Dict) -> Dict:
+    return {
+        **_extract_base_props(raw),
+        'type_str': raw.get('attributes', {}).get('type', None),
+        'constant': raw.get("isConstant", False),  # Identifier doesn't expose this
+        'pure': raw.get('isPure', False),  # Identifier doesn't expose this
+    }
+
+
+def parse_emit_statement(raw: Dict) -> EmitStatement:
+    event_call_parsed = parse(raw['children'][0])
+    assert isinstance(event_call_parsed, FunctionCall)
+
+    return EmitStatement(event_call_parsed, **_extract_base_props(raw))
+
+
+def parse_variable_definition_statement(raw: Dict) -> VariableDeclarationStatement:
+    """
+    children:
+        VariableDeclaration[]
+        Expression?
+    """
+
+    parsed_children: List[VariableDeclaration] = []
+    for child in raw['children'][:-1]:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, VariableDeclaration)
+        parsed_children.append(child_parsed)
+
+    initial_value = None
+    last_child = parse(raw['children'][-1])
+    if isinstance(last_child, VariableDeclaration):
+        parsed_children.append(last_child)
+    else:
+        initial_value = last_child
+
+    return VariableDeclarationStatement(parsed_children, initial_value, **_extract_base_props(raw))
+
+
+def parse_expression_statement(raw: Dict) -> ExpressionStatement:
+    """
+    children:
+        Expression
+    """
+
+    expression_parsed = parse(raw['children'][0])
+    assert isinstance(expression_parsed, Expression)
+
+    return ExpressionStatement(expression_parsed, **_extract_base_props(raw))
+
+
+def parse_conditional(raw: Dict) -> Conditional:
+    true_expr_parsed = parse(raw['children'][0])
+    assert isinstance(true_expr_parsed, Expression)
+
+    false_expr_parsed = parse(raw['children'][1])
+    assert isinstance(false_expr_parsed, Expression)
+
+    cond_parsed = parse(raw['children'][2])
+    assert isinstance(cond_parsed, Expression)
+
+    return Conditional(cond_parsed, true_expr_parsed, false_expr_parsed, **_extract_expr_props(raw))
+
+
+def parse_assignment(raw: Dict) -> Assignment:
+    """
+    children:
+        left (Expression)
+        right (Expression)
+
+    attributes:
+        operator (string)
+        type (string)
+    """
+
+    left = parse(raw['children'][0])
+    assert isinstance(left, Expression)
+
+    right = parse(raw['children'][1])
+    assert isinstance(right, Expression)
+
+    return Assignment(left, raw['attributes']['operator'], right, **_extract_expr_props(raw))
+
+
+def parse_tuple_expression(raw: Dict) -> TupleExpression:
+    """
+    children:
+        (Expression?)[]
+    """
+
+    children_parsed: List[Optional[Expression]] = []
+
+    for child in raw['children']:
+        if child:
+            child_parsed = parse(child)
+            assert isinstance(child_parsed, Expression)
+
+            children_parsed.append(child_parsed)
+        else:
+            children_parsed.append(None)
+
+    return TupleExpression(children_parsed, False, **_extract_expr_props(raw))
+
+
+def parse_unary_operation(raw: Dict) -> UnaryOperation:
+    expression_parsed = parse(raw['children'][0])
+    assert isinstance(expression_parsed, Expression)
+
+    return UnaryOperation(raw['attributes']['operator'], expression_parsed, raw['attributes']['prefix'],
+                          **_extract_expr_props(raw))
+
+
+def parse_binary_operation(raw: Dict) -> BinaryOperation:
+    left_parsed = parse(raw['children'][0])
+    right_parsed = parse(raw['children'][1])
+
+    assert isinstance(left_parsed, Expression)
+    assert isinstance(right_parsed, Expression)
+
+    return BinaryOperation(left_parsed, raw['attributes']['operator'], right_parsed, **_extract_expr_props(raw))
+
+
+def parse_function_call(raw: Dict) -> FunctionCall:
+    attrs = raw['attributes']
+
+    if 'isStructConstructorCall' in attrs:
+        # >= 0.4.12
+        if attrs['isStructConstructorCall']:
+            kind = 'structConstructorCall'
+        else:
+            kind = 'typeConversion' if attrs['type_conversion'] else 'functionCall'
+    else:
+        # >= 0.4.0
+        if attrs['type_conversion']:
+            kind = 'typeConversion'
+        elif attrs['type'].startswith("struct "):
+            kind = 'structConstructorCall'
+        else:
+            kind = 'functionCall'
+
+    if 'names' in attrs:
+        names = attrs['names']
+    else:
+        names = []
+
+    call_parsed = parse(raw['children'][0])
+    assert isinstance(call_parsed, Expression)
+
+    args_parsed: List[Expression] = []
+    for child in raw['children'][1:]:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, Expression)
+        args_parsed.append(child_parsed)
+
+    return FunctionCall(kind, call_parsed, names, args_parsed, **_extract_expr_props(raw))
+
+
+def parse_function_call_options(raw: Dict) -> FunctionCallOptions:
+    expression_parsed = parse(raw['children'][0])
+    assert isinstance(expression_parsed, Expression)
+
+    names = raw['attributes']['names']
+    assert isinstance(names, list)
+    for name in names:
+        assert isinstance(name, str)
+
+    options_parsed: List[Expression] = []
+    for child in raw['children'][1:]:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, Expression)
+        options_parsed.append(child_parsed)
+
+    return FunctionCallOptions(expression_parsed, names, options_parsed, **_extract_expr_props(raw))
+
+
+def parse_new_expression(raw: Dict) -> NewExpression:
+    typename_parsed = parse(raw['children'][0])
+    assert isinstance(typename_parsed, TypeName)
+
+    return NewExpression(typename_parsed, **_extract_expr_props(raw))
+
+
+def parse_member_access(raw: Dict) -> MemberAccess:
+    expr_parsed = parse(raw['children'][0])
+    assert isinstance(expr_parsed, Expression)
+
+    return MemberAccess(expr_parsed, raw['attributes']['member_name'], **_extract_expr_props(raw))
+
+
+def parse_while_statement_internal(raw: Dict, is_do_while: bool) -> WhileStatement:
+    """
+    condition (Expression)
+    body (Statement)
+    """
+
+    condition_parsed = parse(raw['children'][0])
+    assert isinstance(condition_parsed, Expression)
+
+    body_parsed = parse(raw['children'][1])
+    assert isinstance(body_parsed, Statement)
+
+    return WhileStatement(condition_parsed, body_parsed, is_do_while, **_extract_base_props(raw))
+
+
+def parse_while_statement(raw: Dict) -> WhileStatement:
+    return parse_while_statement_internal(raw, False)
+
+
+def parse_do_while_statement(raw: Dict) -> WhileStatement:
+    return parse_while_statement_internal(raw, True)
+
+def parse_for_statement(raw: Dict) -> ForStatement:
+    # if we're using an old version of solc (anything below and including 0.4.11) or if the user
+    # explicitly disabled compact ast, we might need to make some best-effort guesses
+    children = raw['children']
+
+    # there should always be at least one, and never more than 4, children
+    assert(1 <= len(children) <= 4)
+
+    # the last element of the children array must be the body, since it's mandatory
+    # however, it might be a single expression
+    body = children[-1]
+
+    if len(children) == 4:
+        # handle the first trivial case - if there are four children we know exactly what they are
+        pre, cond, post = children[0], children[1], children[2]
+    elif len(children) == 1:
+        # handle the second trivial case - if there is only one child we know there are no expressions
+        pre, cond, post = None, None, None
+    else:
+        attributes = raw.get('attributes', None)
+
+        def has_hint(key):
+            return key in attributes and not attributes[key]
+
+        if attributes and any(map(
+                has_hint,
+                ['condition', 'initializationExpression', 'loopExpression'],
+        )):
+            # if we have attribute hints, rely on those
+
+            if len(children) == 2:
+                # we're missing two expressions, find the one we have
+                if not has_hint('initializationExpression'):
+                    pre, cond, post = children[0], None, None
+                elif not has_hint('condition'):
+                    pre, cond, post = None, children[0], None
+                else:  # if not has_hint('loopExpression'):
+                    pre, cond, post = None, None, children[0]
+            else:
+                # we're missing one expression, figure out what it is
+                if has_hint('initializationExpression'):
+                    pre, cond, post = None, children[0], children[1]
+                elif has_hint('condition'):
+                    pre, cond, post = children[0], None, children[1]
+                else:  # if has_hint('loopExpression'):
+                    pre, cond, post = children[0], children[1], None
+        else:
+            # we don't have attribute hints, and it's literally impossible to be 100% accurate here
+            # let's just try our best
+
+            # the pre statement is a simple statement, and can only be one of the following nodes:
+            #   variable declaration, expression statement
+            #
+            # the condition statement is an expression, and can only be one of the following nodes:
+            #   assignment, conditional, binary, unary, new, indexaccess, memberaccess, functioncall,
+            #   literal, identifier, tuple, elementary type name
+            # however, the condition statement must also be convertible to a boolean
+            #
+            # the post statement is an expression statement, and can only be one of the following nodes:
+            #    expression statement
+
+            first_parsed = parse(children[0])
+            second_parsed = parse(children[1])
+
+            # VariableDefinitionStatement is used by solc 0.4.0-0.4.6
+            # it's changed in 0.4.7 to VariableDeclarationStatement
+            if isinstance(first_parsed, VariableDeclarationStatement):
+                # only the pre statement can be a variable declaration
+
+                if len(children) == 2:
+                    # only one child apart from body, it must be pre
+                    pre, cond, post = children[0], None, None
+                else:
+                    # more than one child, figure out which one is the cond
+                    if isinstance(second_parsed, ExpressionStatement):
+                        # only the post can be an expression statement
+                        pre, cond, post = children[0], None, children[1]
+                    else:
+                        # similarly, the post cannot be anything other than an expression statement
+                        pre, cond, post = children[0], children[1], None
+            elif isinstance(first_parsed, ExpressionStatement):
+                # the first element can either be pre or post
+
+                if len(children) == 2:
+                    # this is entirely ambiguous, so apply a very dumb heuristic:
+                    # if the statement is closer to the start of the body, it's probably the post
+                    # otherwise, it's probably the pre
+                    # this will work in all cases where the formatting isn't completely borked
+
+                    node_len = int(children[0]['src'].split(":")[1])
+
+                    node_start = int(children[0]['src'].split(":")[0])
+                    node_end = node_start + node_len
+
+                    for_start = int(raw['src'].split(":")[0]) + 3  # trim off the 'for'
+                    body_start = int(body['src'].split(":")[0])
+
+                    dist_start = node_start - for_start
+                    dist_end = body_start - node_end
+                    if dist_start > dist_end:
+                        pre, cond, post = None, None, children[0]
+                    else:
+                        pre, cond, post = children[0], None, None
+                else:
+                    # more than one child, we must be the pre
+                    pre, cond, post = children[0], children[1], None
+            else:
+                # the first element must be the cond
+
+                if len(children) == 2:
+                    pre, cond, post = None, children[0], None
+                else:
+                    pre, cond, post = None, children[0], children[1]
+
+    pre_parsed = parse(pre) if pre else None
+    assert pre is None or isinstance(pre_parsed, Statement)
+
+    cond_parsed = parse(cond) if cond else None
+    assert cond is None or isinstance(cond_parsed, Expression)
+
+    post_parsed = parse(post) if post else None
+    assert post is None or isinstance(post_parsed, ExpressionStatement)
+
+    body_parsed = parse(body)
+    assert isinstance(body_parsed, Statement)
+
+    return ForStatement(pre_parsed, cond_parsed, post_parsed, body_parsed, **_extract_base_props(raw))
+
+def parse_continue(raw: Dict) -> Continue:
+    return Continue(**_extract_base_props(raw))
+
+
+def parse_break(raw: Dict) -> Break:
+    return Break(**_extract_base_props(raw))
+
+
+def parse_throw(raw: Dict) -> Throw:
+    return Throw(**_extract_base_props(raw))
+
+
+def parse_source_unit(raw: Dict) -> SourceUnit:
+    children_parsed: List[ASTNode] = []
+    for child in raw['children']:
+        children_parsed.append(parse(child))
+    return SourceUnit(children_parsed, **_extract_base_props(raw))
+
+
+def parse_pragma_directive(raw: Dict) -> PragmaDirective:
+    return PragmaDirective(raw['attributes']['literals'], **_extract_base_props(raw))
+
+
+def parse_import_directive(raw: Dict) -> ImportDirective:
+    return ImportDirective(raw['attributes']['file'], **_extract_base_props(raw))
+
+
+def parse_contract_definition(raw: Dict) -> ContractDefinition:
+    attrs = raw['attributes']
+
+    if 'contractKind' in attrs:
+        # >=0.4.12
+        kind = attrs['contractKind']
+    else:
+        # <0.4.12
+        if attrs['isLibrary']:
+            kind = "library"
+        elif attrs['fullyImplemented']:
+            kind = "contract"
+        else:
+            kind = "interface"
+
+    linearized = attrs['linearizedBaseContracts']
+
+    base_contracts = []
+    nodes = []
+    if 'children' in raw:
+        for child in raw['children']:
+            child_parsed = parse(child)
+            if isinstance(child_parsed, InheritanceSpecifier):
+                base_contracts.append(child_parsed)
+            else:
+                nodes.append(child_parsed)
+
+    return ContractDefinition(kind, linearized, base_contracts, nodes, **_extract_decl_props(raw))
+
+
+def parse_inheritance_specifier(raw: Dict) -> InheritanceSpecifier:
+    basename_parsed = parse(raw['children'][0])
+    assert isinstance(basename_parsed, UserDefinedTypeName)
+
+    if len(raw['children']) > 1:
+        args_parsed = []
+        for child in raw['children'][1:]:
+            child_parsed = parse(child)
+            assert isinstance(child_parsed, Expression)
+            args_parsed.append(child_parsed)
+    else:
+        args_parsed = None
+
+    return InheritanceSpecifier(basename_parsed, args_parsed, **_extract_base_props(raw))
+
+
+def parse_using_for_directive(raw: Dict) -> UsingForDirective:
+    library = parse(raw['children'][0])
+    assert isinstance(library, UserDefinedTypeName)
+
+    typename = None
+    if len(raw['children']) > 1:
+        typename = parse(raw['children'][1])
+        assert isinstance(typename, TypeName)
+
+    return UsingForDirective(library, typename, **_extract_base_props(raw))
+
+
+def parse_struct_definition(raw: Dict) -> StructDefinition:
+    attrs = raw['attributes']
+
+    if 'canonicalName' in attrs:
+        # >=0.4.12
+        canonical_name = attrs['canonicalName']
+    else:
+        canonical_name = None
+
+    members_parsed: List[VariableDeclaration] = []
+    for child in raw['children']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, VariableDeclaration)
+        members_parsed.append(child_parsed)
+
+    return StructDefinition(members_parsed, name=attrs['name'], canonical_name=canonical_name, visibility=None,
+                            **_extract_base_props(raw))
+
+
+def parse_enum_definition(raw: Dict) -> EnumDefinition:
+    attrs = raw['attributes']
+
+    if 'canonicalName' in attrs:
+        # >=0.4.12
+        canonical_name = attrs['canonicalName']
+    else:
+        canonical_name = None
+
+    members_parsed: List[EnumValue] = []
+    for child in raw['children']:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, EnumValue)
+        members_parsed.append(child_parsed)
+
+    return EnumDefinition(members_parsed, name=attrs['name'], canonical_name=canonical_name, visibility=None,
+                          **_extract_base_props(raw))
+
+
+def parse_enum_value(raw: Dict) -> EnumValue:
+    return EnumValue(
+        name=raw['attributes']['name'],
+        canonical_name=None,
+        visibility=None,
+        **_extract_base_props(raw)
+    )
+
+
+def parse_function_definition(raw: Dict) -> FunctionDefinition:
+    attrs = raw['attributes']
+    if 'stateMutability' in attrs:
+        # >=0.4.16
+        mutability = attrs['stateMutability']
+    elif 'payable' in attrs:
+        # >=0.4.5
+        mutability = "payable" if attrs['payable'] else "nonpayable"
+    else:
+        # >=0.4.0
+        """
+        as it turns out, constant functions can do non-constant things, so mark it as payable so err on the side
+        of more detectors triggering
+        """
+        mutability = "payable"
+
+    if 'kind' in attrs:
+        # >= 0.5.0
+        kind = attrs['kind']
+    elif 'isConstructor' in attrs and attrs['isConstructor']:
+        # >= 0.4.12
+        kind = "constructor"
+    else:
+        # >= 0.4.0
+        kind = 'fallback' if attrs['name'] == '' else 'function'
+
+    assert len(raw['children']) >= 3
+
+    params = parse(raw['children'][0])
+    assert isinstance(params, ParameterList)
+
+    rets = parse(raw['children'][1])
+    assert isinstance(rets, ParameterList)
+
+    modifiers_parsed: List[ModifierInvocation] = []
+    for child in raw['children'][2:-1]:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, ModifierInvocation)
+        modifiers_parsed.append(child_parsed)
+
+    body = parse(raw['children'][-1])
+    assert isinstance(body, Block)
+
+    return FunctionDefinition(mutability, kind, modifiers_parsed, body, params=params, rets=rets,
+                              **_extract_decl_props(raw))
+
+
+def parse_parameter_list(raw: Dict) -> ParameterList:
+    """
+    children:
+        (VariableDeclaration?)[]
+    """
+
+    parameters_parsed: List[Optional[VariableDeclaration]] = []
+
+    for child in raw['children']:
+        if child:
+            child_parsed = parse(child)
+            assert isinstance(child_parsed, VariableDeclaration)
+
+            parameters_parsed.append(child_parsed)
+        else:
+            parameters_parsed.append(None)
+
+    return ParameterList(parameters_parsed, **_extract_base_props(raw))
+
+
+def parse_elementary_type_name(raw: Dict) -> ElementaryTypeName:
+    attrs = raw['attributes']
+    if 'stateMutability' in attrs:
+        # >=0.5.0
+        mutability = attrs['stateMutability']
+    else:
+        # >=0.4.0
+        mutability = "payable" if attrs['name'] == 'address' else None
+
+    return ElementaryTypeName(attrs['name'], mutability, **_extract_base_props(raw))
+
+
+def parse_user_defined_type_name(raw: Dict) -> UserDefinedTypeName:
+    name = raw['attributes']['name']
+    if 'referencedDeclaration' in raw['attributes']:
+        # >= 0.4.12
+        referenced_declaration = raw['attributes']['referencedDeclaration']
+    else:
+        referenced_declaration = None
+
+    return UserDefinedTypeName(name, referenced_declaration, **_extract_base_props(raw))
+
+
+def parse_function_type_name(raw: Dict) -> FunctionTypeName:
+    params_parsed = parse(raw['children'][0])
+    assert isinstance(params_parsed, ParameterList)
+
+    rets_parsed = parse(raw['children'][1])
+    assert isinstance(rets_parsed, ParameterList)
+
+    visibility = raw['attributes']['visibility']
+    mutability = raw['attributes']['stateMutability']
+
+    return FunctionTypeName(params_parsed, rets_parsed, visibility, mutability, **_extract_base_props(raw))
+
+
+def parse_mapping(raw: Dict) -> Mapping:
+    key_parsed = parse(raw['children'][0])
+    assert isinstance(key_parsed, TypeName)
+
+    val_parsed = parse(raw['children'][1])
+    assert isinstance(val_parsed, TypeName)
+
+    return Mapping(key_parsed, val_parsed, **_extract_base_props(raw))
+
+
+def parse_array_type_name(raw: Dict) -> ArrayTypeName:
+    base_parsed = parse(raw['children'][0])
+    assert isinstance(base_parsed, TypeName)
+
+    len_parsed = None
+    if len(raw['children']) > 1:
+        len_parsed = parse(raw['children'][1])
+        assert isinstance(len_parsed, Expression)
+
+    return ArrayTypeName(base_parsed, len_parsed, **_extract_base_props(raw))
+
+
+def parse_inline_assembly(raw: Dict) -> InlineAssembly:
+    return InlineAssembly(raw['attributes']['operations'], **_extract_base_props(raw))
+
+
+def parse_block(raw: Dict) -> Block:
+    """
+    children:
+        Statement[]
+    """
+
+    parsed_statements: List[Statement] = []
+    for statement in raw['children']:
+        parsed_statement = parse(statement)
+        assert isinstance(parsed_statement, Statement)
+        parsed_statements.append(parsed_statement)
+
+    return Block(parsed_statements, **_extract_base_props(raw))
+
+
+def parse_placeholder_statement(raw: Dict) -> PlaceholderStatement:
+    return PlaceholderStatement(**_extract_base_props(raw))
+
+
+def parse_if_statement(raw: Dict) -> IfStatement:
+    condition_parsed = parse(raw['children'][0])
+    assert isinstance(condition_parsed, Expression)
+
+    true_body_parsed = parse(raw['children'][1])
+    assert isinstance(true_body_parsed, Statement)
+
+    false_body_parsed = None
+    if len(raw['children']) > 2:
+        false_body_parsed = parse(raw['children'][2])
+        assert isinstance(false_body_parsed, Statement)
+
+    return IfStatement(condition_parsed, true_body_parsed, false_body_parsed, **_extract_base_props(raw))
+
+def parse_return(raw: Dict) -> Return:
+    """
+    children:
+        Expression?
+    """
+
+    expr_parsed = None
+    if len(raw['children']) > 0:
+        expr_parsed = parse(raw['children'][0])
+        assert isinstance(expr_parsed, Expression)
+
+    return Return(expr_parsed, **_extract_base_props(raw))
+
+
+def parse_variable_declaration(raw: Dict) -> VariableDeclaration:
+    attrs = raw['attributes']
+    if 'constant' in attrs:
+        # >=0.4.11
+        constant = attrs['constant']
+    else:
+        # >=0.4.0
+        constant = False
+
+    typename = parse(raw['children'][0])
+    assert isinstance(typename, TypeName)
+
+    value = None
+    if len(raw['children']) > 1:
+        value = parse(raw['children'][1])
+        assert isinstance(value, Expression)
+
+    indexed = attrs['indexed'] if 'indexed' in attrs else None
+
+    if 'storageLocation' in attrs:
+        # >= 0.4.11
+        storage_location = attrs['storageLocation']
+    else:
+        # >= 0.4.0
+        if 'memory' in attrs['type']:
+            storage_location = "memory"
+        elif 'storage' in attrs['type']:
+            storage_location = "storage"
+        else:
+            storage_location = "default"
+
+    return VariableDeclaration(
+        typename, value, raw['attributes']['type'], constant, indexed, storage_location, **_extract_decl_props(raw)
+    )
+
+
+def parse_modifier_definition(raw: Dict) -> ModifierDefinition:
+    params = parse(raw['children'][0])
+    assert isinstance(params, ParameterList)
+
+    body = parse(raw['children'][1])
+    assert isinstance(body, Block)
+
+    return ModifierDefinition(
+        body=body,
+        params=params,
+        rets=None,
+        name=raw['attributes']['name'],
+        canonical_name=None,
+        visibility=None,
+        **_extract_base_props(raw)
+    )
+
+
+def parse_modifier_invocation(raw: Dict) -> ModifierInvocation:
+    name = parse(raw['children'][0])
+    assert isinstance(name, Identifier)
+
+    args_parsed: List[Expression] = []
+    for child in raw['children'][1:]:
+        child_parsed = parse(child)
+        assert isinstance(child_parsed, Expression)
+        args_parsed.append(child_parsed)
+
+    return ModifierInvocation(
+        modifier=name,
+        args=args_parsed,
+        **_extract_base_props(raw)
+    )
+
+
+def parse_event_definition(raw: Dict) -> EventDefinition:
+    params = parse(raw['children'][0])
+    assert isinstance(params, ParameterList)
+
+    return EventDefinition(
+        anonymous=raw['attributes']['anonymous'],
+        params=params, rets=None,
+        name=raw['attributes']['name'], canonical_name=raw['attributes']['name'], visibility=None,
+        **_extract_base_props(raw),
+    )
+
+
+def parse_index_access(raw: Dict) -> IndexAccess:
+    base_parsed = parse(raw['children'][0])
+    assert isinstance(base_parsed, Expression)
+
+    index_parsed = None
+    if len(raw['children']) > 1:
+        index_parsed = parse(raw['children'][1])
+        assert isinstance(index_parsed, Expression)
+
+    return IndexAccess(base_parsed, index_parsed, **_extract_expr_props(raw))
+
+
+def parse_index_range_access(raw: Dict) -> IndexRangeAccess:
+    base = parse(raw['children'][0])
+    assert isinstance(base, Expression)
+
+    start = parse(raw['children'][1])
+    assert isinstance(start, Expression)
+
+    end = None
+    if len(raw['children']) > 2:
+        end = parse(raw['children'][2])
+        assert isinstance(end, Expression)
+
+    return IndexRangeAccess(base, start, end, **_extract_expr_props(raw))
+
+
+def parse_identifier(raw: Dict) -> Identifier:
+    """
+    attributes:
+        type (string)
+        value (string)
+    """
+
+    return Identifier(raw['attributes']['value'], **_extract_expr_props(raw))
+
+
+def parse_elementary_type_name_expression(raw: Dict) -> ElementaryTypeNameExpression:
+    typename_parsed = parse(raw['children'][0])
+    assert isinstance(typename_parsed, ElementaryTypeName)
+
+    return ElementaryTypeNameExpression(typename_parsed, **_extract_expr_props(raw))
+
+
+def parse_literal(raw: Dict) -> Literal:
+    attrs = raw['attributes']
+    return Literal(attrs['token'], attrs['value'], attrs['hexvalue'], attrs['subdenomination'],
+                   **_extract_expr_props(raw))
+
+
+def parse_unsupported(raw: Dict) -> ASTNode:
+    raise ParsingError("unsupported legacy json node", raw['name'], raw.keys(),
+                       [node['name'] for node in raw['children']] if 'children' in raw else [], raw)
+
+
+def parse(raw: Dict) -> ASTNode:
+    try:
+        return PARSERS.get(raw['name'], parse_unsupported)(raw)
+    except ParsingError as e:
+        raise e
+    except Exception as e:
+        raise ParsingError("failed to parse legacy json node", raw['name'], e, raw.keys(), raw)
+
+
+PARSERS: Dict[str, Callable[[Dict], ASTNode]] = {
+    'SourceUnit': parse_source_unit,
+    'PragmaDirective': parse_pragma_directive,
+    'ImportDirective': parse_import_directive,
+    'ContractDefinition': parse_contract_definition,
+    'InheritanceSpecifier': parse_inheritance_specifier,
+    'UsingForDirective': parse_using_for_directive,
+    'StructDefinition': parse_struct_definition,
+    'EnumDefinition': parse_enum_definition,
+    'EnumValue': parse_enum_value,
+    'ParameterList': parse_parameter_list,
+    'FunctionDefinition': parse_function_definition,
+    'VariableDeclaration': parse_variable_declaration,
+    'ModifierDefinition': parse_modifier_definition,
+    'ModifierInvocation': parse_modifier_invocation,
+    'EventDefinition': parse_event_definition,
+    'ElementaryTypeName': parse_elementary_type_name,
+    'UserDefinedTypeName': parse_user_defined_type_name,
+    'FunctionTypeName': parse_function_type_name,
+    'Mapping': parse_mapping,
+    'ArrayTypeName': parse_array_type_name,
+    'InlineAssembly': parse_inline_assembly,
+    'Block': parse_block,
+    'PlaceholderStatement': parse_placeholder_statement,
+    'IfStatement': parse_if_statement,
+    # 'TryCatchClause': parse_try_catch_clause,
+    # 'TryStatement': parse_try_statement,
+    'WhileStatement': parse_while_statement,
+    'DoWhileStatement': parse_do_while_statement,
+    'ForStatement': parse_for_statement,
+    'Continue': parse_continue,
+    'Break': parse_break,
+    'Return': parse_return,
+    'Throw': parse_throw,
+    'EmitStatement': parse_emit_statement,
+    'VariableDeclarationStatement': parse_variable_definition_statement,  # >=0.4.7
+    'VariableDefinitionStatement': parse_variable_definition_statement,  # <=0.4.6
+    'ExpressionStatement': parse_expression_statement,
+    'Conditional': parse_conditional,
+    'Assignment': parse_assignment,
+    'TupleExpression': parse_tuple_expression,
+    'UnaryOperation': parse_unary_operation,
+    'BinaryOperation': parse_binary_operation,
+    'FunctionCall': parse_function_call,
+    'FunctionCallOptions': parse_function_call_options,
+    'NewExpression': parse_new_expression,
+    'MemberAccess': parse_member_access,
+    'IndexAccess': parse_index_access,
+    'IndexRangeAccess': parse_index_range_access,
+    'Identifier': parse_identifier,
+    'ElementaryTypeNameExpression': parse_elementary_type_name_expression,
+    'Literal': parse_literal,
+}

--- a/slither/solc_parsing/types/sniffer.py
+++ b/slither/solc_parsing/types/sniffer.py
@@ -1,0 +1,45 @@
+from typing import Dict, Optional
+
+
+def sniff(raw: Dict):
+    result = sniff_internal(raw)
+    if not result:
+        result = DEFAULT_SNIFF_RESULT
+
+    return HANDLERS[result]
+
+
+def sniff_internal(raw: Dict) -> Optional[str]:
+    for id, rule in SNIFFER_RULES.items():
+        if rule(raw):
+            return id
+
+    for k, v in raw.items():
+        if isinstance(v, dict):
+            result = sniff_internal(v)
+            if result:
+                return result
+
+    return None
+
+
+def sniff_legacy_json(raw: Dict) -> bool:
+    uses_legacy_nodetype_key = 'name' in raw
+    uses_legacy_children = 'children' in raw and isinstance(raw['children'], list)
+
+    return uses_legacy_nodetype_key and uses_legacy_children
+
+
+DEFAULT_SNIFF_RESULT = 'sniffer_compact_json'
+
+SNIFFER_RULES = {
+    'sniffer_legacy_json': sniff_legacy_json,
+}
+
+from .legacy_json import parse as legacy_parser
+from .compact_json import parse as compact_parser
+
+HANDLERS = {
+    'sniffer_legacy_json': legacy_parser,
+    'sniffer_compact_json': compact_parser,
+}

--- a/slither/solc_parsing/types/types.py
+++ b/slither/solc_parsing/types/types.py
@@ -1,0 +1,486 @@
+from typing import List, Optional, Dict, Union
+
+
+class ASTNode:
+    __slots__ = "src", "id"
+
+    def __init__(self, src: str, id: int):
+        self.src = src
+        self.id = id
+
+
+class SourceUnit(ASTNode):
+    __slots__ = "nodes"
+
+    def __init__(self, nodes: List[ASTNode], **kwargs):
+        super().__init__(**kwargs)
+        self.nodes = nodes
+
+
+class Declaration(ASTNode):
+    __slots__ = "name", "canonical_name", "visibility"
+
+    def __init__(self, name: str, canonical_name: Optional[str], visibility: Optional[str], **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        self.canonical_name = canonical_name
+        self.visibility = visibility
+
+
+class PragmaDirective(ASTNode):
+    __slots__ = "literals"
+
+    def __init__(self, literals: List[str], **kwargs):
+        super().__init__(**kwargs)
+        self.literals = literals
+
+
+class ImportDirective(Declaration):
+    __slots__ = "path"
+
+    def __init__(self, path: str, **kwargs):
+        super().__init__(**kwargs)
+        self.path = path
+
+
+# kind can be: "interface", "contract", "library"
+class ContractDefinition(Declaration):
+    __slots__ = "kind", "linearized_base_contracts", "base_contracts", "nodes"
+
+    def __init__(self, kind: Optional[str], base: Optional[List[int]], base_contracts: List['InheritanceSpecifier'],
+                 nodes: List[ASTNode], **kwargs):
+        super().__init__(**kwargs)
+        self.kind = kind
+        self.linearized_base_contracts = base
+        self.base_contracts = base_contracts
+        self.nodes = nodes
+
+
+class InheritanceSpecifier(ASTNode):
+    __slots__ = "basename", "args"
+
+    def __init__(self, basename: 'UserDefinedTypeName', args: Optional[List['Expression']], **kwargs):
+        super().__init__(**kwargs)
+        self.basename = basename
+        self.args = args
+
+
+class UsingForDirective(ASTNode):
+    __slots__ = "library", "typename"
+
+    def __init__(self, library: 'UserDefinedTypeName', typename: 'TypeName', **kwargs):
+        super().__init__(**kwargs)
+        self.library = library
+        self.typename = typename
+
+
+class StructDefinition(Declaration):
+    __slots__ = "members"
+
+    def __init__(self, members: List['VariableDeclaration'], **kwargs):
+        super().__init__(**kwargs)
+        self.members = members
+
+
+class EnumDefinition(Declaration):
+    __slots__ = "members"
+
+    def __init__(self, members: List['EnumValue'], **kwargs):
+        super().__init__(**kwargs)
+        self.members = members
+
+
+class EnumValue(Declaration):
+    pass
+
+
+class ParameterList(ASTNode):
+    __slots__ = "params"
+
+    def __init__(self, params: List['VariableDeclaration'], **kwargs):
+        super().__init__(**kwargs)
+        self.params = params
+
+
+class CallableDeclaration(Declaration):
+    __slots__ = "params", "rets"
+
+    def __init__(self, params: ParameterList, rets: Optional[ParameterList], **kwargs):
+        super().__init__(**kwargs)
+        self.params = params
+        self.rets = rets
+
+
+# mutability can be: "pure", "view", "nonpayable", "payable"
+# kind can be: "function", "constructor", "fallback", "receive"
+class FunctionDefinition(CallableDeclaration):
+    __slots__ = "mutability", "kind", "modifiers", "body"
+
+    def __init__(self, mutability: str, kind: str, modifiers: List['ModifierInvocation'], body: 'Block', **kwargs):
+        super().__init__(**kwargs)
+        self.mutability = mutability
+        self.kind = kind
+        self.modifiers = modifiers
+        self.body = body
+
+
+class VariableDeclaration(Declaration):
+    __slots__ = "typename", "value", "type_str", "constant", "indexed", "location"
+
+    def __init__(self, typename: 'TypeName', value: Optional['Expression'], type_str: str, constant: bool,
+                 indexed: Optional[bool], location: str, **kwargs):
+        super().__init__(**kwargs)
+        self.type_str = type_str
+        self.value = value
+        self.constant = constant
+        self.typename = typename
+        self.indexed = indexed
+        self.location = location
+
+
+class ModifierDefinition(CallableDeclaration):
+    __slots__ = "body"
+
+    def __init__(self, body: 'Block', **kwargs):
+        super().__init__(**kwargs)
+        self.body = body
+
+
+class ModifierInvocation(ASTNode):
+    __slots__ = "modifier", "args"
+
+    def __init__(self, modifier: 'Identifier', args: Optional[List['Expression']], **kwargs):
+        super().__init__(**kwargs)
+        self.modifier = modifier
+        self.args = args
+
+
+class EventDefinition(CallableDeclaration):
+    __slots__ = "anonymous"
+
+    def __init__(self, anonymous: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.anonymous = anonymous
+
+
+class TypeName(ASTNode):
+    pass
+
+
+class ElementaryTypeName(TypeName):
+    __slots__ = "name", "mutability"
+
+    def __init__(self, name: str, mutability: Optional[str], **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        self.mutability = mutability
+
+
+class UserDefinedTypeName(TypeName):
+    """
+    referenced_declaration might be None for old versions of solidity
+    """
+    __slots__ = "name", "referenced_declaration"
+
+    def __init__(self, name: str, referenced_declaration: Optional[int], **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        self.referenced_declaration = referenced_declaration
+
+
+class FunctionTypeName(TypeName):
+    __slots__ = "params", "rets", "visibility", "mutability"
+
+    def __init__(self, params: 'ParameterList', rets: 'ParameterList', visibility: str, mutability: str, **kwargs):
+        super().__init__(**kwargs)
+        self.params = params
+        self.rets = rets
+        self.visibility = visibility
+        self.mutability = mutability
+
+
+class Mapping(TypeName):
+    __slots__ = "key", "value"
+
+    def __init__(self, key: TypeName, value: TypeName, **kwargs):
+        super().__init__(**kwargs)
+        self.key = key
+        self.value = value
+
+
+class ArrayTypeName(TypeName):
+    __slots__ = "base", "len"
+
+    def __init__(self, base: TypeName, len: Optional['Expression'], **kwargs):
+        super().__init__(**kwargs)
+        self.base = base
+        self.len = len
+
+
+class Statement(ASTNode):
+    pass
+
+
+class InlineAssembly(Statement):
+    __slots__ = "ast"
+
+    def __init__(self, ast: Union[Dict, str], **kwargs):
+        super().__init__(**kwargs)
+        self.ast = ast
+
+
+class Block(Statement):
+    __slots__ = "statements"
+
+    def __init__(self, statements: List[Statement], **kwargs):
+        super().__init__(**kwargs)
+        self.statements = statements
+
+
+class PlaceholderStatement(Statement):
+    pass
+
+
+class IfStatement(Statement):
+    __slots__ = "condition", "true_body", "false_body"
+
+    def __init__(self, condition: 'Expression', true_budy: Statement, false_body: Optional[Statement], **kwargs):
+        super().__init__(**kwargs)
+        self.condition = condition
+        self.true_body = true_budy
+        self.false_body = false_body
+
+
+class TryCatchClause(ASTNode):
+    __slots__ = "error_name", "params", "block"
+
+    def __init__(self, error_name: str, params: Optional['ParameterList'], block: Block, **kwargs):
+        super().__init__(**kwargs)
+        self.error_name = error_name
+        self.params = params
+        self.block = block
+
+
+class TryStatement(Statement):
+    __slots__ = "external_call", "clauses"
+
+    def __init__(self, external_call: 'Expression', clauses: List[TryCatchClause], **kwargs):
+        super().__init__(**kwargs)
+        self.external_call = external_call
+        self.clauses = clauses
+
+
+class WhileStatement(Statement):
+    __slots__ = "condition", "body", "is_do_while"
+
+    def __init__(self, condition: 'Expression', body: Statement, is_do_while: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.condition = condition
+        self.body = body
+        self.is_do_while = is_do_while
+
+
+class ForStatement(Statement):
+    __slots__ = "init", "cond", "loop", "body"
+
+    def __init__(self, init: Optional[Statement], cond: Optional['Expression'], loop: Optional['ExpressionStatement'],
+                 body: Statement, **kwargs):
+        super().__init__(**kwargs)
+        self.init = init
+        self.cond = cond
+        self.loop = loop
+        self.body = body
+
+
+class Continue(Statement):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Break(Statement):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Return(Statement):
+    __slots__ = "expression"
+
+    def __init__(self, expression: Optional['Expression'], **kwargs):
+        super().__init__(**kwargs)
+        self.expression = expression
+
+
+class Throw(Statement):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class EmitStatement(Statement):
+    __slots__ = "event_call"
+
+    def __init__(self, event_call: 'FunctionCall', **kwargs):
+        super().__init__(**kwargs)
+        self.event_call = event_call
+
+
+class VariableDeclarationStatement(Statement):
+    __slots__ = "variables", "initial_value"
+
+    def __init__(self, variables: List[Optional['VariableDeclaration']], initial_value: Optional['Expression'],
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.variables = variables
+        self.initial_value = initial_value
+
+
+class ExpressionStatement(Statement):
+    __slots__ = "expression"
+
+    def __init__(self, expression: 'Expression', **kwargs):
+        super().__init__(**kwargs)
+        self.expression = expression
+
+
+class Expression(ASTNode):
+    __slots__ = "type_str", "constant", "pure"
+
+    def __init__(self, type_str: str, constant: bool, pure: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.type_str = type_str
+        self.constant = constant
+        self.pure = pure
+
+
+class Conditional(Expression):
+    __slots__ = "condition", "true_expr", "false_expr"
+
+    def __init__(self, condition: Expression, true_expr: Expression, false_expr: Expression, **kwargs):
+        super().__init__(**kwargs)
+        self.condition = condition
+        self.true_expr = true_expr
+        self.false_expr = false_expr
+
+
+class Assignment(Expression):
+    __slots__ = "left", "operator", "right"
+
+    def __init__(self, left: Expression, operator: str, right: Expression, **kwargs):
+        super().__init__(**kwargs)
+        self.left = left
+        self.operator = operator
+        self.right = right
+
+
+class TupleExpression(Expression):
+    __slots__ = "components", "is_array"
+
+    def __init__(self, components: List[Optional[Expression]], is_array: bool, **kwargs):
+        super().__init__(**kwargs)
+
+        self.components = components
+        self.is_array = is_array
+
+
+class UnaryOperation(Expression):
+    __slots__ = "operator", "expression", "is_prefix"
+
+    def __init__(self, operator: str, expression: Expression, is_prefix: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.operator = operator
+        self.expression = expression
+        self.is_prefix = is_prefix
+
+
+class BinaryOperation(Expression):
+    __slots__ = "left", "operator", "right"
+
+    def __init__(self, left: Expression, operator: str, right: Expression, **kwargs):
+        super().__init__(**kwargs)
+        self.left = left
+        self.operator = operator
+        self.right = right
+
+
+# kind can be: "functionCall", "typeConversion", "structConstructorCall"
+class FunctionCall(Expression):
+    __slots__ = "kind", "expression", "arguments", "names"
+
+    def __init__(self, kind: str, expression: Expression, names: List[str], arguments: List[Expression], **kwargs):
+        super().__init__(**kwargs)
+        self.kind = kind
+        self.expression = expression
+        self.names = names
+        self.arguments = arguments
+
+
+class FunctionCallOptions(Expression):
+    __slots__ = "expression", "names", "options"
+
+    def __init__(self, expression: Expression, names: List[str], options: List[Expression], **kwargs):
+        super().__init__(**kwargs)
+        self.expression = expression
+        self.names = names
+        self.options = options
+
+
+class NewExpression(Expression):
+    __slots__ = "typename"
+
+    def __init__(self, typename: TypeName, **kwargs):
+        super().__init__(**kwargs)
+        self.typename = typename
+
+
+class MemberAccess(Expression):
+    __slots__ = "expression", "member_name"
+
+    def __init__(self, expression: Expression, member_name: str, **kwargs):
+        super().__init__(**kwargs)
+        self.expression = expression
+        self.member_name = member_name
+
+
+class IndexAccess(Expression):
+    __slots__ = "base", "index"
+
+    def __init__(self, base: Expression, index: Optional[Expression], **kwargs):
+        super().__init__(**kwargs)
+        self.base = base
+        self.index = index
+
+
+class IndexRangeAccess(Expression):
+    __slots__ = "base", "start", "end"
+
+    def __init__(self, base: Expression, start: Expression, end: Expression, **kwargs):
+        super().__init__(**kwargs)
+        self.base = base
+        self.start = start
+        self.end = end
+
+
+class Identifier(Expression):
+    __slots__ = "name"
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+
+
+class ElementaryTypeNameExpression(Expression):
+    __slots__ = "typename"
+
+    def __init__(self, typename: ElementaryTypeName, **kwargs):
+        super().__init__(**kwargs)
+        self.typename = typename
+
+
+class Literal(Expression):
+    __slots__ = "kind", "value", "hex_value", "subdenomination"
+
+    def __init__(self, kind: str, value: str, hex_value: str, subdenomination: str, **kwargs):
+        super().__init__(**kwargs)
+        self.kind = kind
+        self.value = value
+        self.hex_value = hex_value
+        self.subdenomination = subdenomination

--- a/slither/solc_parsing/variables/event_variable.py
+++ b/slither/solc_parsing/variables/event_variable.py
@@ -1,20 +1,13 @@
-from typing import Dict
-
 from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.event_variable import EventVariable
+from ..types.types import VariableDeclaration
 
 
-class EventVariableSolc(VariableDeclarationSolc):
-    def __init__(self, variable: EventVariable, variable_data: Dict):
+class EventVariableSolc(VariableDeclarationSolc[EventVariable]):
+    def __init__(self, variable: EventVariable, variable_data: VariableDeclaration):
         super().__init__(variable, variable_data)
 
-    @property
-    def underlying_variable(self) -> EventVariable:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, EventVariable)
-        return self._variable
-
-    def _analyze_variable_attributes(self, attributes: Dict):
+    def _analyze_variable_attributes(self, attributes: VariableDeclaration):
         """
         Analyze event variable attributes
         :param attributes: The event variable attributes to parse.
@@ -22,7 +15,7 @@ class EventVariableSolc(VariableDeclarationSolc):
         """
 
         # Check for the indexed attribute
-        if "indexed" in attributes:
-            self.underlying_variable.indexed = attributes["indexed"]
+        if attributes.indexed is not None:
+            self.underlying_variable.indexed = attributes.indexed
 
         super()._analyze_variable_attributes(attributes)

--- a/slither/solc_parsing/variables/function_type_variable.py
+++ b/slither/solc_parsing/variables/function_type_variable.py
@@ -1,15 +1,8 @@
-from typing import Dict
-
+from slither.solc_parsing.types.types import VariableDeclaration
 from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.function_type_variable import FunctionTypeVariable
 
 
-class FunctionTypeVariableSolc(VariableDeclarationSolc):
-    def __init__(self, variable: FunctionTypeVariable, variable_data: Dict):
+class FunctionTypeVariableSolc(VariableDeclarationSolc[FunctionTypeVariable]):
+    def __init__(self, variable: FunctionTypeVariable, variable_data: VariableDeclaration):
         super().__init__(variable, variable_data)
-
-    @property
-    def underlying_variable(self) -> FunctionTypeVariable:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, FunctionTypeVariable)
-        return self._variable

--- a/slither/solc_parsing/variables/local_variable.py
+++ b/slither/solc_parsing/variables/local_variable.py
@@ -1,33 +1,13 @@
-from typing import Dict
-
-from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.local_variable import LocalVariable
+from .variable_declaration import VariableDeclarationSolc
+from ..types.types import VariableDeclarationStatement, VariableDeclaration
 
 
-class LocalVariableSolc(VariableDeclarationSolc):
-    def __init__(self, variable: LocalVariable, variable_data: Dict):
+class LocalVariableSolc(VariableDeclarationSolc[LocalVariable]):
+    def __init__(self, variable: LocalVariable, variable_data: VariableDeclarationStatement):
         super().__init__(variable, variable_data)
 
-    @property
-    def underlying_variable(self) -> LocalVariable:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, LocalVariable)
-        return self._variable
-
-    def _analyze_variable_attributes(self, attributes: Dict):
-        """'
-        Variable Location
-        Can be storage/memory or default
-        """
-        if "storageLocation" in attributes:
-            location = attributes["storageLocation"]
-            self.underlying_variable.set_location(location)
-        else:
-            if "memory" in attributes["type"]:
-                self.underlying_variable.set_location("memory")
-            elif "storage" in attributes["type"]:
-                self.underlying_variable.set_location("storage")
-            else:
-                self.underlying_variable.set_location("default")
+    def _analyze_variable_attributes(self, attributes: VariableDeclaration):
+        self.underlying_variable.set_location(attributes.location)
 
         super()._analyze_variable_attributes(attributes)

--- a/slither/solc_parsing/variables/local_variable_init_from_tuple.py
+++ b/slither/solc_parsing/variables/local_variable_init_from_tuple.py
@@ -1,16 +1,9 @@
-from typing import Dict
-
-from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.local_variable_init_from_tuple import LocalVariableInitFromTuple
+from .variable_declaration import VariableDeclarationSolc
+from ..types.types import VariableDeclarationStatement
 
 
-class LocalVariableInitFromTupleSolc(VariableDeclarationSolc):
-    def __init__(self, variable: LocalVariableInitFromTuple, variable_data: Dict, index: int):
+class LocalVariableInitFromTupleSolc(VariableDeclarationSolc[LocalVariableInitFromTuple]):
+    def __init__(self, variable: LocalVariableInitFromTuple, variable_data: VariableDeclarationStatement, index: int):
         super().__init__(variable, variable_data)
         variable.tuple_index = index
-
-    @property
-    def underlying_variable(self) -> LocalVariableInitFromTuple:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, LocalVariableInitFromTuple)
-        return self._variable

--- a/slither/solc_parsing/variables/state_variable.py
+++ b/slither/solc_parsing/variables/state_variable.py
@@ -1,15 +1,8 @@
-from typing import Dict
-
-from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.state_variable import StateVariable
+from .variable_declaration import VariableDeclarationSolc
+from ..types.types import VariableDeclaration
 
 
-class StateVariableSolc(VariableDeclarationSolc):
-    def __init__(self, variable: StateVariable, variable_data: Dict):
+class StateVariableSolc(VariableDeclarationSolc[StateVariable]):
+    def __init__(self, variable: StateVariable, variable_data: VariableDeclaration):
         super().__init__(variable, variable_data)
-
-    @property
-    def underlying_variable(self) -> StateVariable:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, StateVariable)
-        return self._variable

--- a/slither/solc_parsing/variables/structure_variable.py
+++ b/slither/solc_parsing/variables/structure_variable.py
@@ -1,15 +1,8 @@
-from typing import Dict
-
 from slither.solc_parsing.variables.variable_declaration import VariableDeclarationSolc
 from slither.core.variables.structure_variable import StructureVariable
+from ..types.types import VariableDeclaration
 
 
-class StructureVariableSolc(VariableDeclarationSolc):
-    def __init__(self, variable: StructureVariable, variable_data: Dict):
+class StructureVariableSolc(VariableDeclarationSolc[StructureVariable]):
+    def __init__(self, variable: StructureVariable, variable_data: VariableDeclaration):
         super().__init__(variable, variable_data)
-
-    @property
-    def underlying_variable(self) -> StructureVariable:
-        # Todo: Not sure how to overcome this with mypy
-        assert isinstance(self._variable, StructureVariable)
-        return self._variable

--- a/slither/solc_parsing/variables/variable_declaration.py
+++ b/slither/solc_parsing/variables/variable_declaration.py
@@ -1,36 +1,23 @@
 import logging
-from typing import Dict
-
-from slither.solc_parsing.expressions.expression_parsing import parse_expression
+from typing import Optional, Union, TypeVar, Generic
 
 from slither.core.variables.variable import Variable
 
-from slither.solc_parsing.solidity_types.type_parsing import parse_type, UnknownType
+from slither.solc_parsing.solidity_types.type_parsing import parse_type
 
-from slither.core.solidity_types.elementary_type import (
-    ElementaryType,
-    NonElementaryType,
-)
-from slither.solc_parsing.exceptions import ParsingError
+from slither.solc_parsing.expressions.expression_parsing import parse_expression
+from slither.solc_parsing.types.types import VariableDeclarationStatement, Expression, VariableDeclaration, TypeName
 
 logger = logging.getLogger("VariableDeclarationSolcParsing")
 
 
-class MultipleVariablesDeclaration(Exception):
-    """
-    This is raised on
-    var (a,b) = ...
-    It should occur only on local variable definition
-    """
-
-    # pylint: disable=unnecessary-pass
-    pass
+T = TypeVar('T', bound=Variable)
 
 
-class VariableDeclarationSolc:
+class VariableDeclarationSolc(Generic[T]):
     def __init__(
-        self, variable: Variable, variable_data: Dict
-    ):  # pylint: disable=too-many-branches
+            self, variable: T, variable_data: Union[VariableDeclaration, VariableDeclarationStatement]
+    ): # pylint: disable=too-many-branches
         """
         A variable can be declared through a statement, or directly.
         If it is through a statement, the following children may contain
@@ -41,57 +28,20 @@ class VariableDeclarationSolc:
 
         self._variable = variable
         self._was_analyzed = False
-        self._elem_to_parse = None
+        self._elem_to_parse: Optional[Union[TypeName, str]] = None
         self._initializedNotParsed = None
-
-        self._is_compact_ast = False
 
         self._reference_id = None
 
-        if "nodeType" in variable_data:
-            self._is_compact_ast = True
-            nodeType = variable_data["nodeType"]
-            if nodeType in [
-                "VariableDeclarationStatement",
-                "VariableDefinitionStatement",
-            ]:
-                if len(variable_data["declarations"]) > 1:
-                    raise MultipleVariablesDeclaration
-                init = None
-                if "initialValue" in variable_data:
-                    init = variable_data["initialValue"]
-                self._init_from_declaration(variable_data["declarations"][0], init)
-            elif nodeType == "VariableDeclaration":
-                self._init_from_declaration(variable_data, variable_data.get("value", None))
-            else:
-                raise ParsingError("Incorrect variable declaration type {}".format(nodeType))
+        if isinstance(variable_data, VariableDeclarationStatement):
+            assert len(variable_data.variables) == 1
 
-        else:
-            nodeType = variable_data["name"]
-
-            if nodeType in [
-                "VariableDeclarationStatement",
-                "VariableDefinitionStatement",
-            ]:
-                if len(variable_data["children"]) == 2:
-                    init = variable_data["children"][1]
-                elif len(variable_data["children"]) == 1:
-                    init = None
-                elif len(variable_data["children"]) > 2:
-                    raise MultipleVariablesDeclaration
-                else:
-                    raise ParsingError(
-                        "Variable declaration without children?" + str(variable_data)
-                    )
-                declaration = variable_data["children"][0]
-                self._init_from_declaration(declaration, init)
-            elif nodeType == "VariableDeclaration":
-                self._init_from_declaration(variable_data, False)
-            else:
-                raise ParsingError("Incorrect variable declaration type {}".format(nodeType))
+            self._init_from_declaration(variable_data.variables[0], variable_data.initial_value)
+        elif isinstance(variable_data, VariableDeclaration):
+            self._init_from_declaration(variable_data, variable_data.value)
 
     @property
-    def underlying_variable(self) -> Variable:
+    def underlying_variable(self) -> T:
         return self._variable
 
     @property
@@ -102,74 +52,28 @@ class VariableDeclarationSolc:
         """
         return self._reference_id
 
-    def _analyze_variable_attributes(self, attributes: Dict):
-        if "visibility" in attributes:
-            self._variable.visibility = attributes["visibility"]
-        else:
-            self._variable.visibility = "internal"
+    def _analyze_variable_attributes(self, var: VariableDeclaration):
+        self._variable.visibility = var.visibility
 
-    def _init_from_declaration(self, var: Dict, init: bool):  # pylint: disable=too-many-branches
-        if self._is_compact_ast:
-            attributes = var
-            self._typeName = attributes["typeDescriptions"]["typeString"]
-        else:
-            assert len(var["children"]) <= 2
-            assert var["name"] == "VariableDeclaration"
-
-            attributes = var["attributes"]
-            self._typeName = attributes["type"]
-
-        self._variable.name = attributes["name"]
-        # self._arrayDepth = 0
-        # self._isMapping = False
-        # self._mappingFrom = None
-        # self._mappingTo = False
-        # self._initial_expression = None
-        # self._type = None
+    def _init_from_declaration(self, var: VariableDeclaration, init: Optional[Expression]):
+        self._typeName = var.type_str
+        self._variable.name = var.name
 
         # Only for comapct ast format
         # the id can be used later if referencedDeclaration
         # is provided
-        if "id" in var:
-            self._reference_id = var["id"]
+        self._reference_id = var.id
 
-        if "constant" in attributes:
-            self._variable.is_constant = attributes["constant"]
+        self._variable.is_constant = var.constant
+        self._analyze_variable_attributes(var)
 
-        self._analyze_variable_attributes(attributes)
+        self._elem_to_parse = var.typename
+        if not var.typename:
+            self._elem_to_parse = var.type_str
 
-        if self._is_compact_ast:
-            if var["typeName"]:
-                self._elem_to_parse = var["typeName"]
-            else:
-                self._elem_to_parse = UnknownType(var["typeDescriptions"]["typeString"])
-        else:
-            if not var["children"]:
-                # It happens on variable declared inside loop declaration
-                try:
-                    self._variable.type = ElementaryType(self._typeName)
-                    self._elem_to_parse = None
-                except NonElementaryType:
-                    self._elem_to_parse = UnknownType(self._typeName)
-            else:
-                self._elem_to_parse = var["children"][0]
-
-        if self._is_compact_ast:
-            self._initializedNotParsed = init
-            if init:
-                self._variable.initialized = True
-        else:
-            if init:  # there are two way to init a var local in the AST
-                assert len(var["children"]) <= 1
-                self._variable.initialized = True
-                self._initializedNotParsed = init
-            elif len(var["children"]) in [0, 1]:
-                self._variable.initialized = False
-                self._initializedNotParsed = []
-            else:
-                assert len(var["children"]) == 2
-                self._variable.initialized = True
-                self._initializedNotParsed = var["children"][1]
+        self._initializedNotParsed = init
+        if init:
+            self._variable.initialized = True
 
     def analyze(self, caller_context):
         # Can be re-analyzed due to inheritance


### PR DESCRIPTION
the codebase is littered with `is_compact_ast` and it's hard to work with magic dictionaries everywhere. this PR introduces a new parsing step which translates solc ast json into a plain python object and handles any inconsistencies between different solc versions.

creating the pr now so I can have the ci run some tests

todo:
- handle try/catch in legacy ast format
- write some tests