### PR TITLE
Relax is_protected heuristic

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1405,7 +1405,11 @@ class Function(metaclass=ABCMeta):  # pylint: disable=too-many-public-methods
         """
             Determine if the function is protected using a check on msg.sender
 
-            Only detects if msg.sender is directly used in a condition
+            Consider onlyOwner as a safe modifier.
+            If the owner functionality is incorrectly implemented, this will lead to incorrectly
+            classify the function as protected
+
+            Otherwise only detects if msg.sender is directly used in a condition
             For example, it wont work for:
                 address a = msg.sender
                 require(a == owner)
@@ -1415,6 +1419,9 @@ class Function(metaclass=ABCMeta):  # pylint: disable=too-many-public-methods
 
         if self._is_protected is None:
             if self.is_constructor:
+                self._is_protected = True
+                return True
+            if "onlyOwner" in [m.name for m in self.modifiers]:
                 self._is_protected = True
                 return True
             conditional_vars = self.all_conditional_solidity_variables_read(include_loop=False)


### PR DESCRIPTION
This PR makes `onlyOwner` to be considered as a safe modifier.

While I think we should avoid hardcoding behaviors based on function/modifier name, I have tried a couple of different heuristics to improve `is_protected`, based on #401 ideas, but in the end none is as effective as just using the modifier name. 

If `onlyOwner` is incorrectly implemented, this PR will make Slither incorrectly assume that the function is protected. 

Overall I think this is a tradeoff that we can follow: we have a couple of detectors that can catch incorrect `onlyOwner`, and if someone tries to add a backdoor, he will have other ways to fool Slither anyway. 

The benefits of using this approach (removing multiple FPs) outweigh the downsides I think.

Fix #401