### PR TITLE
Fix typo

### DIFF
--- a/slither/detectors/operations/missing_zero_address_validation.py
+++ b/slither/detectors/operations/missing_zero_address_validation.py
@@ -40,7 +40,7 @@ contract C {
   }
 }
 ```
-Bob calls `updateOwner` without specifying the `newOwner`, soBob loses ownership of the contract.
+Bob calls `updateOwner` without specifying the `newOwner`, so Bob loses ownership of the contract.
 """
     # endregion wiki_exploit_scenario
 


### PR DESCRIPTION
Add missing space in `WIKI_EXPLOIT_SCENARIO` in `missing_zero_address_validation.py`.