### PR TITLE
Fix multi-file --filter-paths bug

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -330,9 +330,9 @@ class SlitherCore(Context):  # pylint: disable=too-many-instance-attributes,too-
             for elem in r["elements"]
             if "source_mapping" in elem
         ]
-        source_mapping_elements = map(
+        source_mapping_elements = list(map(
             lambda x: os.path.normpath(x) if x else x, source_mapping_elements
-        )
+        ))
         matching = False
 
         for path in self._paths_to_filter:


### PR DESCRIPTION
It looks like multiple comma-separated file paths provided in the `--filter-paths` argument don't work since the `source_mapping_elements` mapping object get exhausted after the first iteration of the loop here https://github.com/crytic/slither/blob/705f8db526ace58fec9bfd9f025765d9bc4860a3/slither/core/slither_core.py#L342.

Suggesting a straightforward fix.