### PR TITLE
fix set `self.filename` when using crytic-compile

### DIFF
--- a/slither/slither.py
+++ b/slither/slither.py
@@ -74,7 +74,6 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
                 else:
                     crytic_compile = CryticCompile(target, **kwargs)
                 self._crytic_compile = crytic_compile
-                self.filename = crytic_compile.target
             except InvalidCompilation as e:
                 # pylint: disable=raise-missing-from
                 raise SlitherError(f"Invalid compilation: \n{str(e)}")
@@ -189,7 +188,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         :return: List of registered printers outputs.
         """
 
-        return [p.output(self.filename).data for p in self._printers]
+        return [p.output(self._crytic_compile.target).data for p in self._printers]
 
     @property
     def triage_mode(self):

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -74,6 +74,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
                 else:
                     crytic_compile = CryticCompile(target, **kwargs)
                 self._crytic_compile = crytic_compile
+                self.filename = crytic_compile.target
             except InvalidCompilation as e:
                 # pylint: disable=raise-missing-from
                 raise SlitherError(f"Invalid compilation: \n{str(e)}")


### PR DESCRIPTION
When using CryticCompile (the "default"), `self.filename` will not be set, but is passed into each printer. Due to this, executing the `inheritance-graph` and `call-graph` printers will result in files with the default name, `contracts` and `all_contracts`, respectively. Instead of using the name of the Solidity file. Example on `Migrations.sol`:

```
INFO:Printers:Call Graph: all_contracts.dot
Call Graph: Migrations.dot

INFO:Printers:Inheritance Graph: contracts.dot
```

With the fix of this PR applied the result will instead be:
```
INFO:Printers:Call Graph: Migrations.sol.dot
Call Graph: Migrations.dot

INFO:Printers:Inheritance Graph: Migrations.sol.dot
```