### PR TITLE
Support bytes.concat

### DIFF
--- a/slither/core/declarations/solidity_variables.py
+++ b/slither/core/declarations/solidity_variables.py
@@ -67,6 +67,7 @@ SOLIDITY_FUNCTIONS: Dict[str, List[str]] = {
     "abi.encodePacked()": ["bytes"],
     "abi.encodeWithSelector()": ["bytes"],
     "abi.encodeWithSignature()": ["bytes"],
+    "bytes.concat()": ["bytes"],
     # abi.decode returns an a list arbitrary types
     "abi.decode()": [],
     "type(address)": [],

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1057,13 +1057,15 @@ def convert_to_low_level(ir):
 def can_be_solidity_func(ir) -> bool:
     if not isinstance(ir, HighLevelCall):
         return False
-    return ir.destination.name == "abi" and ir.function_name in [
+    is_abi = ir.destination.name == "abi" and ir.function_name in [
         "encode",
         "encodePacked",
         "encodeWithSelector",
         "encodeWithSignature",
         "decode",
     ]
+    is_bytes = ir.destination.name == "bytes" and ir.function_name == "concat"
+    return is_abi or is_bytes
 
 
 def convert_to_solidity_func(ir):


### PR DESCRIPTION
Fixes #944.

Not sure if this is correct. I followed the implementation of `abi.encodePacked`, which only does the same as below. Haven't found tests for these.

`bytes.concat` is very similar to `abi.encodePacked`, with the main difference being lesser number of input types are supported (literals and `bytes`)