### PR TITLE
Add hardhat to the list of supported projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Slither is a Solidity static analysis framework written in Python 3. It runs a s
 
 ## Bugs and Optimizations Detection
 
-Run Slither on a Truffle/Embark/Dapp/Etherlime application:
+Run Slither on a Truffle/Embark/Dapp/Etherlime/Hardhat application:
 ```bash
 slither .
 ```


### PR DESCRIPTION
As far as I know, slither works fine in Hardhat projects, but since it's not indicated on the readme people often ask about it on our discord.