### PR TITLE
ElementaryType: `size` for `bytes` returns bit width

### DIFF
--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -188,8 +188,8 @@ class ElementaryType(Type):
             return int(8)
         if t == "address":
             return int(160)
-        if t.startswith("bytes"):
-            return int(t[len("bytes") :])
+        if t != "bytes" and t.startswith("bytes"):
+            return 8 * int(t[len("bytes") :])
         return None
 
     @property


### PR DESCRIPTION
For `unitXX`, `intXX`, `bool` and `address` types `size` property returns
size in bits.  But for `bytesXX` type it was returning size in bytes.  It
makes calculation in `storage_size` break, as well as makes comparing
`size` values for different types more tricky.

Also, `bytes` (without any width) is a valid variable width type.  It
should return `None`.