### PR TITLE
fix if statement handling for solc 0.7.0+

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -355,7 +355,7 @@ class FunctionSolc:
             condition_node.add_unparsed_expression(condition)
             link_underlying_nodes(node, condition_node)
             trueStatement = self._parse_statement(if_statement["trueBody"], condition_node)
-            if if_statement["falseBody"]:
+            if "falseBody" in if_statement and if_statement["falseBody"]:
                 falseStatement = self._parse_statement(if_statement["falseBody"], condition_node)
         else:
             children = if_statement[self.get_children("children")]


### PR DESCRIPTION
solidity started stripping null members it seems. this might not be the only thing that's broken, but I guess we can fix them as we stumble across them.

repro case:
```
solc, the solidity compiler commandline interface
Version: 0.7.0+commit.9e61f92b.Linux.g++
```

```solidity
contract C {
    function f() public {
        if (0 > 0) {
            0;
        }
    }
}
```