### PR TITLE
Remove COUNTER from class

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -90,6 +90,10 @@ class SlitherCore(Context):  # pylint: disable=too-many-instance-attributes,too-
 
         self._show_ignored_findings = False
 
+        self.counter_slithir_tuple = 0
+        self.counter_slithir_temporary = 0
+        self.counter_slithir_reference = 0
+
     ###################################################################################
     ###################################################################################
     # region Source code

--- a/slither/slithir/variables/reference.py
+++ b/slither/slithir/variables/reference.py
@@ -1,17 +1,19 @@
+from typing import TYPE_CHECKING
+
 from slither.core.children.child_node import ChildNode
 from slither.core.declarations import Contract, Enum, SolidityVariable, Function
 from slither.core.variables.variable import Variable
 
+if TYPE_CHECKING:
+    from slither.core.cfg.node import Node
 
 class ReferenceVariable(ChildNode, Variable):
 
-    COUNTER = 0
-
-    def __init__(self, node, index=None):
+    def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:
-            self._index = ReferenceVariable.COUNTER
-            ReferenceVariable.COUNTER += 1
+            self._index = node.slither.counter_slithir_reference
+            node.slither.counter_slithir_reference += 1
         else:
             self._index = index
         self._points_to = None

--- a/slither/slithir/variables/reference.py
+++ b/slither/slithir/variables/reference.py
@@ -7,8 +7,8 @@ from slither.core.variables.variable import Variable
 if TYPE_CHECKING:
     from slither.core.cfg.node import Node
 
-class ReferenceVariable(ChildNode, Variable):
 
+class ReferenceVariable(ChildNode, Variable):
     def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:

--- a/slither/slithir/variables/temporary.py
+++ b/slither/slithir/variables/temporary.py
@@ -1,16 +1,18 @@
+from typing import TYPE_CHECKING
+
 from slither.core.children.child_node import ChildNode
 from slither.core.variables.variable import Variable
 
+if TYPE_CHECKING:
+    from slither.core.cfg.node import Node
 
 class TemporaryVariable(ChildNode, Variable):
 
-    COUNTER = 0
-
-    def __init__(self, node, index=None):
+    def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:
-            self._index = TemporaryVariable.COUNTER
-            TemporaryVariable.COUNTER += 1
+            self._index = node.slither.counter_slithir_temporary
+            node.slither.counter_slithir_temporary += 1
         else:
             self._index = index
         self._node = node

--- a/slither/slithir/variables/temporary.py
+++ b/slither/slithir/variables/temporary.py
@@ -6,8 +6,8 @@ from slither.core.variables.variable import Variable
 if TYPE_CHECKING:
     from slither.core.cfg.node import Node
 
-class TemporaryVariable(ChildNode, Variable):
 
+class TemporaryVariable(ChildNode, Variable):
     def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:

--- a/slither/slithir/variables/tuple.py
+++ b/slither/slithir/variables/tuple.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
 
 
 class TupleVariable(ChildNode, SlithIRVariable):
-
     def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:

--- a/slither/slithir/variables/tuple.py
+++ b/slither/slithir/variables/tuple.py
@@ -1,16 +1,19 @@
+from typing import TYPE_CHECKING
+
 from slither.core.children.child_node import ChildNode
 from slither.slithir.variables.variable import SlithIRVariable
+
+if TYPE_CHECKING:
+    from slither.core.cfg.node import Node
 
 
 class TupleVariable(ChildNode, SlithIRVariable):
 
-    COUNTER = 0
-
-    def __init__(self, node, index=None):
+    def __init__(self, node: "Node", index=None):
         super().__init__()
         if index is None:
-            self._index = TupleVariable.COUNTER
-            TupleVariable.COUNTER += 1
+            self._index = node.slither.counter_slithir_tuple
+            node.slither.counter_slithir_tuple += 1
         else:
             self._index = index
 

--- a/tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol.0.5.8.UninitializedFunctionPtrsConstructor.json
+++ b/tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol.0.5.8.UninitializedFunctionPtrsConstructor.json
@@ -213,6 +213,114 @@
             "elements": [
                 {
                     "type": "contract",
+                    "name": "bad2",
+                    "source_mapping": {
+                        "start": 483,
+                        "length": 199,
+                        "filename_used": "/GENERIC_PATH",
+                        "filename_relative": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29
+                        ],
+                        "starting_column": 1,
+                        "ending_column": 2
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "s.a(10)",
+                    "source_mapping": {
+                        "start": 668,
+                        "length": 7,
+                        "filename_used": "/GENERIC_PATH",
+                        "filename_relative": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            27
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 12
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "constructor",
+                            "source_mapping": {
+                                "start": 625,
+                                "length": 55,
+                                "filename_used": "/GENERIC_PATH",
+                                "filename_relative": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    25,
+                                    26,
+                                    27,
+                                    28
+                                ],
+                                "starting_column": 3,
+                                "ending_column": 4
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "bad2",
+                                    "source_mapping": {
+                                        "start": 483,
+                                        "length": 199,
+                                        "filename_used": "/GENERIC_PATH",
+                                        "filename_relative": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            20,
+                                            21,
+                                            22,
+                                            23,
+                                            24,
+                                            25,
+                                            26,
+                                            27,
+                                            28,
+                                            29
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 2
+                                    }
+                                },
+                                "signature": "constructor()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "Contract bad2 (tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol#20-29) \n\t s.a(10) (tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol#27) is an unintialized function pointer call in a constructor\n",
+            "markdown": "Contract [bad2](tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol#L20-L29) \n\t [s.a(10)](tests/detectors/uninitialized-fptr-cst/uninitialized_function_ptr_constructor.sol#L27) is an unintialized function pointer call in a constructor\n",
+            "id": "1f43b676571aff0a3ce0353dc8548e252c588f7c9248c104637d500882880134",
+            "check": "uninitialized-fptr-cst",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "contract",
                     "name": "bad3",
                     "source_mapping": {
                         "start": 684,


### PR DESCRIPTION
The globally shared COUNTERs lead to generating different IRs if the same codebase was analyzed through different `Slither` objects, but within the same python env

Additionally this PR adds missing python types