### PR TITLE
Do not use available_functions_as_dict in find_variable

### DIFF
--- a/slither/solc_parsing/expressions/find_variable.py
+++ b/slither/solc_parsing/expressions/find_variable.py
@@ -158,7 +158,7 @@ def _find_in_contract(
             ).values()
         }
     else:
-        functions = contract.available_functions_as_dict()
+        functions = {f.full_name: f for f in contract.functions if not f.is_shadowed}
     if var_name in functions:
         return functions[var_name]
 


### PR DESCRIPTION
The reason is that this function is now called early on (before the contract is properly constructed), which can break the memoization