### PR TITLE
core/solidity_types: fix storage size and min size for bytes

### DIFF
--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -34,7 +34,7 @@ class ArrayType(Type):
         return self._length
 
     @property
-    def lenght_value(self) -> Optional[Literal]:
+    def length_value(self) -> Optional[Literal]:
         return self._length_value
 
     @property

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -127,10 +127,10 @@ Max_Byte = {k: 2 ** (8 * (i + 1)) - 1 for i, k in enumerate(Byte[2:])}
 Max_Byte["bytes"] = None
 Max_Byte["string"] = None
 Max_Byte["byte"] = 255
-Min_Byte = {k: 1 << (4 + 8 * i) for i, k in enumerate(Byte[2:])}
+Min_Byte = {k: 0 for k in Byte}
 Min_Byte["bytes"] = 0x0
-Min_Byte["string"] = None
-Min_Byte["byte"] = 0x10
+Min_Byte["string"] = 0x0
+Min_Byte["byte"] = 0x0
 
 MaxValues = dict(dict(Max_Int, **Max_Uint), **Max_Byte)
 MinValues = dict(dict(Min_Int, **Min_Uint), **Min_Byte)

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -188,8 +188,8 @@ class ElementaryType(Type):
             return int(8)
         if t == "address":
             return int(160)
-        if t.startswith("bytes"):
-            return int(t[len("bytes") :])
+        if t.startswith("bytes") and t != "bytes":
+            return int(t[len("bytes") :]) * 8
         return None
 
     @property


### PR DESCRIPTION
When a contract contains a state variable such as `bytes32[3] data`, calling `data.type.storage_size` [returns](https://github.com/crytic/slither/blob/master/slither/core/solidity_types/array_type.py#L44) `12` bytes (`data.type` is `ArrayType`). This is because the size of each element in the array is [calculated](https://github.com/crytic/slither/blob/master/slither/core/solidity_types/elementary_type.py#L201) to be `4` bytes instead of `32` bytes. Changing the [size property](https://github.com/crytic/slither/blob/master/slither/core/solidity_types/elementary_type.py#L192) to return the number of bits (eg. 256) instead of bytes (eg. 32) fixes this issue, and `data.type.storage_size` correctly evaluates to `96` bytes, or three storage slots. I believe this is the desired behavior as `uint256[3] data` reports a size of `96` bytes currently. I ran into this error while working on [this issue](https://github.com/crytic/slither/issues/793) and using the size and offset to parse values from storage.