### PR TITLE
[Draft] Allow to list modifiers that are being used to protect against reentrancy to avoid fake positive

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -11,7 +11,7 @@ import pstats
 from slither.detectors.reentrancy.reentrancy import Reentrancy
 import sys
 import traceback
-from typing import List, Optional
+from typing import Optional
 
 from pkg_resources import iter_entry_points, require
 

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -45,6 +45,7 @@ defaults_flag_in_config = {
     "zip": None,
     "zip_type": "lzma",
     "show_ignored_findings": False,
+    "guard_modifiers": "nonReentrant",
     **DEFAULTS_FLAG_IN_CONFIG_CRYTIC_COMPILE,
 }
 


### PR DESCRIPTION
Hi, 

Thinking about the fake positive when running the reentrancy detectors, I thought that an easy what would be to enable the users to list all the modifiers they use to avoid this exploit.

This is pretty straightforward and could be a way to work around until we can come with something smarter than can detect with modifiers that are actually protecting against reentrancy attacks.

Related to issues #683, #735 
