### PR TITLE
Fix that Function.can_send_eth() wrongly returns self._can_reenter. add tests for this and other properties and getters of Function class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ To run the unit tests, you need
 
 Several linters and security checkers are run on the PRs.
 
-To run them locally:
+To run them locally in the root dir of the repository:
 
-- `pylint slither --rconfig pyproject.toml`
-- `black slither --config pyproject.toml`
+- `pylint slither tests --rcfile pyproject.toml`
+- `black . --config pyproject.toml`
 
 We use black `19.10b0`.
 ### Detectors tests

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -309,7 +309,7 @@ class Function(metaclass=ABCMeta):  # pylint: disable=too-many-public-methods
                 if isinstance(ir, Call) and ir.can_send_eth():
                     self._can_send_eth = True
                     return True
-        return self._can_reenter
+        return self._can_send_eth
 
     @property
     def slither(self) -> "SlitherCore":

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -9,6 +9,7 @@ tests that `tests/test_function.sol` gets translated into correct
 and that these objects behave correctly.
 """
 
+
 def test_functions():
     slither = Slither("tests/test_function.sol")
     functions = slither.contracts_as_dict["TestFunction"].available_functions_as_dict()

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -3,9 +3,9 @@ from slither.core.declarations.function import FunctionType
 from slither.core.solidity_types.elementary_type import ElementaryType
 
 """
-tests for slither.core.declarations.Function.
-tests that `tests/functions.sol` gets translated into correct
-slither.core.declarations.Function objects or its subclasses
+tests for `slither.core.declarations.Function`.
+tests that `tests/test_function.sol` gets translated into correct
+`slither.core.declarations.Function` objects or its subclasses
 and that these objects behave correctly.
 """
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,7 +1,3 @@
-from slither import Slither
-from slither.core.declarations.function import FunctionType
-from slither.core.solidity_types.elementary_type import ElementaryType
-
 """
 tests for `slither.core.declarations.Function`.
 tests that `tests/test_function.sol` gets translated into correct
@@ -9,8 +5,13 @@ tests that `tests/test_function.sol` gets translated into correct
 and that these objects behave correctly.
 """
 
+from slither import Slither
+from slither.core.declarations.function import FunctionType
+from slither.core.solidity_types.elementary_type import ElementaryType
+
 
 def test_functions():
+    # pylint: disable=too-many-statements
     slither = Slither("tests/test_function.sol")
     functions = slither.contracts_as_dict["TestFunction"].available_functions_as_dict()
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,0 +1,83 @@
+from slither import Slither
+from slither.core.declarations.function import FunctionType
+from slither.core.solidity_types.elementary_type import ElementaryType
+
+"""
+tests for slither.core.declarations.Function.
+tests that `tests/functions.sol` gets translated into correct
+slither.core.declarations.Function objects or its subclasses
+and that these objects behave correctly.
+"""
+
+def test_functions():
+    slither = Slither("tests/test_function.sol")
+    functions = slither.contracts_as_dict["TestFunction"].available_functions_as_dict()
+    print(functions)
+
+    f = functions["external_payable(uint256)"]
+    assert f.name == "external_payable"
+    assert f.full_name == "external_payable(uint256)"
+    assert f.canonical_name == "TestFunction.external_payable(uint256)"
+    assert f.solidity_signature == "external_payable(uint256)"
+    assert f.signature_str == "external_payable(uint256) returns(uint256)"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert f.payable
+    assert f.visibility == "external"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert f.parameters[0].name == "_a"
+    assert f.parameters[0].type == ElementaryType("uint256")
+    assert f.return_type[0] == ElementaryType("uint256")
+
+    f = functions["public_reenter()"]
+    assert f.name == "public_reenter"
+    assert f.full_name == "public_reenter()"
+    assert f.canonical_name == "TestFunction.public_reenter()"
+    assert f.solidity_signature == "public_reenter()"
+    assert f.signature_str == "public_reenter() returns()"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "public"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert not f.parameters
+    assert not f.return_type
+
+    f = functions["public_payable_reenter_send(bool)"]
+    assert f.name == "public_payable_reenter_send"
+    assert f.full_name == "public_payable_reenter_send(bool)"
+    assert f.canonical_name == "TestFunction.public_payable_reenter_send(bool)"
+    assert f.solidity_signature == "public_payable_reenter_send(bool)"
+    assert f.signature_str == "public_payable_reenter_send(bool) returns()"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert f.can_reenter()
+    assert f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert f.payable
+    assert f.visibility == "public"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert f.parameters[0].name == "_b"
+    assert f.parameters[0].type == ElementaryType("bool")
+    assert not f.return_type

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -150,3 +150,92 @@ def test_functions():
     assert f.is_empty
     assert not f.parameters
     assert not f.return_type
+
+    f = functions["receive()"]
+    assert f.name == "receive"
+    assert f.full_name == "receive()"
+    assert f.canonical_name == "TestFunction.receive()"
+    assert f.solidity_signature == "receive()"
+    assert f.signature_str == "receive() returns()"
+    assert f.function_type == FunctionType.RECEIVE
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert f.is_receive
+    assert f.payable
+    assert f.visibility == "external"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert f.is_empty
+    assert not f.parameters
+    assert not f.return_type
+
+    f = functions["constructor(address)"]
+    assert f.name == "constructor"
+    assert f.full_name == "constructor(address)"
+    assert f.canonical_name == "TestFunction.constructor(address)"
+    assert f.solidity_signature == "constructor(address)"
+    assert f.signature_str == "constructor(address) returns()"
+    assert f.function_type == FunctionType.CONSTRUCTOR
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert f.payable
+    assert f.visibility == "public"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert f.is_empty
+    assert f.parameters[0].name == "_e"
+    assert f.parameters[0].type == ElementaryType("address")
+    assert not f.return_type
+
+    f = functions["private_view()"]
+    assert f.name == "private_view"
+    assert f.full_name == "private_view()"
+    assert f.canonical_name == "TestFunction.private_view()"
+    assert f.solidity_signature == "private_view()"
+    assert f.signature_str == "private_view() returns(bool)"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "private"
+    assert f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert not f.parameters
+    assert f.return_type[0] == ElementaryType("bool")
+
+    f = functions["public_pure()"]
+    assert f.name == "public_pure"
+    assert f.full_name == "public_pure()"
+    assert f.canonical_name == "TestFunction.public_pure()"
+    assert f.solidity_signature == "public_pure()"
+    assert f.signature_str == "public_pure() returns(bool)"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "public"
+    assert f.view
+    assert f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert not f.parameters
+    assert f.return_type[0] == ElementaryType("bool")

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -12,7 +12,6 @@ and that these objects behave correctly.
 def test_functions():
     slither = Slither("tests/test_function.sol")
     functions = slither.contracts_as_dict["TestFunction"].available_functions_as_dict()
-    print(functions)
 
     f = functions["external_payable(uint256)"]
     assert f.name == "external_payable"
@@ -80,4 +79,72 @@ def test_functions():
     assert not f.is_empty
     assert f.parameters[0].name == "_b"
     assert f.parameters[0].type == ElementaryType("bool")
+    assert not f.return_type
+
+    f = functions["external_send(uint8)"]
+    assert f.name == "external_send"
+    assert f.full_name == "external_send(uint8)"
+    assert f.canonical_name == "TestFunction.external_send(uint8)"
+    assert f.solidity_signature == "external_send(uint8)"
+    assert f.signature_str == "external_send(uint8) returns()"
+    assert f.function_type == FunctionType.NORMAL
+    assert not f.contains_assembly
+    assert f.can_reenter()
+    assert f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "external"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert f.parameters[0].name == "_c"
+    assert f.parameters[0].type == ElementaryType("uint8")
+    assert not f.return_type
+
+    f = functions["internal_assembly(bytes)"]
+    assert f.name == "internal_assembly"
+    assert f.full_name == "internal_assembly(bytes)"
+    assert f.canonical_name == "TestFunction.internal_assembly(bytes)"
+    assert f.solidity_signature == "internal_assembly(bytes)"
+    assert f.signature_str == "internal_assembly(bytes) returns(uint256)"
+    assert f.function_type == FunctionType.NORMAL
+    assert f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert not f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "internal"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert not f.is_empty
+    assert f.parameters[0].name == "_d"
+    assert f.parameters[0].type == ElementaryType("bytes")
+    assert f.return_type[0] == ElementaryType("uint256")
+
+    f = functions["fallback()"]
+    assert f.name == "fallback"
+    assert f.full_name == "fallback()"
+    assert f.canonical_name == "TestFunction.fallback()"
+    assert f.solidity_signature == "fallback()"
+    assert f.signature_str == "fallback() returns()"
+    assert f.function_type == FunctionType.FALLBACK
+    assert not f.contains_assembly
+    assert not f.can_reenter()
+    assert not f.can_send_eth()
+    assert not f.is_constructor
+    assert f.is_fallback
+    assert not f.is_receive
+    assert not f.payable
+    assert f.visibility == "external"
+    assert not f.view
+    assert not f.pure
+    assert f.is_implemented
+    assert f.is_empty
+    assert not f.parameters
     assert not f.return_type

--- a/tests/test_function.sol
+++ b/tests/test_function.sol
@@ -42,7 +42,7 @@ contract TestFunction {
 
     }
 
-    constructor() public payable {
+    constructor(address payable _e) public payable {
 
     }
 

--- a/tests/test_function.sol
+++ b/tests/test_function.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.6.12;
+
+// solidity source used by tests/test_function.py.
+// tests/test_function.py tests that the functions
+// below get
+
+contract TestFunction {
+    bool entered = false;
+
+    function external_payable(uint _a) external payable returns (uint) {
+        return 1;
+    }
+
+    function public_reenter() public {
+        msg.sender.call("");
+    }
+
+    function public_payable_reenter_send(bool _b) public payable {
+        msg.sender.call{value: 1}("");
+    }
+
+    function external_send(uint _a) external {
+        require(!entered);
+        entered = true;
+        msg.sender.call{value: 1}("");
+    }
+
+    function _internal(uint _a) internal returns (uint) {
+        uint256 chain;
+        assembly {
+            chain := chainid()
+        }
+        return chain;
+    }
+
+    fallback() external {
+
+    }
+}

--- a/tests/test_function.sol
+++ b/tests/test_function.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.6.12;
 
 // solidity source used by tests/test_function.py.
-// tests/test_function.py tests that the functions
-// below get
+// tests/test_function.py tests that the functions below get translated into correct
+// `slither.core.declarations.Function` objects or its subclasses
+// and that these objects behave correctly.
 
 contract TestFunction {
     bool entered = false;
@@ -19,13 +20,13 @@ contract TestFunction {
         msg.sender.call{value: 1}("");
     }
 
-    function external_send(uint _a) external {
+    function external_send(uint8 _c) external {
         require(!entered);
         entered = true;
         msg.sender.call{value: 1}("");
     }
 
-    function _internal(uint _a) internal returns (uint) {
+    function internal_assembly(bytes calldata _d) internal returns (uint) {
         uint256 chain;
         assembly {
             chain := chainid()
@@ -35,5 +36,21 @@ contract TestFunction {
 
     fallback() external {
 
+    }
+
+    receive() external payable {
+
+    }
+
+    constructor() public payable {
+
+    }
+
+    function private_view() private view returns (bool) {
+        return entered;
+    }
+
+    function public_pure() public pure returns (bool) {
+        return true;
     }
 }


### PR DESCRIPTION
Given a function that can not send ether but can reenter:

```solidity
function reenter() public {
    msg.sender.call("");
}
```

```python
f = Slither(...).contracts...functions
assert f.can_reenter()
assert not f.can_send_eth()
```

The second assertion will fail.
Looks like a copy & paste error.

this PR fixes that and adds tests for regression as well as most of the codomain of many other properties and getters of `slither.core.declarations.Function`.

The tests revealed that for a function `f` with visibility `pure`, `f.view` will return `True`.
Is this correct?
