### PR TITLE
Fixed infinite recursion in show_ignore_findings

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -332,6 +332,6 @@ class SlitherCore(Context):
 
     @property
     def show_ignore_findings(self) -> bool:
-        return self.show_ignore_findings
+        return self._show_ignored_findings
 
     # endregion


### PR DESCRIPTION
"show_ignore_findings" calls itself instead of returning a similar named variable.
This causes an infinite recursion, resulting in an RecursionError when creating a Slither Object via the Python API