### PR TITLE
fix cfg printer filename generation

### DIFF
--- a/slither/printers/functions/cfg.py
+++ b/slither/printers/functions/cfg.py
@@ -8,7 +8,7 @@ class CFG(AbstractPrinter):
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#cfg"
 
-    def output(self, filename):
+    def output(self, filename_origin):
         """
         _filename is not used
         Args:
@@ -21,8 +21,8 @@ class CFG(AbstractPrinter):
             if contract.is_top_level:
                 continue
             for function in contract.functions + contract.modifiers:
-                if filename:
-                    filename = "{}-{}-{}.dot".format(filename, contract.name, function.full_name)
+                if filename_origin:
+                    filename = "{}-{}-{}.dot".format(filename_origin, contract.name, function.full_name)
                 else:
                     filename = "{}-{}.dot".format(contract.name, function.full_name)
                 info += "Export {}\n".format(filename)

--- a/slither/printers/functions/cfg.py
+++ b/slither/printers/functions/cfg.py
@@ -8,7 +8,7 @@ class CFG(AbstractPrinter):
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#cfg"
 
-    def output(self, filename_origin):
+    def output(self, filename):
         """
         _filename is not used
         Args:
@@ -21,15 +21,15 @@ class CFG(AbstractPrinter):
             if contract.is_top_level:
                 continue
             for function in contract.functions + contract.modifiers:
-                if filename_origin:
-                    filename = "{}-{}-{}.dot".format(filename_origin, contract.name, function.full_name)
+                if filename:
+                    new_filename = "{}-{}-{}.dot".format(filename, contract.name, function.full_name)
                 else:
-                    filename = "{}-{}.dot".format(contract.name, function.full_name)
-                info += "Export {}\n".format(filename)
+                    new_filename = "{}-{}.dot".format(contract.name, function.full_name)
+                info += "Export {}\n".format(new_filename)
                 content = function.slithir_cfg_to_dot_str()
-                with open(filename, "w", encoding="utf8") as f:
+                with open(new_filename, "w", encoding="utf8") as f:
                     f.write(content)
-                all_files.append((filename, content))
+                all_files.append((new_filename, content))
 
         self.info(info)
 

--- a/slither/printers/functions/cfg.py
+++ b/slither/printers/functions/cfg.py
@@ -22,7 +22,9 @@ class CFG(AbstractPrinter):
                 continue
             for function in contract.functions + contract.modifiers:
                 if filename:
-                    new_filename = "{}-{}-{}.dot".format(filename, contract.name, function.full_name)
+                    new_filename = "{}-{}-{}.dot".format(
+                        filename, contract.name, function.full_name
+                    )
                 else:
                     new_filename = "{}-{}.dot".format(contract.name, function.full_name)
                 info += "Export {}\n".format(new_filename)


### PR DESCRIPTION
before:
```
INFO:Printers:Export C-doubleAndAdd(uint256,uint256).dot
Export C-doubleAndAdd(uint256,uint256).dot-C-test().dot
Export C-doubleAndAdd(uint256,uint256).dot-C-test().dot-C-slitherConstructorVariables().dot
```

after:
```
INFO:Printers:Export C-doubleAndAdd(uint256,uint256).dot
Export C-test().dot
Export C-slitherConstructorVariables().dot
```