### PR TITLE
Add support for type(X).min/max 

### DIFF
--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -5,6 +5,7 @@ from slither.core.solidity_types.type import Type
 
 
 # see https://solidity.readthedocs.io/en/v0.4.24/miscellaneous.html?highlight=grammar
+from slither.exceptions import SlitherException
 
 Int = [
     "int",
@@ -42,6 +43,9 @@ Int = [
     "int256",
 ]
 
+Max_Int = {k: 2 ** (8 * i - 1) - 1 if i > 0 else 2 ** 255 - 1 for i, k in enumerate(Int)}
+Min_Int = {k: -(2 ** (8 * i - 1)) if i > 0 else -(2 ** 255) for i, k in enumerate(Int)}
+
 Uint = [
     "uint",
     "uint8",
@@ -77,6 +81,12 @@ Uint = [
     "uint248",
     "uint256",
 ]
+
+Max_Uint = {k: 2 ** (8 * i) - 1 if i > 0 else 2 ** 256 - 1 for i, k in enumerate(Uint)}
+Min_Uint = {k: 0 for k in Uint}
+
+MaxValues = dict(Max_Int, **Max_Uint)
+MinValues = dict(Min_Int, **Min_Uint)
 
 Byte = [
     "byte",
@@ -179,6 +189,18 @@ class ElementaryType(Type):
         if self.size is None:
             return 32, True
         return int(self.size / 8), False
+
+    @property
+    def min(self) -> int:
+        if self.name in MinValues:
+            return MinValues[self.name]
+        raise SlitherException(f"{self.name} does not have a min value")
+
+    @property
+    def max(self) -> int:
+        if self.name in MaxValues:
+            return MaxValues[self.name]
+        raise SlitherException(f"{self.name} does not have a max value")
 
     def __str__(self):
         return self._type

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -456,6 +456,9 @@ def _convert_type_contract(ir, slither):
         assignment.lvalue.set_type(ElementaryType("string"))
         return assignment
 
+    if isinstance(contract, ElementaryType):
+        print(contract.type)
+
     raise SlithIRError(f"type({contract.name}).{ir.variable_right} is unknown")
 
 
@@ -1427,6 +1430,12 @@ def remove_unused(result):
                 if not ins.lvalue.name in to_keep and ins != last_elem:
                     to_remove.append(ins)
                     removed = True
+            # Remove type(X) if X is an elementary type
+            # This assume that type(X) is only used with min/max
+            # If Solidity introduces other operation, we might remove this removal
+            if isinstance(ins, SolidityCall) and ins.function == SolidityFunction('type()'):
+                if isinstance(ins.arguments[0], ElementaryType):
+                    to_remove.append(ins)
 
         result = [i for i in result if not i in to_remove]
     return result

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1417,7 +1417,7 @@ def remove_unused(result):
             # Remove type(X) if X is an elementary type
             # This assume that type(X) is only used with min/max
             # If Solidity introduces other operation, we might remove this removal
-            if isinstance(ins, SolidityCall) and ins.function == SolidityFunction('type()'):
+            if isinstance(ins, SolidityCall) and ins.function == SolidityFunction("type()"):
                 if isinstance(ins.arguments[0], ElementaryType):
                     to_remove.append(ins)
 

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -370,17 +370,9 @@ class ExpressionToSlithIR(ExpressionVisitor):
                     assert isinstance(type_expression_found, ElementaryTypeNameExpression)
                     type_found = type_expression_found.type
                     if expression.member_name == "min:":
-                        op = Assignment(
-                            val,
-                            Constant(str(type_found.min), type_found),
-                            type_found,
-                        )
+                        op = Assignment(val, Constant(str(type_found.min), type_found), type_found,)
                     else:
-                        op = Assignment(
-                            val,
-                            Constant(str(type_found.max), type_found),
-                            type_found,
-                        )
+                        op = Assignment(val, Constant(str(type_found.max), type_found), type_found,)
                     self._result.append(op)
                     set_val(expression, val)
                     return

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -4,11 +4,15 @@ from slither.core.declarations import (
     Function,
     SolidityVariable,
     SolidityVariableComposed,
+    SolidityFunction,
 )
 from slither.core.expressions import (
     AssignmentOperationType,
     UnaryOperationType,
     BinaryOperationType,
+    ElementaryTypeNameExpression,
+    CallExpression,
+    Identifier,
 )
 from slither.core.solidity_types import ArrayType, ElementaryType
 from slither.core.solidity_types.type import Type
@@ -350,6 +354,37 @@ class ExpressionToSlithIR(ExpressionVisitor):
 
     def _post_member_access(self, expression):
         expr = get(expression.expression)
+
+        # Look for type(X).max / min
+        # Because we looked at the AST structure, we need to look into the nested expression
+        # Hopefully this is always on a direct sub field, and there is no weird construction
+        if isinstance(expression.expression, CallExpression) and expression.member_name in [
+            "min",
+            "max",
+        ]:
+            if isinstance(expression.expression.called, Identifier):
+                if expression.expression.called.value == SolidityFunction("type()"):
+                    assert len(expression.expression.arguments) == 1
+                    val = TemporaryVariable(self._node)
+                    type_expression_found = expression.expression.arguments[0]
+                    assert isinstance(type_expression_found, ElementaryTypeNameExpression)
+                    type_found = type_expression_found.type
+                    if expression.member_name == "min:":
+                        op = Assignment(
+                            val,
+                            Constant(str(type_found.min), type_found),
+                            type_found,
+                        )
+                    else:
+                        op = Assignment(
+                            val,
+                            Constant(str(type_found.max), type_found),
+                            type_found,
+                        )
+                    self._result.append(op)
+                    set_val(expression, val)
+                    return
+
         val = ReferenceVariable(self._node)
         member = Member(expr, Constant(expression.member_name), val)
         member.set_expression(expression)

--- a/tests/ast-parsing/expected/minmax-0.4.0-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.0-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.1-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.1-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.10-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.10-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.11-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.11-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.12-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.12-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.12-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.12-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.13-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.13-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.13-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.13-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.14-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.14-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.14-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.14-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.15-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.15-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.15-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.15-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.16-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.16-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.16-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.16-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.17-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.17-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.17-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.17-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.18-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.18-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.18-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.18-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.19-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.19-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.19-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.19-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.2-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.2-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.20-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.20-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.20-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.20-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.21-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.21-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.21-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.21-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.22-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.22-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.22-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.22-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.23-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.23-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.23-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.23-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.24-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.24-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.24-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.24-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.25-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.25-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.25-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.25-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.26-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.4.26-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.26-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.26-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.3-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.3-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.4-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.4-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.5-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.5-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.6-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.6-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.7-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.7-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.8-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.8-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.4.9-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.4.9-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.0-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.0-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.0-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.0-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.1-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.1-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.1-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.1-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.10-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.10-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.10-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.10-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.11-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.11-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.11-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.11-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.12-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.12-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.12-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.12-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.13-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.13-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.13-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.13-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.14-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.14-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.14-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.14-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.15-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.15-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.15-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.15-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.16-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.16-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.16-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.16-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.17-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.17-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.17-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.17-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.2-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.2-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.2-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.2-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.3-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.3-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.3-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.3-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.4-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.4-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.4-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.4-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.5-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.5-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.5-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.5-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.6-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.6-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.6-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.6-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.7-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.7-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.7-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.7-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.8-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.8-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.8-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.8-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.9-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.5.9-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.5.9-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.5.9-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.0-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.0-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.0-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.0-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.1-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.1-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.1-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.1-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.10-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.10-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.10-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.10-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.11-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.11-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.11-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.11-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.12-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.12-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.12-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.12-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.2-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.2-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.2-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.2-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.3-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.3-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.3-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.3-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.4-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.4-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.4-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.4-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.5-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.5-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.5-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.5-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.6-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.6-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.6-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.6-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.7-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.7-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.7-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.7-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.8-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.8-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.8-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.8-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.9-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.6.9-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.6.9-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.6.9-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.0-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.7.0-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.0-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.7.0-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.1-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.7.1-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.1-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.7.1-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.2-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.7.2-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.2-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.7.2-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.3-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.7.3-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.3-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.7.3-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.4-compact.json
+++ b/tests/ast-parsing/expected/minmax-0.7.4-compact.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/expected/minmax-0.7.4-legacy.json
+++ b/tests/ast-parsing/expected/minmax-0.7.4-legacy.json
@@ -1,0 +1,5 @@
+{
+  "C": {
+    "f()": "digraph{\n0[label=\"Node Type: ENTRY_POINT 0\n\"];\n0->1;\n1[label=\"Node Type: NEW VARIABLE 1\n\"];\n}\n"
+  }
+}

--- a/tests/ast-parsing/minmax-0.4.0.sol
+++ b/tests/ast-parsing/minmax-0.4.0.sol
@@ -1,0 +1,9 @@
+contract C{
+
+    function f() public{
+
+        uint a = 0; // min/max not supported yet
+
+    }
+
+}

--- a/tests/ast-parsing/minmax-0.6.8.sol
+++ b/tests/ast-parsing/minmax-0.6.8.sol
@@ -1,0 +1,9 @@
+contract C{
+
+    function f() public{
+
+        uint a = type(uint).max;
+
+    }
+
+}

--- a/tests/test_ast_parsing.py
+++ b/tests/test_ast_parsing.py
@@ -462,6 +462,7 @@ def get_all_test() -> List[Item]:
         base_ver_idx = 0
 
         for solc_ver in solc_versions:
+
             # if it's time to move to the next base version, do it now
             if base_ver_idx + 1 < len(base_vers) and base_vers[base_ver_idx + 1] == solc_ver:
                 base_ver_idx += 1
@@ -500,7 +501,6 @@ def generate_output(sl: Slither) -> Dict[str, Dict[str, str]]:
 
 
 ALL_TESTS = get_all_test()
-
 
 def set_solc(test_item: Item):
     # hacky hack hack to pick the solc version we want
@@ -559,7 +559,6 @@ def _generate_test(test_item: Item, skip_existing=False):
         return
 
     set_solc(test_item)
-
     sl = Slither(
         test_file,
         solc_force_legacy_json=test_item.is_legacy,
@@ -568,9 +567,9 @@ def _generate_test(test_item: Item, skip_existing=False):
     )
 
     actual = generate_output(sl)
-
+    print(f"Generate {expected_file}")
     with open(expected_file, "w") as f:
-        json.dump(actual, f, ident="  ")
+        json.dump(actual, f, indent="  ")
 
 
 if __name__ == "__main__":

--- a/tests/test_ast_parsing.py
+++ b/tests/test_ast_parsing.py
@@ -502,6 +502,7 @@ def generate_output(sl: Slither) -> Dict[str, Dict[str, str]]:
 
 ALL_TESTS = get_all_test()
 
+
 def set_solc(test_item: Item):
     # hacky hack hack to pick the solc version we want
     env = dict(os.environ)


### PR DESCRIPTION
```solidity
contract C{

    function f() public{

        uint a = type(uint).max;

    }

}
```
IRs generated:
```
		Expression: a = type()(uint256).max
		IRs:
			TMP_1(uint256) := 115792089237316195423570985008687907853269984665640564039457584007913129639935(uint256)
			a(uint256) := TMP_1(uint256)
```

Fix #671, fix #670 

- [ ] Update parser tests