### PR TITLE
Tightened the supported versions of solidity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Slither is a Solidity static analysis framework written in Python 3. It runs a s
 * Easily integrates into continuous integration and Truffle builds
 * Built-in 'printers' quickly report crucial contract information
 * Detector API to write custom analyses in Python
-* Ability to analyze contracts written with Solidity >= 0.4
+* Ability to analyze contracts written with Solidity `>= 0.4` and `< 0.7`
 * Intermediate representation ([SlithIR](https://github.com/trailofbits/slither/wiki/SlithIR)) enables simple, high-precision analyses
 * Correctly parses 99.9% of all public Solidity code
 * Average execution time of less than 1 second per contract


### PR DESCRIPTION
While using slither to analyze some contracts written with solidity `0.8` (see [here](https://github.com/clearmatics/zeth/tree/develop/zeth_contracts/contracts)), I got an error (i.e. `ERROR:root:unresolved reference to identifier vk.slot `) related to the `x.slot` syntax introduced in solidity 0.7 as a replacement of the syntax `x_slot` to retrieve the slot pointed to by the variable `x`.

See the difference between the [solidity 0.7 doc](https://docs.soliditylang.org/en/v0.7.0/assembly.html?highlight=mstore#access-to-external-variables-functions-and-libraries) and the [solidity 0.6 doc](https://docs.soliditylang.org/en/v0.6.0/assembly.html?highlight=mstore#access-to-external-variables-functions-and-libraries) for further details.

That is somewhat confusing, provided that the README states that contracts written with solidity >= 0.4 can be analyzed with the tool, however, I realized (beyond the error above) that the syntax for solidity 0.7 is not yet fully supported: https://github.com/crytic/slither/issues/559

As a consequence, this PR clarifies which solidity versions are currently supported, as a way to remove potential future issues for other users. 