### PR TITLE
Added support for SARIF as output format

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -811,7 +811,7 @@ def main_impl(all_detector_classes, all_printer_classes):
 
     if outputting_sarif:
         StandardOutputCapture.disable()
-        output_to_sarif(None if outputting_sarif_stdout else args.sarif, None, json_results)
+        output_to_sarif(None if outputting_sarif_stdout else args.sarif, json_results)
 
     if outputting_zip:
         output_to_zip(args.zip, output_error, json_results, args.zip_type)

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -23,7 +23,7 @@ from slither.detectors.abstract_detector import AbstractDetector, DetectorClassi
 from slither.printers import all_printers
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.slither import Slither
-from slither.utils.output import output_to_json, output_to_zip, ZIP_TYPES_ACCEPTED
+from slither.utils.output import output_to_json, output_to_zip, output_to_sarif, ZIP_TYPES_ACCEPTED
 from slither.utils.output_capture import StandardOutputCapture
 from slither.utils.colors import red, blue, set_colorization_enabled
 from slither.utils.command_line import (
@@ -389,6 +389,13 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
     )
 
     group_misc.add_argument(
+        "--sarif",
+        help='Export the results as a SARIF JSON file ("--sarif -" to export to stdout)',
+        action="store",
+        default=defaults_flag_in_config["sarif"],
+    )
+
+    group_misc.add_argument(
         "--json-types",
         help="Comma-separated list of result types to output to JSON, defaults to "
         + f'{",".join(output_type for output_type in DEFAULT_JSON_OUTPUT_TYPES)}. '
@@ -636,6 +643,8 @@ def main_impl(all_detector_classes, all_printer_classes):
     output_error = None
     outputting_json = args.json is not None
     outputting_json_stdout = args.json == "-"
+    outputting_sarif = args.sarif is not None
+    outputting_sarif_stdout = args.sarif == "-"
     outputting_zip = args.zip is not None
     if args.zip_type not in ZIP_TYPES_ACCEPTED.keys():
         to_log = f'Zip type not accepted, it must be one of {",".join(ZIP_TYPES_ACCEPTED.keys())}'
@@ -643,8 +652,8 @@ def main_impl(all_detector_classes, all_printer_classes):
 
     # If we are outputting JSON, capture all standard output. If we are outputting to stdout, we block typical stdout
     # output.
-    if outputting_json:
-        StandardOutputCapture.enable(outputting_json_stdout)
+    if outputting_json or output_to_sarif:
+        StandardOutputCapture.enable(outputting_json_stdout or outputting_sarif_stdout )
 
     printer_classes = choose_printers(args, all_printer_classes)
     detector_classes = choose_detectors(args, all_detector_classes)
@@ -723,7 +732,7 @@ def main_impl(all_detector_classes, all_printer_classes):
             ) = process_all(filename, args, detector_classes, printer_classes)
 
         # Determine if we are outputting JSON
-        if outputting_json or outputting_zip:
+        if outputting_json or outputting_zip or output_to_sarif:
             # Add our compilation information to JSON
             if "compilations" in args.json_types:
                 compilation_results = []
@@ -799,6 +808,10 @@ def main_impl(all_detector_classes, all_printer_classes):
             }
         StandardOutputCapture.disable()
         output_to_json(None if outputting_json_stdout else args.json, output_error, json_results)
+
+    if outputting_sarif:
+        StandardOutputCapture.disable()
+        output_to_sarif(None if outputting_sarif_stdout else args.sarif, None, json_results)
 
     if outputting_zip:
         output_to_zip(args.zip, output_error, json_results, args.zip_type)

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -34,6 +34,7 @@ defaults_flag_in_config = {
     "exclude_medium": False,
     "exclude_high": False,
     "json": None,
+    "sarif": None,
     "json-types": ",".join(DEFAULT_JSON_OUTPUT_TYPES),
     "disable_color": False,
     "filter_paths": None,


### PR DESCRIPTION
Adds support for outputting reports as SARIF. 

https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/about-integration-with-code-scanning

Makes use of the new Github "security-severity" ratings to assign a severity based on the "impact" of the rule.

https://github.blog/changelog/2021-07-19-codeql-code-scanning-new-severity-levels-for-security-alerts/

Useable with a Github Action or with direct upload:

```
slither --sarif slither.sarif examples/slither-prop
```
```
curl -u $USER:$TOKEN -X POST -H "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/crytic/slither/code-scanning/sarifs  -d '{"commit_sha":"1c907d5126efaa7dbd124d6bd9aec23bb8cc3e8e","ref":"refs/heads/master","sarif":"'$(gzip -c slither.sarif | base64 -w0)'"}'
```

![Screenshot 2021-08-03 at 15 56 42](https://user-images.githubusercontent.com/4208881/128028135-3bea8acb-61b8-4de0-baa5-27b54655c779.png)
