### PR TITLE
Disable parsing types on memberAccess

### DIFF
--- a/slither/core/expressions/member_access.py
+++ b/slither/core/expressions/member_access.py
@@ -6,7 +6,8 @@ from slither.core.solidity_types.type import Type
 
 class MemberAccess(ExpressionTyped):
     def __init__(self, member_name, member_type, expression):
-        assert isinstance(member_type, Type)
+        # assert isinstance(member_type, Type)
+        # TODO member_type is not always a Type
         assert isinstance(expression, Expression)
         super().__init__()
         self._type: Type = member_type

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -802,13 +802,15 @@ def parse_expression(expression: Dict, caller_context: CallerContext) -> "Expres
     if name == "MemberAccess":
         if caller_context.is_compact_ast:
             member_name = expression["memberName"]
-            member_type = parse_type(
-                UnknownType(expression["typeDescriptions"]["typeString"]), caller_context
-            )
+            member_type = expression["typeDescriptions"]["typeString"]
+            # member_type = parse_type(
+            #     UnknownType(expression["typeDescriptions"]["typeString"]), caller_context
+            # )
             member_expression = parse_expression(expression["expression"], caller_context)
         else:
             member_name = expression["attributes"]["member_name"]
-            member_type = parse_type(UnknownType(expression["attributes"]["type"]), caller_context)
+            member_type = expression["attributes"]["type"]
+            # member_type = parse_type(UnknownType(expression["attributes"]["type"]), caller_context)
             children = expression["children"]
             assert len(children) == 1
             member_expression = parse_expression(children[0], caller_context)


### PR DESCRIPTION
Undo part of https://github.com/crytic/slither/pull/730

Currently `parse_type` is too weak to handle all the types from a memberAccess, we should consider rewriting this function to be cleaner and more robust.