### PR TITLE
Add more descriptive names to inheritance-graph + call-graph printers outputted files

### DIFF
--- a/slither/printers/call/call_graph.py
+++ b/slither/printers/call/call_graph.py
@@ -178,29 +178,31 @@ class PrinterCallGraph(AbstractPrinter):
             filename(string)
         """
 
+        all_contracts_filename = ""
         if not filename.endswith(".dot"):
-            filename += ".dot"
+            all_contracts_filename = f"{filename}.all_contracts.call-graph.dot"
         if filename == ".dot":
-            filename = "all_contracts.dot"
+            all_contracts_filename = "all_contracts.dot"
 
         info = ""
         results = []
-        with open(filename, "w", encoding="utf8") as f:
-            info += f"Call Graph: {filename}\n"
+        with open(all_contracts_filename, "w", encoding="utf8") as f:
+            info += f"Call Graph: {all_contracts_filename}\n"
             content = "\n".join(
                 ["strict digraph {"] + [_process_functions(self.slither.functions)] + ["}"]
             )
             f.write(content)
-            results.append((filename, content))
+            results.append((all_contracts_filename, content))
 
         for derived_contract in self.slither.contracts_derived:
-            with open(f"{derived_contract.name}.dot", "w", encoding="utf8") as f:
-                info += f"Call Graph: {derived_contract.name}.dot\n"
+            derived_output_filename = f"{filename}.{derived_contract.name}.call-graph.dot"
+            with open(derived_output_filename, "w", encoding="utf8") as f:
+                info += f"Call Graph: {derived_output_filename}\n"
                 content = "\n".join(
                     ["strict digraph {"] + [_process_functions(derived_contract.functions)] + ["}"]
                 )
                 f.write(content)
-                results.append((filename, content))
+                results.append((derived_output_filename, content))
 
         self.info(info)
         res = self.generate_output(info)

--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -193,7 +193,7 @@ class PrinterInheritanceGraph(AbstractPrinter):
         if filename == "":
             filename = "contracts.dot"
         if not filename.endswith(".dot"):
-            filename += ".dot"
+            filename += ".inheritance-graph.dot"
         info = "Inheritance Graph: " + filename + "\n"
         self.info(info)
 


### PR DESCRIPTION
fixes issue #727 

depends on PR #726 to be merged, otherwise the `filename` argument will be an empty string.

example: `slither Contract.sol --print call-graph,inheritance-graph`

```
INFO:Printers:Call Graph: Contract.sol.all_contracts.call-graph.dot
Call Graph: Contract.sol.SafeMath.call-graph.dot
Call Graph: Contract.sol.Contract.call-graph.dot

INFO:Printers:Inheritance Graph: Contract.sol.inheritance-graph.dot
```