### PR TITLE
[WIP] Add "eth-receive" printer which lists functions per contract that can receive ETH as well as requires/state-changes related to msg.sender and msg.value

### DIFF
--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -17,4 +17,4 @@ from .summary.require_calls import RequireOrAssert
 from .summary.constructor_calls import ConstructorPrinter
 from .guidance.echidna import Echidna
 from .summary.evm import PrinterEVM
-from .functions.payable import Payable
+from .functions.eth_receive import EthReceivePrinter

--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -17,3 +17,4 @@ from .summary.require_calls import RequireOrAssert
 from .summary.constructor_calls import ConstructorPrinter
 from .guidance.echidna import Echidna
 from .summary.evm import PrinterEVM
+from .functions.payable import Payable

--- a/slither/printers/functions/eth_receive.py
+++ b/slither/printers/functions/eth_receive.py
@@ -1,5 +1,6 @@
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.utils.myprettytable import MyPrettyTable
+from slither.utils.output import Output
 
 
 class EthReceivePrinter(AbstractPrinter):
@@ -9,7 +10,7 @@ class EthReceivePrinter(AbstractPrinter):
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#eth-receive"
 
-    def output(self, _filename: str):
+    def output(self, _filename: str) -> Output:
         txt = ""
         all_tables = []
         for contract in self.slither.contracts:

--- a/slither/printers/functions/eth_receive.py
+++ b/slither/printers/functions/eth_receive.py
@@ -2,12 +2,12 @@ from slither.printers.abstract_printer import AbstractPrinter
 from slither.utils.myprettytable import MyPrettyTable
 
 
-class Payable(AbstractPrinter):
+class EthReceivePrinter(AbstractPrinter):
 
-    ARGUMENT = "payable"
-    HELP = "Print all functions which can receive ether"
+    ARGUMENT = "eth-receive"
+    HELP = "Print all functions that can receive ether"
 
-    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#payable"
+    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#eth-receive"
 
     def output(self, _filename: str):
         txt = ""

--- a/slither/printers/functions/eth_receive.py
+++ b/slither/printers/functions/eth_receive.py
@@ -5,7 +5,7 @@ from slither.utils.myprettytable import MyPrettyTable
 class EthReceivePrinter(AbstractPrinter):
 
     ARGUMENT = "eth-receive"
-    HELP = "Print all functions that can receive ether"
+    HELP = "Print all functions that can receive ETH"
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#eth-receive"
 

--- a/slither/printers/functions/eth_receive.py
+++ b/slither/printers/functions/eth_receive.py
@@ -1,6 +1,13 @@
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.utils.myprettytable import MyPrettyTable
 from slither.utils.output import Output
+from slither.slithir.operations import Operation
+
+MSG_SENDER_AND_VALUE = set(["msg.sender", "msg.value"])
+
+
+def reads_msg_sender_or_value(ir: Operation) -> bool:
+    return any(str(var) in MSG_SENDER_AND_VALUE for var in ir.read)
 
 
 class EthReceivePrinter(AbstractPrinter):
@@ -14,14 +21,24 @@ class EthReceivePrinter(AbstractPrinter):
         txt = ""
         all_tables = []
         for contract in self.slither.contracts:
-            if contract.is_top_level:
+            if contract.is_top_level or contract.is_interface:
                 continue
             payable_functions = [f for f in contract.functions if f.payable]
             if payable_functions:
                 txt += f"\n{contract.name}:\n"
-                table = MyPrettyTable(["Name"])
+                table = MyPrettyTable(["Name", "Relevant Expressions"])
                 for function in payable_functions:
-                    table.add_row([function.solidity_signature])
+                    relevant_expressions = [
+                        ir
+                        for ir in function.all_slithir_operations()
+                        if reads_msg_sender_or_value(ir)
+                    ]
+                    table.add_row(
+                        [
+                            function.solidity_signature,
+                            "\n".join(str(ir.expression) for ir in relevant_expressions),
+                        ]
+                    )
                 txt += str(table) + "\n"
                 all_tables.append((contract.name, table))
 

--- a/slither/printers/functions/payable.py
+++ b/slither/printers/functions/payable.py
@@ -1,0 +1,33 @@
+from slither.printers.abstract_printer import AbstractPrinter
+from slither.utils.myprettytable import MyPrettyTable
+
+
+class Payable(AbstractPrinter):
+
+    ARGUMENT = "payable"
+    HELP = "Print all functions which can receive ether"
+
+    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#payable"
+
+    def output(self, _filename: str):
+        txt = ""
+        all_tables = []
+        for contract in self.slither.contracts:
+            if contract.is_top_level:
+                continue
+            payable_functions = [f for f in contract.functions if f.payable]
+            if payable_functions:
+                txt += f"\n{contract.name}:\n"
+                table = MyPrettyTable(["Name"])
+                for function in payable_functions:
+                    table.add_row([function.solidity_signature])
+                txt += str(table) + "\n"
+                all_tables.append((contract.name, table))
+
+        self.info(txt)
+
+        res = self.generate_output(txt)
+        for name, table in all_tables:
+            res.add_pretty_table(table, name)
+
+        return res


### PR DESCRIPTION
I didn't find an existing printer that included this output.

Will update the printers documentation in the wiki once this is merged.

- [x] print all functions that are payable
- [ ] print "Related Statements" in those functions that involve `msg.sender` and `msg.value`
- [ ] ensure requires/asserts and state variable writes that involve `msg.sender` or `msg.value` are recognizable
- [ ] ensure modifiers are included correctly
- [ ] detect cases where ether is forwarded rather than kept
- [ ] communicate if "Related Statements" are in called functions

Example:
```
slither --print eth-receive 0xc32f9b0292965c5dd4a0ea1abfcc1f5a36d66986
...
INFO:Printers:
TimelockInterface:
+----------------------------------------------------------+
|                           Name                           |
+----------------------------------------------------------+
| executeTransaction(address,uint256,string,bytes,uint256) |
+----------------------------------------------------------+

DualGovernorAlpha:
+------------------+
|       Name       |
+------------------+
| execute(uint256) |
+------------------+

INFO:Slither:0xc32f9b0292965c5dd4a0ea1abfcc1f5a36d66986 analyzed (5 contracts)
```