### PR TITLE
add `region`s to enable folding support in editors

### DIFF
--- a/slither/detectors/assembly/shift_parameter_mixup.py
+++ b/slither/detectors/assembly/shift_parameter_mixup.py
@@ -17,6 +17,8 @@ class ShiftParameterMixup(AbstractDetector):
 
     WIKI_TITLE = "Incorrect shift in assembly."
     WIKI_DESCRIPTION = "Detect if the values in a shift operation are reversed"
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract C {
@@ -28,6 +30,7 @@ contract C {
 }
 ```
 The shift statement will right-shift the constant 8 by `a` bits"""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Swap the order of parameters."
 

--- a/slither/detectors/attributes/const_functions_asm.py
+++ b/slither/detectors/attributes/const_functions_asm.py
@@ -25,7 +25,7 @@ class ConstantFunctionsAsm(AbstractDetector):
 Functions declared as `constant`/`pure`/`view` using assembly code.
 
 `constant`/`pure`/`view` was not enforced prior to Solidity 0.5.
-Starting from Solidity 0.5, a call to a `caonstant`/`pure`/`view` function uses the `STATICCALL` opcode, which reverts in case of state modification.
+Starting from Solidity 0.5, a call to a `constant`/`pure`/`view` function uses the `STATICCALL` opcode, which reverts in case of state modification.
 
 As a result, a call to an [incorrectly labeled function may trap a contract compiled with Solidity 0.5](https://solidity.readthedocs.io/en/develop/050-breaking-changes.html#interoperability-with-older-contracts)."""
     # endregion wiki_description

--- a/slither/detectors/attributes/const_functions_asm.py
+++ b/slither/detectors/attributes/const_functions_asm.py
@@ -19,14 +19,18 @@ class ConstantFunctionsAsm(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#constant-functions-using-assembly-code"
 
     WIKI_TITLE = "Constant functions using assembly code"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Functions declared as `constant`/`pure`/`view` using assembly code.
 
 `constant`/`pure`/`view` was not enforced prior to Solidity 0.5.
-Starting from Solidity 0.5, a call to a `constant`/`pure`/`view` function uses the `STATICCALL` opcode, which reverts in case of state modification.
+Starting from Solidity 0.5, a call to a `caonstant`/`pure`/`view` function uses the `STATICCALL` opcode, which reverts in case of state modification.
 
 As a result, a call to an [incorrectly labeled function may trap a contract compiled with Solidity 0.5](https://solidity.readthedocs.io/en/develop/050-breaking-changes.html#interoperability-with-older-contracts)."""
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Constant{
@@ -39,6 +43,7 @@ contract Constant{
 ```
 `Constant` was deployed with Solidity 0.4.25. Bob writes a smart contract that interacts with `Constant` in Solidity 0.5.0. 
 All the calls to `get` revert, breaking Bob's smart contract execution."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Ensure the attributes of contracts compiled prior to Solidity 0.5.0 are correct."

--- a/slither/detectors/attributes/const_functions_state.py
+++ b/slither/detectors/attributes/const_functions_state.py
@@ -19,6 +19,8 @@ class ConstantFunctionsState(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#constant-functions-changing-the-state"
 
     WIKI_TITLE = "Constant functions changing the state"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Functions declared as `constant`/`pure`/`view` change the state.
 
@@ -26,7 +28,9 @@ Functions declared as `constant`/`pure`/`view` change the state.
 Starting from Solidity 0.5, a call to a `constant`/`pure`/`view` function uses the `STATICCALL` opcode, which reverts in case of state modification.
 
 As a result, a call to an [incorrectly labeled function may trap a contract compiled with Solidity 0.5](https://solidity.readthedocs.io/en/develop/050-breaking-changes.html#interoperability-with-older-contracts)."""
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Constant{
@@ -39,6 +43,7 @@ contract Constant{
 ```
 `Constant` was deployed with Solidity 0.4.25. Bob writes a smart contract that interacts with `Constant` in Solidity 0.5.0. 
 All the calls to `get` revert, breaking Bob's smart contract execution."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Ensure that attributes of contracts compiled prior to Solidity 0.5.0 are correct."

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -30,9 +30,14 @@ class IncorrectSolc(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-versions-of-solidity"
 
     WIKI_TITLE = "Incorrect versions of Solidity"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 `solc` frequently releases new compiler versions. Using an old version prevents access to new Solidity security checks.
 We also recommend avoiding complex `pragma` statement."""
+    # endregion wiki_description
+
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Deploy with any of the following Solidity versions:
 - 0.5.16 - 0.5.17
@@ -40,6 +45,7 @@ Deploy with any of the following Solidity versions:
 - 0.7.5 - 0.7.6
 Use a simple pragma version that allows any of these versions.
 Consider using the latest version of Solidity for testing."""
+    # endregion wiki_recommendation
 
     COMPLEX_PRAGMA_TXT = "is too complex"
     OLD_VERSION_TXT = "allows old versions"

--- a/slither/detectors/attributes/locked_ether.py
+++ b/slither/detectors/attributes/locked_ether.py
@@ -25,6 +25,8 @@ class LockedEther(AbstractDetector):  # pylint: disable=too-many-nested-blocks
 
     WIKI_TITLE = "Contracts that lock Ether"
     WIKI_DESCRIPTION = "Contract with a `payable` function, but without a withdrawal capacity."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 pragma solidity 0.4.24;
@@ -34,6 +36,7 @@ contract Locked{
 }
 ```
 Every Ether sent to `Locked` will be lost."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove the payable attribute or add a withdraw function."
 

--- a/slither/detectors/attributes/unimplemented_interface.py
+++ b/slither/detectors/attributes/unimplemented_interface.py
@@ -21,6 +21,8 @@ class MissingInheritance(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#missing-inheritance"
     WIKI_TITLE = "Missing inheritance"
     WIKI_DESCRIPTION = "Detect missing inheritance."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 interface ISomething {
@@ -35,6 +37,7 @@ contract Something {
 ```
 `Something` should inherit from `ISomething`. 
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Inherit from the missing interface or contract."
 

--- a/slither/detectors/compiler_bugs/array_by_reference.py
+++ b/slither/detectors/compiler_bugs/array_by_reference.py
@@ -26,6 +26,8 @@ class ArrayByReference(AbstractDetector):
     WIKI_DESCRIPTION = (
         "Detect arrays passed to a function that expects reference to a storage array"
     )
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Memory {
@@ -48,6 +50,7 @@ contract Memory {
 
 Bob calls `f()`. Bob assumes that at the end of the call `x[0]` is 2, but it is 1.
 As a result, Bob's usage of the contract is incorrect."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Ensure the correct usage of `memory` and `storage` in the function parameters. Make all the locations explicit."
 

--- a/slither/detectors/compiler_bugs/enum_conversion.py
+++ b/slither/detectors/compiler_bugs/enum_conversion.py
@@ -48,6 +48,8 @@ class EnumConversion(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#dangerous-enum-conversion"
     WIKI_TITLE = "Dangerous enum conversion"
     WIKI_DESCRIPTION = "Detect out-of-range `enum` conversion (`solc` < `0.4.5`)."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     pragma solidity 0.4.2;
@@ -61,6 +63,7 @@ class EnumConversion(AbstractDetector):
 }
 ```
 Attackers can trigger unexpected behaviour by calling `bug(1)`."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Use a recent compiler version. If `solc` <`0.4.5` is required, check the `enum` conversion range."
 

--- a/slither/detectors/compiler_bugs/multiple_constructor_schemes.py
+++ b/slither/detectors/compiler_bugs/multiple_constructor_schemes.py
@@ -20,6 +20,8 @@ class MultipleConstructorSchemes(AbstractDetector):
     WIKI_DESCRIPTION = (
         "Detect multiple constructor definitions in the same contract (using new and old schemes)."
     )
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -37,6 +39,7 @@ contract A {
 }
 ```
 In Solidity [0.4.22](https://github.com/ethereum/solidity/releases/tag/v0.4.23), a contract with both constructor schemes will compile. The first constructor will take precedence over the second, which may be unintended."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Only declare one constructor, preferably using the new scheme `constructor(...)` instead of `function <contractName>(...)`."
 

--- a/slither/detectors/compiler_bugs/reused_base_constructor.py
+++ b/slither/detectors/compiler_bugs/reused_base_constructor.py
@@ -34,6 +34,8 @@ class ReusedBaseConstructor(AbstractDetector):
 
     WIKI_TITLE = "Reused base constructors"
     WIKI_DESCRIPTION = "Detects if the same base constructor is called with arguments from two different locations in the same inheritance hierarchy."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 pragma solidity ^0.4.0;
@@ -65,6 +67,8 @@ The constructor of `A` is called multiple times in `D` and `E`:
 - `D` inherits from `B` and `C`, both of which construct `A`.
 - `E` only inherits from `B`, but `B` and `E` construct `A`.
 ."""
+    # endregion wiki_exploit_scenario
+
     WIKI_RECOMMENDATION = "Remove the duplicate constructor call."
 
     def _detect_explicitly_called_base_constructors(self, contract):

--- a/slither/detectors/compiler_bugs/storage_ABIEncoderV2_array.py
+++ b/slither/detectors/compiler_bugs/storage_ABIEncoderV2_array.py
@@ -62,6 +62,8 @@ class ABIEncoderV2Array(AbstractDetector):
     )
     WIKI_TITLE = "Storage ABIEncoderV2 Array"
     WIKI_DESCRIPTION = """`solc` versions `0.4.7`-`0.5.10` contain a [compiler bug](https://blog.ethereum.org/2019/06/25/solidity-storage-array-bugs.) leading to incorrect ABI encoder usage."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -75,6 +77,8 @@ contract A {
 ```
 `abi.encode(bad_arr)` in a call to `bad()` will incorrectly encode the array as `[[1, 2], [2, 3], [3, 4]]` and lead to unintended behavior.
 """
+    # endregion wiki_exploit_scenario
+
     WIKI_RECOMMENDATION = "Use a compiler >= `0.5.10`."
 
     @staticmethod

--- a/slither/detectors/compiler_bugs/storage_signed_integer_array.py
+++ b/slither/detectors/compiler_bugs/storage_signed_integer_array.py
@@ -59,8 +59,13 @@ class StorageSignedIntegerArray(AbstractDetector):
         "https://github.com/crytic/slither/wiki/Detector-Documentation#storage-signed-integer-array"
     )
     WIKI_TITLE = "Storage Signed Integer Array"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """`solc` versions `0.4.7`-`0.5.10` contain [a compiler bug](https://blog.ethereum.org/2019/06/25/solidity-storage-array-bugs)
 leading to incorrect values in signed integer arrays."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -75,6 +80,8 @@ contract A {
 `bad0()` uses a (storage-allocated) signed integer array state variable to store the ether balances of three accounts.  
 `-1` is supposed to indicate uninitialized values but the Solidity bug makes these as `1`, which could be exploited by the accounts.
 """
+    # endregion wiki_exploit_scenario
+
     WIKI_RECOMMENDATION = "Use a compiler version >= `0.5.10`."
 
     @staticmethod

--- a/slither/detectors/compiler_bugs/uninitialized_function_ptr_in_constructor.py
+++ b/slither/detectors/compiler_bugs/uninitialized_function_ptr_in_constructor.py
@@ -89,6 +89,8 @@ class UninitializedFunctionPtrsConstructor(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#uninitialized-function-pointers-in-constructors"
     WIKI_TITLE = "Uninitialized function pointers in constructors"
     WIKI_DESCRIPTION = "solc versions `0.4.5`-`0.4.26` and `0.5.0`-`0.5.8` contain a compiler bug leading to unexpected behavior when calling uninitialized function pointers in constructors."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract bad0 {
@@ -102,6 +104,8 @@ contract bad0 {
 }
 ```
 The call to `a(10)` will lead to unexpected behavior because function pointer `a` is not initialized in the constructor."""
+    # endregion wiki_exploit_scenario
+
     WIKI_RECOMMENDATION = (
         "Initialize function pointers before calling. Avoid function pointers if possible."
     )

--- a/slither/detectors/erc/incorrect_erc20_interface.py
+++ b/slither/detectors/erc/incorrect_erc20_interface.py
@@ -19,6 +19,8 @@ class IncorrectERC20InterfaceDetection(AbstractDetector):
 
     WIKI_TITLE = "Incorrect erc20 interface"
     WIKI_DESCRIPTION = "Incorrect return values for `ERC20` functions. A contract compiled with Solidity > 0.4.22 interacting with these functions will fail to execute them, as the return value is missing."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Token{
@@ -27,6 +29,7 @@ contract Token{
 }
 ```
 `Token.transfer` does not return a boolean. Bob deploys the token. Alice creates a contract that interacts with it but assumes a correct `ERC20` interface implementation. Alice's contract is unable to interact with Bob's contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Set the appropriate return values and types for the defined `ERC20` functions."

--- a/slither/detectors/erc/incorrect_erc721_interface.py
+++ b/slither/detectors/erc/incorrect_erc721_interface.py
@@ -20,6 +20,8 @@ class IncorrectERC721InterfaceDetection(AbstractDetector):
 
     WIKI_TITLE = "Incorrect erc721 interface"
     WIKI_DESCRIPTION = "Incorrect return values for `ERC721` functions. A contract compiled with solidity > 0.4.22 interacting with these functions will fail to execute them, as the return value is missing."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Token{
@@ -28,6 +30,7 @@ contract Token{
 }
 ```
 `Token.ownerOf` does not return an address like `ERC721` expects. Bob deploys the token. Alice creates a contract that interacts with it but assumes a correct `ERC721` interface implementation. Alice's contract is unable to interact with Bob's contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Set the appropriate return values and vtypes for the defined `ERC721` functions."

--- a/slither/detectors/erc/unindexed_event_parameters.py
+++ b/slither/detectors/erc/unindexed_event_parameters.py
@@ -18,6 +18,8 @@ class UnindexedERC20EventParameters(AbstractDetector):
 
     WIKI_TITLE = "Unindexed ERC20 event oarameters"
     WIKI_DESCRIPTION = "Detects whether events defined by the `ERC20` specification that should have some parameters as `indexed` are missing the `indexed` keyword."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract ERC20Bad {
@@ -30,6 +32,7 @@ contract ERC20Bad {
 ```
 `Transfer` and `Approval` events should have the 'indexed' keyword on their two first parameters, as defined by the `ERC20` specification.
 Failure to include these keywords will exclude the parameter data in the transaction/block's bloom filter, so external tooling searching for these parameters may overlook them and fail to index logs from this token contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Add the `indexed` keyword to event parameters that should include it, according to the `ERC20` specification."
 

--- a/slither/detectors/functions/arbitrary_send.py
+++ b/slither/detectors/functions/arbitrary_send.py
@@ -94,6 +94,8 @@ class ArbitrarySend(AbstractDetector):
 
     WIKI_TITLE = "Functions that send Ether to arbitrary destinations"
     WIKI_DESCRIPTION = "Unprotected call to a function sending Ether to an arbitrary address."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract ArbitrarySend{
@@ -108,6 +110,7 @@ contract ArbitrarySend{
 }
 ```
 Bob calls `setDestination` and `withdraw`. As a result he withdraws the contract's balance."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Ensure that an arbitrary user cannot withdraw unauthorized funds."
 

--- a/slither/detectors/functions/dead_code.py
+++ b/slither/detectors/functions/dead_code.py
@@ -21,6 +21,8 @@ class DeadCode(AbstractDetector):
 
     WIKI_TITLE = "Dead-code"
     WIKI_DESCRIPTION = "Functions that are not sued."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -28,6 +30,7 @@ contract Contract{
 }
 ```
 `dead_code` is not used in the contract, and make the code's review more difficult."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove unused functions."
 

--- a/slither/detectors/functions/modifier.py
+++ b/slither/detectors/functions/modifier.py
@@ -42,6 +42,8 @@ class ModifierDefaultDetection(AbstractDetector):
 
     WIKI_TITLE = "Incorrect modifier"
     WIKI_DESCRIPTION = "If a modifier does not execute `_` or revert, the execution of the function will return the default value, which can be misleading for the caller."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     modidfier myModif(){
@@ -54,6 +56,7 @@ class ModifierDefaultDetection(AbstractDetector):
     }
 ```
 If the condition in `myModif` is false, the execution of `get()` will return 0."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "All the paths in a modifier must execute `_` or revert."
 

--- a/slither/detectors/functions/suicidal.py
+++ b/slither/detectors/functions/suicidal.py
@@ -21,6 +21,8 @@ class Suicidal(AbstractDetector):
 
     WIKI_TITLE = "Suicidal"
     WIKI_DESCRIPTION = "Unprotected call to a function executing `selfdestruct`/`suicide`."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Suicidal{
@@ -30,6 +32,7 @@ contract Suicidal{
 }
 ```
 Bob calls `kill` and destructs the contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Protect access to all sensitive functions."
 

--- a/slither/detectors/functions/unimplemented.py
+++ b/slither/detectors/functions/unimplemented.py
@@ -28,6 +28,8 @@ class UnimplementedFunctionDetection(AbstractDetector):
 
     WIKI_TITLE = "Unimplemented functions"
     WIKI_DESCRIPTION = "Detect functions that are not implemented on derived-most contracts."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 interface BaseInterface {
@@ -48,6 +50,7 @@ contract DerivedContract is BaseInterface, BaseInterface2 {
 `DerivedContract` does not implement `BaseInterface.f2` or `BaseInterface2.f3`.
 As a result, the contract will not properly compile. 
 All unimplemented functions must be implemented on a contract that is meant to be used."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Implement all unimplemented functions in any contract you intend to use directly (not simply inherit from)."
 

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -22,11 +22,14 @@ class NamingConvention(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#conformance-to-solidity-naming-conventions"
 
     WIKI_TITLE = "Conformance to Solidity naming conventions"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Solidity defines a [naming convention](https://solidity.readthedocs.io/en/v0.4.25/style-guide.html#naming-conventions) that should be followed.
 #### Rule exceptions
 - Allow constant variable name/symbol/decimals to be lowercase (`ERC20`).
 - Allow `_` at the beginning of the `mixed_case` match for private variables and unused parameters."""
+    # endregion wiki_description
 
     WIKI_RECOMMENDATION = "Follow the Solidity [naming convention](https://solidity.readthedocs.io/en/v0.4.25/style-guide.html#naming-conventions)."
 

--- a/slither/detectors/operations/bad_prng.py
+++ b/slither/detectors/operations/bad_prng.py
@@ -89,6 +89,8 @@ class BadPRNG(AbstractDetector):
 
     WIKI_TITLE = "Weak PRNG"
     WIKI_DESCRIPTION = "Weak PRNG due to a modulo on `block.timestamp`, `now` or `blockhash`. These can be influenced by miners to some extent so they should be avoided."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Game {
@@ -102,6 +104,7 @@ contract Game {
 ```
 Eve is a miner. Eve calls `guessing` and re-orders the block containing the transaction. 
 As a result, Eve wins the game."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Do not use `block.timestamp`, `now` or `blockhash` as a source of randomness"

--- a/slither/detectors/operations/missing_events_access_control.py
+++ b/slither/detectors/operations/missing_events_access_control.py
@@ -22,6 +22,8 @@ class MissingEventsAccessControl(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#missing-events-access-control"
     WIKI_TITLE = "Missing events access control"
     WIKI_DESCRIPTION = "Detect missing events for critical access control parameters"
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract C {
@@ -38,6 +40,7 @@ contract C {
 ```
 `updateOwner()` has no event, so it is difficult to track off-chain owner changes.
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Emit an event for critical parameter changes."
 

--- a/slither/detectors/operations/missing_events_arithmetic.py
+++ b/slither/detectors/operations/missing_events_arithmetic.py
@@ -22,6 +22,8 @@ class MissingEventsArithmetic(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#missing-events-arithmetic"
     WIKI_TITLE = "Missing events arithmetic"
     WIKI_DESCRIPTION = "Detect missing events for critical arithmetic parameters."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract C {
@@ -42,6 +44,7 @@ contract C {
 ```
 `updateOwner()` has no event, so it is difficult to track off-chain changes in the buy price. 
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Emit an event for critical parameter changes."
 

--- a/slither/detectors/operations/missing_zero_address_validation.py
+++ b/slither/detectors/operations/missing_zero_address_validation.py
@@ -24,6 +24,8 @@ class MissingZeroAddressValidation(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#missing-zero-address-validation"
     WIKI_TITLE = "Missing zero address validation"
     WIKI_DESCRIPTION = "Detect missing zero address validation."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract C {
@@ -40,6 +42,7 @@ contract C {
 ```
 Bob calls `updateOwner` without specifying the `newOwner`, soBob loses ownership of the contract.
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Check that the address is not zero."
 

--- a/slither/detectors/operations/unchecked_low_level_return_values.py
+++ b/slither/detectors/operations/unchecked_low_level_return_values.py
@@ -20,6 +20,8 @@ class UncheckedLowLevel(UnusedReturnValues):
 
     WIKI_TITLE = "Unchecked low-level calls"
     WIKI_DESCRIPTION = "The return value of a low-level call is not checked."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract MyConc{
@@ -31,6 +33,7 @@ contract MyConc{
 The return value of the low-level call is not checked, so if the call fails, the Ether will be locked in the contract.
 If the low level is used to prevent blocking operations, consider logging failed calls.
     """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Ensure that the return value of a low-level call is checked or logged."
 

--- a/slither/detectors/operations/unchecked_send_return_value.py
+++ b/slither/detectors/operations/unchecked_send_return_value.py
@@ -21,6 +21,8 @@ class UncheckedSend(UnusedReturnValues):
 
     WIKI_TITLE = "Unchecked Send"
     WIKI_DESCRIPTION = "The return value of a `send` is not checked."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract MyConc{
@@ -32,6 +34,7 @@ contract MyConc{
 The return value of `send` is not checked, so if the send fails, the Ether will be locked in the contract.
 If `send` is used to prevent blocking operations, consider logging the failed `send`.
     """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Ensure that the return value of `send` is checked or logged."
 

--- a/slither/detectors/operations/unchecked_transfer.py
+++ b/slither/detectors/operations/unchecked_transfer.py
@@ -22,6 +22,8 @@ class UncheckedTransfer(UnusedReturnValues):
 
     WIKI_TITLE = "Unchecked transfer"
     WIKI_DESCRIPTION = "The return value of an external transfer/transferFrom call is not checked"
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Token {
@@ -37,6 +39,7 @@ contract MyBank{
 }
 ```
 Several tokens do not revert in case of failure and return false. If one of these tokens is used in `MyBank`, `deposit` will not revert if the transfer fails, and an attacker can call `deposit` for free.."""
+    # endregion wiki_exploit_scenariox
 
     WIKI_RECOMMENDATION = (
         "Use `SafeERC20`, or ensure that the transfer/transferFrom return value is checked."

--- a/slither/detectors/operations/unused_return_values.py
+++ b/slither/detectors/operations/unused_return_values.py
@@ -24,6 +24,8 @@ class UnusedReturnValues(AbstractDetector):
     WIKI_DESCRIPTION = (
         "The return value of an external call is not stored in a local or state variable."
     )
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract MyConc{
@@ -34,6 +36,7 @@ contract MyConc{
 }
 ```
 `MyConc` calls `add` of `SafeMath`, but does not store the result in `a`. As a result, the computation has no effect."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Ensure that all the return values of the function calls are used."
 

--- a/slither/detectors/operations/void_constructor.py
+++ b/slither/detectors/operations/void_constructor.py
@@ -14,6 +14,8 @@ class VoidConstructor(AbstractDetector):
     WIKI_TITLE = "Void constructor"
     WIKI_DESCRIPTION = "Detect the call to a constructor that is not implemented"
     WIKI_RECOMMENDATION = "Remove the constructor call."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A{}
@@ -22,6 +24,7 @@ contract B is A{
 }
 ```
 When reading `B`'s constructor definition, we might assume that `A()` initiates the contract, but no code is executed."""
+    # endregion wiki_exploit_scenario
 
     def _detect(self):
         """"""

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -25,9 +25,14 @@ class ReentrancyBenign(Reentrancy):
     )
 
     WIKI_TITLE = "Reentrancy vulnerabilities"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detection of the [reentrancy bug](https://github.com/trailofbits/not-so-smart-contracts/tree/master/reentrancy).
 Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentrancy-no-eth`)."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function callme(){
@@ -39,6 +44,7 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
 ```
 
 `callme` contains a reentrancy. The reentrancy is benign because it's exploitation would have the same effect as two consecutive calls."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Apply the [`check-effects-interactions` pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy)."
 

--- a/slither/detectors/reentrancy/reentrancy_eth.py
+++ b/slither/detectors/reentrancy/reentrancy_eth.py
@@ -25,9 +25,14 @@ class ReentrancyEth(Reentrancy):
     )
 
     WIKI_TITLE = "Reentrancy vulnerabilities"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detection of the [reentrancy bug](https://github.com/trailofbits/not-so-smart-contracts/tree/master/reentrancy).
 Do not report reentrancies that don't involve Ether (see `reentrancy-no-eth`)"""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function withdrawBalance(){
@@ -41,6 +46,7 @@ Do not report reentrancies that don't involve Ether (see `reentrancy-no-eth`)"""
 ```
 
 Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw more than its initial deposit to the contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Apply the [`check-effects-interactions pattern`](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy)."
 

--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -24,9 +24,14 @@ class ReentrancyEvent(Reentrancy):
     )
 
     WIKI_TITLE = "Reentrancy vulnerabilities"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detection of the [reentrancy bug](https://github.com/trailofbits/not-so-smart-contracts/tree/master/reentrancy).
 Only report reentrancies leading to out-of-order events."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function bug(Called d){
@@ -37,6 +42,7 @@ Only report reentrancies leading to out-of-order events."""
 ```
 
 If `d.()` re-enters, the `Counter` events will be shown in an incorrect order, which might lead to issues for third parties."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Apply the [`check-effects-interactions` pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy)."
 

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -28,9 +28,14 @@ class ReentrancyNoGas(Reentrancy):
     )
 
     WIKI_TITLE = "Reentrancy vulnerabilities"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detection of the [reentrancy bug](https://github.com/trailofbits/not-so-smart-contracts/tree/master/reentrancy).
 Only report reentrancy that is based on `transfer` or `send`."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function callme(){
@@ -40,6 +45,7 @@ Only report reentrancy that is based on `transfer` or `send`."""
 ```
 
 `send` and `transfer` do not protect from reentrancies in case of gas price changes."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Apply the [`check-effects-interactions` pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy)."
 

--- a/slither/detectors/reentrancy/reentrancy_read_before_write.py
+++ b/slither/detectors/reentrancy/reentrancy_read_before_write.py
@@ -24,10 +24,14 @@ class ReentrancyReadBeforeWritten(Reentrancy):
     )
 
     WIKI_TITLE = "Reentrancy vulnerabilities"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detection of the [reentrancy bug](https://github.com/trailofbits/not-so-smart-contracts/tree/master/reentrancy).
 Do not report reentrancies that involve Ether (see `reentrancy-eth`)."""
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function bug(){
@@ -39,6 +43,8 @@ Do not report reentrancies that involve Ether (see `reentrancy-eth`)."""
     }   
 ```
 """
+    # endregion wiki_exploit_scenario
+
     WIKI_RECOMMENDATION = "Apply the [`check-effects-interactions` pattern](http://solidity.readthedocs.io/en/v0.4.21/security-considerations.html#re-entrancy)."
 
     STANDARD_JSON = False

--- a/slither/detectors/reentrancy/token.py
+++ b/slither/detectors/reentrancy/token.py
@@ -46,9 +46,14 @@ class TokenReentrancy(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#token-reentrant"
 
     WIKI_TITLE = "Token reentrant"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
     Tokens that allow arbitrary external call on transfer/transfer (such as ERC223/ERC777) can be exploited on third
     party through a reentrancy."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
     ```solidity
 contract MyToken{
@@ -70,9 +75,12 @@ contract MyDefi{
 
     `MyDefi` has a reentrancy, but its developers did not think transferFrom could be reentrancy.
     `MyToken` is used in MyDefi. As a result an attacker can exploit the reentrancy."""
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """Avoid to have external calls in `transfer`/`transferFrom`.
 If you do, ensure your users are aware of the potential issues."""
+    # endregion wiki_recommendation
 
     def _detect(self):
         results = []

--- a/slither/detectors/shadowing/abstract.py
+++ b/slither/detectors/shadowing/abstract.py
@@ -34,6 +34,8 @@ class ShadowingAbstractDetection(AbstractDetector):
 
     WIKI_TITLE = "State variable shadowing from abstract contracts"
     WIKI_DESCRIPTION = "Detection of state variables shadowed from abstract contracts."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract BaseContract{
@@ -45,7 +47,8 @@ contract DerivedContract is BaseContract{
 }
 ```
 `owner` of `BaseContract` is shadowed in `DerivedContract`."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Remove the state variable shadowing."
 
     def _detect(self):

--- a/slither/detectors/shadowing/builtin_symbols.py
+++ b/slither/detectors/shadowing/builtin_symbols.py
@@ -19,6 +19,8 @@ class BuiltinSymbolShadowing(AbstractDetector):
 
     WIKI_TITLE = "Builtin Symbol Shadowing"
     WIKI_DESCRIPTION = "Detection of shadowing built-in symbols using local variables, state variables, functions, modifiers, or events."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 pragma solidity ^0.4.24;
@@ -36,7 +38,8 @@ contract Bug {
 }
 ```
 `now` is defined as a state variable, and shadows with the built-in symbol `now`. The function `assert` overshadows the built-in `assert` function. Any use of either of these built-in symbols may lead to unexpected results."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Rename the local variables, state variables, functions, modifiers, and events that shadow a builtin symbol."
 
     SHADOWING_FUNCTION = "function"

--- a/slither/detectors/shadowing/local.py
+++ b/slither/detectors/shadowing/local.py
@@ -19,6 +19,8 @@ class LocalShadowing(AbstractDetector):
 
     WIKI_TITLE = "Local variable shadowing"
     WIKI_DESCRIPTION = "Detection of shadowing using local variables."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 pragma solidity ^0.4.24;
@@ -39,7 +41,8 @@ contract Bug {
 }
 ```
 `sensitive_function.owner` shadows `Bug.owner`. As a result, the use of `owner` in `sensitive_function` might be incorrect."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Rename the local variables that shadow another component."
 
     OVERSHADOWED_FUNCTION = "function"

--- a/slither/detectors/shadowing/state.py
+++ b/slither/detectors/shadowing/state.py
@@ -33,6 +33,8 @@ class StateShadowing(AbstractDetector):
 
     WIKI_TITLE = "State variable shadowing"
     WIKI_DESCRIPTION = "Detection of state variables shadowed."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract BaseContract{
@@ -58,6 +60,7 @@ contract DerivedContract is BaseContract{
 }
 ```
 `owner` of `BaseContract` is never assigned and the modifier `isOwner` does not work."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove the state variable shadowing."
 

--- a/slither/detectors/slither/name_reused.py
+++ b/slither/detectors/slither/name_reused.py
@@ -34,13 +34,20 @@ class NameReused(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#name-reused"
 
     WIKI_TITLE = "Name reused"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """If a codebase has two contracts the similar names, the compilation artifacts
 will not contain one of the contracts with the duplicate name."""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 Bob's `truffle` codebase has two contracts named `ERC20`.
 When `truffle compile` runs, only one of the two contracts will generate artifacts in `build/contracts`.
 As a result, the second contract cannot be analyzed.
 """
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Rename the contract."
 
     def _detect(self):  # pylint: disable=too-many-locals,too-many-branches

--- a/slither/detectors/source/rtlo.py
+++ b/slither/detectors/source/rtlo.py
@@ -15,6 +15,8 @@ class RightToLeftOverride(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#right-to-left-override-character"
     WIKI_TITLE = "Right-to-Left-Override character"
     WIKI_DESCRIPTION = "An attacker can manipulate the logic of the contract by using a right-to-left-override character (`U+202E)`."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Token
@@ -43,6 +45,8 @@ contract Token
 `Token` uses the right-to-left-override character when calling `_withdraw`. As a result, the fee is incorrectly sent to `msg.sender`, and the token balance is sent to the owner.
 
 """
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Special control characters must not be allowed."
 
     RTLO_CHARACTER_ENCODED = "\u202e".encode("utf-8")

--- a/slither/detectors/statements/array_length_assignment.py
+++ b/slither/detectors/statements/array_length_assignment.py
@@ -72,6 +72,8 @@ class ArrayLengthAssignment(AbstractDetector):
 
     WIKI_TITLE = "Array Length Assignment"
     WIKI_DESCRIPTION = """Detects the direct assignment of an array's length."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -94,9 +96,12 @@ Contract storage/state-variables are indexed by a 256-bit integer.
 The user can set the array length to `2**256-1` in order to index all storage slots. 
 In the example above, one could call the function `f` to set the array length, then call the function `g` to control any storage slot desired. 
 Note that storage slots here are indexed via a hash of the indexers; nonetheless, all storage will still be accessible and could be controlled by the attacker."""
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """Do not allow array lengths to be set directly set; instead, opt to add values as needed.
 Otherwise, thoroughly review the contract to ensure a user-controlled variable cannot reach an array length assignment."""
+    # endregion wiki_recommendation
 
     def _detect(self):
         """

--- a/slither/detectors/statements/assert_state_change.py
+++ b/slither/detectors/statements/assert_state_change.py
@@ -50,6 +50,8 @@ class AssertStateChange(AbstractDetector):
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#assert-state-change"
     WIKI_TITLE = "Assert state shange"
     WIKI_DESCRIPTION = """Incorrect use of `assert()`. See Solidity best [practices](https://solidity.readthedocs.io/en/latest/control-structures.html#id4)."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -63,6 +65,8 @@ contract A {
 ```
 The assert in `bad()` increments the state variable `s_a` while checking for the condition.
 """
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = """Use `require` for invariants modifying the state."""
 
     def _detect(self):

--- a/slither/detectors/statements/boolean_constant_equality.py
+++ b/slither/detectors/statements/boolean_constant_equality.py
@@ -24,6 +24,8 @@ class BooleanEquality(AbstractDetector):
 
     WIKI_TITLE = "Boolean equality"
     WIKI_DESCRIPTION = """Detects the comparison to boolean constants."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -37,6 +39,7 @@ contract A {
 }
 ```
 Boolean constants can be used directly and do not need to be compare to `true` or `false`."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = """Remove the equality to the boolean constant."""
 

--- a/slither/detectors/statements/boolean_constant_misuse.py
+++ b/slither/detectors/statements/boolean_constant_misuse.py
@@ -32,6 +32,8 @@ class BooleanConstantMisuse(AbstractDetector):
 
     WIKI_TITLE = "Misuse of a Boolean constant"
     WIKI_DESCRIPTION = """Detects the misuse of a Boolean constant."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -52,7 +54,8 @@ contract A {
 ```
 Boolean constants in code have only a few legitimate uses. 
 Other uses (in complex expressions, as conditionals) indicate either an error or, most likely, the persistence of faulty code."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = """Verify and simplify the condition."""
 
     @staticmethod

--- a/slither/detectors/statements/calls_in_loop.py
+++ b/slither/detectors/statements/calls_in_loop.py
@@ -20,6 +20,8 @@ class MultipleCallsInLoop(AbstractDetector):
 
     WIKI_TITLE = "Calls inside a loop"
     WIKI_DESCRIPTION = "Calls inside a loop might lead to a denial-of-service attack."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract CallsInLoop{
@@ -39,7 +41,8 @@ contract CallsInLoop{
 }
 ```
 If one of the destinations has a fallback function that reverts, `bad` will always revert."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Favor [pull over push](https://github.com/ethereum/wiki/wiki/Safety#favor-pull-over-push-for-external-calls) strategy for external calls."
 
     @staticmethod

--- a/slither/detectors/statements/controlled_delegatecall.py
+++ b/slither/detectors/statements/controlled_delegatecall.py
@@ -27,6 +27,8 @@ class ControlledDelegateCall(AbstractDetector):
 
     WIKI_TITLE = "Controlled Delegatecall"
     WIKI_DESCRIPTION = "`Delegatecall` or `callcode` to an address controlled by the user."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Delegatecall{
@@ -36,7 +38,8 @@ contract Delegatecall{
 }
 ```
 Bob calls `delegate` and delegates the execution to his malicious contract. As a result, Bob withdraws the funds of the contract and destructs it."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Avoid using `delegatecall`. Use only trusted destinations."
 
     def _detect(self):

--- a/slither/detectors/statements/costly_operations_in_loop.py
+++ b/slither/detectors/statements/costly_operations_in_loop.py
@@ -20,6 +20,8 @@ class CostlyOperationsInLoop(AbstractDetector):
     WIKI_DESCRIPTION = (
         "Costly operations inside a loop might waste gas, so optimizations are justified."
     )
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract CostlyOperationsInLoop{
@@ -43,7 +45,8 @@ contract CostlyOperationsInLoop{
 }
 ```
 Incrementing `state_variable` in a loop incurs a lot of gas because of expensive `SSTOREs`, which might lead to an `out-of-gas`."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Use a local variable to hold the loop computation result."
 
     @staticmethod

--- a/slither/detectors/statements/deprecated_calls.py
+++ b/slither/detectors/statements/deprecated_calls.py
@@ -27,6 +27,8 @@ class DeprecatedStandards(AbstractDetector):
 
     WIKI_TITLE = "Deprecated standards"
     WIKI_DESCRIPTION = "Detect the usage of deprecated standards."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract ContractWithDeprecatedReferences {
@@ -55,6 +57,7 @@ contract ContractWithDeprecatedReferences {
     }
 }
 ```"""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Replace all uses of deprecated symbols."
 

--- a/slither/detectors/statements/divide_before_multiply.py
+++ b/slither/detectors/statements/divide_before_multiply.py
@@ -153,6 +153,8 @@ class DivideBeforeMultiply(AbstractDetector):
 
     WIKI_TITLE = "Divide before multiply"
     WIKI_DESCRIPTION = """Solidity integer division might truncate. As a result, performing multiplication before division can sometimes avoid loss of precision."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -164,6 +166,7 @@ contract A {
 If `n` is greater than `oldSupply`, `coins` will be zero. For example, with `oldSupply = 5; n = 10, interest = 2`, coins will be zero.  
 If `(oldSupply * interest / n)` was used, `coins` would have been `1`.   
 In general, it's usually a good idea to re-arrange arithmetic to perform multiplication before division, unless the limit of a smaller type makes this dangerous."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = """Consider ordering multiplication before division."""
 

--- a/slither/detectors/statements/incorrect_strict_equality.py
+++ b/slither/detectors/statements/incorrect_strict_equality.py
@@ -35,6 +35,8 @@ class IncorrectStrictEquality(AbstractDetector):
 
     WIKI_TITLE = "Dangerous strict equalities"
     WIKI_DESCRIPTION = "Use of strict equalities that can be easily manipulated by an attacker."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Crowdsale{
@@ -44,7 +46,8 @@ contract Crowdsale{
 ```
 `Crowdsale` relies on `fund_reached` to know when to stop the sale of tokens.
 `Crowdsale` reaches 100 Ether. Bob sends 0.1 Ether. As a result, `fund_reached` is always false and the `crowdsale` never ends."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = (
         """Don't use strict equality to determine if an account has enough Ether or tokens."""
     )

--- a/slither/detectors/statements/mapping_deletion.py
+++ b/slither/detectors/statements/mapping_deletion.py
@@ -22,6 +22,8 @@ class MappingDeletionDetection(AbstractDetector):
 
     WIKI_TITLE = "Deletion on mapping containing a structure"
     WIKI_DESCRIPTION = "A deletion in a structure containing a mapping will not delete the mapping (see the [Solidity documentation](https://solidity.readthedocs.io/en/latest/types.html##delete)). The remaining data may be used to compromise the contract."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     struct BalancesStruct{
@@ -36,6 +38,7 @@ class MappingDeletionDetection(AbstractDetector):
 ```
 `remove` deletes an item of `stackBalance`.
 The mapping `balances` is never deleted, so `remove` does not work as intended."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         "Use a lock mechanism instead of a deletion to disable structure containing a mapping."

--- a/slither/detectors/statements/redundant_statements.py
+++ b/slither/detectors/statements/redundant_statements.py
@@ -22,6 +22,8 @@ class RedundantStatements(AbstractDetector):
 
     WIKI_TITLE = "Redundant Statements"
     WIKI_DESCRIPTION = "Detect the usage of redundant statements that have no effect."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract RedundantStatementsContract {
@@ -41,6 +43,7 @@ contract RedundantStatementsContract {
 }
 ```
 Each commented line references types/identifiers, but performs no action with them, so no code will be generated for such statements and they can be removed."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove redundant statements if they congest code but offer no value."
 

--- a/slither/detectors/statements/too_many_digits.py
+++ b/slither/detectors/statements/too_many_digits.py
@@ -18,9 +18,14 @@ class TooManyDigits(AbstractDetector):
 
     WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#too-many-digits"
     WIKI_TITLE = "Too many digits"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Literals with many digits are difficult to read and review.
 """
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract MyContract{
@@ -30,12 +35,16 @@ contract MyContract{
 
 While `1_ether` looks like `1 ether`, it is `10 ether`. As a result, it's likely to be used incorrectly.
 """
+    # endregion wiki_exploit_scenario
+
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Use:
 - [Ether suffix](https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#ether-units),
 - [Time suffix](https://solidity.readthedocs.io/en/latest/units-and-global-variables.html#time-units), or
 - [The scientific notation](https://solidity.readthedocs.io/en/latest/types.html#rational-and-integer-literals)
 """
+    # endregion wiki_recommendation
 
     @staticmethod
     def _detect_too_many_digits(f):

--- a/slither/detectors/statements/tx_origin.py
+++ b/slither/detectors/statements/tx_origin.py
@@ -21,6 +21,8 @@ class TxOrigin(AbstractDetector):
 
     WIKI_TITLE = "Dangerous usage of `tx.origin`"
     WIKI_DESCRIPTION = "`tx.origin`-based protection can be abused by a malicious contract if a legitimate user interacts with the malicious contract."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract TxOrigin {
@@ -31,7 +33,8 @@ contract TxOrigin {
     }
 ```
 Bob is the owner of `TxOrigin`. Bob calls Eve's contract. Eve's contract calls `TxOrigin` and bypasses the `tx.origin` protection."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Do not use `tx.origin` for authorization."
 
     @staticmethod

--- a/slither/detectors/statements/type_based_tautology.py
+++ b/slither/detectors/statements/type_based_tautology.py
@@ -74,6 +74,8 @@ class TypeBasedTautology(AbstractDetector):
 
     WIKI_TITLE = "Tautology or contradiction"
     WIKI_DESCRIPTION = """Detects expressions that are tautologies or contradictions."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract A {
@@ -95,6 +97,7 @@ contract A {
 `x` is a `uint256`, so `x >= 0` will be always true.
 `y` is a `uint8`, so `y <512` will be always true.  
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         """Fix the incorrect comparison by changing the value type or the comparison."""

--- a/slither/detectors/statements/unary.py
+++ b/slither/detectors/statements/unary.py
@@ -42,6 +42,8 @@ class IncorrectUnaryExpressionDetection(AbstractDetector):
 
     WIKI_TITLE = "Dangerous unary expressions"
     WIKI_DESCRIPTION = "Unary expressions such as `x=+1` probably typos."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```Solidity 
 contract Bug{
@@ -54,6 +56,7 @@ contract Bug{
 }
 ```
 `increase()` uses `=+` instead of `+=`, so `counter` will never exceed 1."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove the unary expression."
 

--- a/slither/detectors/statements/unprotected_upgradeable.py
+++ b/slither/detectors/statements/unprotected_upgradeable.py
@@ -32,6 +32,8 @@ class UnprotectedUpgradeable(AbstractDetector):
 
     WIKI_TITLE = "Unprotected upgradeable contract"
     WIKI_DESCRIPTION = """Detects logic contract that can be destructed."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
     ```solidity
     contract Buggy is Initializable{
@@ -48,6 +50,7 @@ class UnprotectedUpgradeable(AbstractDetector):
     }
     ```
     Buggy is an upgradeable contract. Anyone can call initialize on the logic contract, and destruct the contract."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = (
         """Add a constructor to ensure `initialize` cannot be called on the logic contract."""

--- a/slither/detectors/statements/write_after_write.py
+++ b/slither/detectors/statements/write_after_write.py
@@ -103,6 +103,8 @@ class WriteAfterWrite(AbstractDetector):
 
     WIKI_TITLE = "Write after write"
     WIKI_DESCRIPTION = """Detects variables that are written but never read and written again."""
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
     ```solidity
     contract Buggy{
@@ -115,6 +117,7 @@ class WriteAfterWrite(AbstractDetector):
     }
     ```
     `a` is first asigned to `b`, and then to `c`. As a result the first write does nothing."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = """Fix or remove the writes."""
 

--- a/slither/detectors/variables/function_init_state_variables.py
+++ b/slither/detectors/variables/function_init_state_variables.py
@@ -51,6 +51,8 @@ class FunctionInitializedState(AbstractDetector):
 
     WIKI_TITLE = "Function Initializing State"
     WIKI_DESCRIPTION = "Detects the immediate initialization of state variables through function calls that are not pure/constant, or that use non-constant state variable."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract StateVarInitFromFunction {
@@ -79,6 +81,7 @@ In this case, users might intend a function to return a value a state variable c
 In the example above, the same function sets two different values for state variables because it checks a state variable that is not yet initialized in one case, and is initialized in the other. 
 Special care must be taken when initializing state variables from an immediate function call so as not to incorrectly assume the state is initialized.
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove any initialization of state variables via non-constant state variables or function calls. If variables must be set upon contract deployment, locate initialization in the constructor instead."
 

--- a/slither/detectors/variables/predeclaration_usage_local.py
+++ b/slither/detectors/variables/predeclaration_usage_local.py
@@ -19,6 +19,8 @@ class PredeclarationUsageLocal(AbstractDetector):
 
     WIKI_TITLE = "Pre-declaration usage of local variables"
     WIKI_DESCRIPTION = "Detects the possible usage of a variable before the declaration is stepped over (either because it is later declared, or declared in another scope)."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract C {
@@ -42,7 +44,8 @@ contract C {
 ```
 In the case above, the variable `x` is used before its declaration, which may result in unintended consequences. 
 Additionally, the for-loop uses the variable `max`, which is declared in a previous scope that may not always be reached. This could lead to unintended consequences if the user mistakenly uses a variable prior to any intended declaration assignment. It also may indicate that the user intended to reference a different variable."""
-
+    # endregion wiki_exploit_scenario
+    
     WIKI_RECOMMENDATION = "Move all variable declarations prior to any usage of the variable, and ensure that reaching a variable declaration does not depend on some conditional if it is used unconditionally."
 
     def detect_predeclared_local_usage(self, node, results, already_declared, visited):

--- a/slither/detectors/variables/uninitialized_local_variables.py
+++ b/slither/detectors/variables/uninitialized_local_variables.py
@@ -19,6 +19,8 @@ class UninitializedLocalVars(AbstractDetector):
 
     WIKI_TITLE = "Uninitialized local variables"
     WIKI_DESCRIPTION = "Uninitialized local variables."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Uninitialized is Owner{
@@ -29,6 +31,7 @@ contract Uninitialized is Owner{
 }
 ```
 Bob calls `transfer`. As a result, all Ether is sent to the address `0x0` and is lost."""
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Initialize all the variables. If a variable is meant to be initialized to zero, explicitly set it to zero to improve code readability."
 

--- a/slither/detectors/variables/uninitialized_state_variables.py
+++ b/slither/detectors/variables/uninitialized_state_variables.py
@@ -28,6 +28,8 @@ class UninitializedStateVarsDetection(AbstractDetector):
 
     WIKI_TITLE = "Uninitialized state variables"
     WIKI_DESCRIPTION = "Uninitialized state variables."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Uninitialized{
@@ -40,9 +42,13 @@ contract Uninitialized{
 ```
 Bob calls `transfer`. As a result, the Ether are sent to the address `0x0` and are lost.
 """
+    # endregion wiki_exploit_scenario
+
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Initialize all the variables. If a variable is meant to be initialized to zero, explicitly set it to zero to improve code readability.
 """
+    # endregion wiki_recommendation
 
     @staticmethod
     def _written_variables(contract):

--- a/slither/detectors/variables/uninitialized_storage_variables.py
+++ b/slither/detectors/variables/uninitialized_storage_variables.py
@@ -19,6 +19,8 @@ class UninitializedStorageVars(AbstractDetector):
 
     WIKI_TITLE = "Uninitialized storage variables"
     WIKI_DESCRIPTION = "An uninitialized storage variable will act as a reference to the first state variable, and can override a critical variable."
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Uninitialized{
@@ -36,6 +38,7 @@ contract Uninitialized{
 ```
 Bob calls `func`. As a result, `owner` is overridden to `0`.
 """
+    # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Initialize all storage variables."
 

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -286,8 +286,10 @@ class SlitherCompilationUnitSolc:
                 and not contract.is_top_level
             ):
                 raise SlitherException(
+                    # region multi-line-string
                     """Your codebase has a contract named 'SlitherInternalTopLevelContract'.
 Please rename it, this name is reserved for Slither's internals"""
+                    # endregion multi-line
                 )
             if contract.name in self._compilation_unit.contracts_as_dict:
                 if contract.id != self._compilation_unit.contracts_as_dict[contract.name].id:

--- a/slither/tools/upgradeability/checks/constant.py
+++ b/slither/tools/upgradeability/checks/constant.py
@@ -11,10 +11,14 @@ class WereConstant(AbstractCheck):
     HELP = "Variables that should be constant"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-that-should-be-constant"
     WIKI_TITLE = "Variables that should be constant"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect state variables that should be `constant̀`.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -32,10 +36,13 @@ contract ContractV2{
 Because `variable2` is not anymore a `constant`, the storage location of `variable3` will be different.
 As a result, `ContractV2` will have a corrupted storage layout.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Do not remove `constant` from a state variables during an update.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_CONTRACT_V2 = True
@@ -92,10 +99,13 @@ class BecameConstant(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#variables-that-should-not-be-constant"
     WIKI_TITLE = "Variables that should not be constant"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect state variables that should not be `constant̀`.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -113,10 +123,13 @@ contract ContractV2{
 Because `variable2` is now a `constant`, the storage location of `variable3` will be different.
 As a result, `ContractV2` will have a corrupted storage layout.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Do not make an existing state variable `constant`.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_CONTRACT_V2 = True

--- a/slither/tools/upgradeability/checks/functions_ids.py
+++ b/slither/tools/upgradeability/checks/functions_ids.py
@@ -44,10 +44,13 @@ class IDCollision(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-ids-collisions"
     WIKI_TITLE = "Functions ids collisions"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect function id collision between the contract and the proxy.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -65,10 +68,13 @@ contract Proxy{
 `Proxy.tgeo()` and `Contract.gsf()` have the same function id (0x67e43e43). 
 As a result, `Proxy.tgeo()` will shadow Contract.gsf()`.  
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Rename the function. Avoid public functions in the proxy.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_PROXY = True
@@ -111,10 +117,13 @@ class FunctionShadowing(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#functions-shadowing"
     WIKI_TITLE = "Functions shadowing"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect function shadowing between the contract and the proxy.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -131,10 +140,13 @@ contract Proxy{
 ```
 `Proxy.get` will shadow any call to `get()`. As a result `get()` is never executed in the logic contract and cannot be updated.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Rename the function. Avoid public functions in the proxy.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_PROXY = True

--- a/slither/tools/upgradeability/checks/initialization.py
+++ b/slither/tools/upgradeability/checks/initialization.py
@@ -45,14 +45,19 @@ class InitializablePresent(AbstractCheck):
     HELP = "Initializable is missing"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initializable-is-missing"
     WIKI_TITLE = "Initializable is missing"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect if a contract `Initializable` is present.
 """
+    # endregion wiki_description
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Review manually the contract's initialization..
 Consider using a `Initializable` contract to follow [standard practice](https://docs.openzeppelin.com/upgrades/2.7/writing-upgradeable).
 """
+    # endregion wiki_recommendation
 
     def _check(self):
         initializable = self.contract.compilation_unit.get_contract_from_name("Initializable")
@@ -73,13 +78,17 @@ class InitializableInherited(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initializable-is-not-inherited"
     WIKI_TITLE = "Initializable is not inherited"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect if `Initializable` is inherited.
 """
+    # endregion wiki_description
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Review manually the contract's initialization. Consider inheriting `Initializable`.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 
@@ -103,13 +112,17 @@ class InitializableInitializer(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initializer-is-missing"
     WIKI_TITLE = "initializer() is missing"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect the lack of `Initializable.initializer()` modifier.
 """
+    # endregion wiki_description
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Review manually the contract's initialization. Consider inheriting a `Initializable.initializer()` modifier.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 
@@ -137,10 +150,14 @@ class MissingInitializerModifier(AbstractCheck):
     HELP = "initializer() is not called"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initializer-is-not-called"
     WIKI_TITLE = "initializer() is not called"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect if `Initializable.initializer()` is called.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -152,10 +169,13 @@ contract Contract{
 ```
 `initialize` should have the `initializer` modifier to prevent someone from initializing the contract multiple times.  
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Use `Initializable.initializer()`.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 
@@ -189,10 +209,14 @@ class MissingCalls(AbstractCheck):
     HELP = "Missing calls to init functions"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialize-functions-are-not-called"
     WIKI_TITLE = "Initialize functions are not called"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect missing calls to initialize functions.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Base{
@@ -209,10 +233,13 @@ contract Derived is Base{
 ```
 `Derived.initialize` does not call `Base.initialize` leading the contract to not be correctly initialized.  
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Ensure all the initialize functions are reached by the most derived initialize function.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 
@@ -246,10 +273,14 @@ class MultipleCalls(AbstractCheck):
     HELP = "Init functions called multiple times"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialize-functions-are-called-multiple-times"
     WIKI_TITLE = "Initialize functions are called multiple times"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect multiple calls to a initialize function.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Base{
@@ -273,10 +304,13 @@ contract DerivedDerived is Derived{
 ```
 `Base.initialize(uint)` is called two times in `DerivedDerived.initiliaze` execution, leading to a potential corruption.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Call only one time every initialize function.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 
@@ -314,15 +348,19 @@ class InitializeTarget(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#initialize-function"
     WIKI_TITLE = "Initialize function"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Show the function that must be called at deployment. 
 
 This finding does not have an immediate security impact and is informative.
 """
+    # endregion wiki_description
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Ensure that the function is called at deployment.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 

--- a/slither/tools/upgradeability/checks/variable_initialization.py
+++ b/slither/tools/upgradeability/checks/variable_initialization.py
@@ -12,10 +12,13 @@ class VariableWithInit(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#state-variable-initialized"
     WIKI_TITLE = "State variable initialized"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect state variables that are initialized.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -24,10 +27,13 @@ contract Contract{
 ```
 Using `Contract` will the delegatecall proxy pattern will lead `variable` to be 0 when called through the proxy.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Using initialize functions to write initial values in state variables.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
 

--- a/slither/tools/upgradeability/checks/variables_order.py
+++ b/slither/tools/upgradeability/checks/variables_order.py
@@ -11,9 +11,14 @@ class MissingVariable(AbstractCheck):
     HELP = "Variable missing in the v2"
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#missing-variables"
     WIKI_TITLE = "Missing variables"
+
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect variables that were present in the original contracts but are not in the updated one.
 """
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract V1{
@@ -29,10 +34,13 @@ The new version, `V2` does not contain `variable1`.
 If a new variable is added in an update of `V2`, this variable will hold the latest value of `variable2` and
 will be corrupted.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Do not change the order of the state variables in the updated contract.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_CONTRACT_V2 = True
@@ -62,10 +70,13 @@ class DifferentVariableContractProxy(AbstractCheck):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#incorrect-variables-with-the-proxy"
     WIKI_TITLE = "Incorrect variables with the proxy"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect variables that are different between the contract and the proxy.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -78,10 +89,13 @@ contract Proxy{
 ```
 `Contract` and `Proxy` do not have the same storage layout. As a result the storage of both contracts can be corrupted.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Avoid variables in the proxy. If a variable is in the proxy, ensure it has the same layout than in the contract.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_PROXY = True
@@ -129,10 +143,13 @@ class DifferentVariableContractNewContract(DifferentVariableContractProxy):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#incorrect-variables-with-the-v2"
     WIKI_TITLE = "Incorrect variables with the v2"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect variables that are different between the original contract and the updated one.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -145,10 +162,13 @@ contract ContractV2{
 ```
 `Contract` and `ContractV2` do not have the same storage layout. As a result the storage of both contracts can be corrupted.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Respect the variable order of the original contract in the updated contract.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_PROXY = False
@@ -168,10 +188,13 @@ class ExtraVariablesProxy(AbstractCheck):
     )
     WIKI_TITLE = "Extra variables in the proxy"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Detect variables that are in the proxy and not in the contract.
 """
+    # endregion wiki_description
 
+    # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
@@ -185,10 +208,13 @@ contract Proxy{
 ```
 `Proxy` contains additional variables. A future update of `Contract` is likely to corrupt the proxy.
 """
+    # endregion wiki_exploit_scenario
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Avoid variables in the proxy. If a variable is in the proxy, ensure it has the same layout than in the contract.
 """
+    # endregion wiki_recommendation
 
     REQUIRE_CONTRACT = True
     REQUIRE_PROXY = True
@@ -229,15 +255,19 @@ class ExtraVariablesNewContract(ExtraVariablesProxy):
     WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#extra-variables-in-the-v2"
     WIKI_TITLE = "Extra variables in the v2"
 
+    # region wiki_description
     WIKI_DESCRIPTION = """
 Show new variables in the updated contract. 
 
 This finding does not have an immediate security impact and is informative.
 """
+    # endregion wiki_description
 
+    # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Ensure that all the new variables are expected.
 """
+    # endregion wiki_recommendation
 
     IMPACT = CheckClassification.INFORMATIONAL
 


### PR DESCRIPTION
Before: https://i.imgur.com/mMuHwyn.png - Multi-line strings break editor folding 

After: https://i.imgur.com/4nFuvl8.png - Folding works!

More context:

In theory the Python language server could provide semantic folding support. However, it seems this [is not a priority for e.g. Pylance (VS code LPSP)](https://github.com/microsoft/pylance-release/issues/372).