### PR TITLE
move function type assignment from _analyze_attributes to _analyze_type

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -208,6 +208,13 @@ class FunctionSolc:
             if self._function.name == self._function.contract_declarer.name:
                 self._function.function_type = FunctionType.CONSTRUCTOR
 
+        if "isConstructor" in attributes and attributes["isConstructor"]:
+            self._function.function_type = FunctionType.CONSTRUCTOR
+
+        if "kind" in attributes:
+            if attributes["kind"] == "constructor":
+                self._function.function_type = FunctionType.CONSTRUCTOR
+
     def _analyze_attributes(self):
         if self.is_compact_ast:
             attributes = self._functionNotParsed
@@ -227,13 +234,6 @@ class FunctionSolc:
 
         if "constant" in attributes:
             self._function.view = attributes["constant"]
-
-        if "isConstructor" in attributes and attributes["isConstructor"]:
-            self._function.function_type = FunctionType.CONSTRUCTOR
-
-        if "kind" in attributes:
-            if attributes["kind"] == "constructor":
-                self._function.function_type = FunctionType.CONSTRUCTOR
 
         if "visibility" in attributes:
             self._function.visibility = attributes["visibility"]


### PR DESCRIPTION
This moves `_function_type` assignment from `_analyze_attributes` to `_analyze_type`. I am fairly confident this doesn't break anything, because:
- `_analyze_type` is called exactly once in the codebase on `FunctionSolc.__init__`.
- `_analyze_attributes` is called exactly once for a function or modifier in `FunctionSolc|ModifierSolc.analyze_params()`. This is called in:
  - `FunctionSolc.analyze_params()`:
    - `_analyze_params_top_level_function`, which is a node in `_analyze_third_part`
  - Both:
    - `ContractParser._analyze_params_elements`, which is also a node in `_analyze_third_part`

Based on this analysis, it seems to me there will be no unintended side-effects from setting the function type correctly early