### PR TITLE
Small slither-mutate fixes

### DIFF
--- a/slither/tools/mutator/mutators/MIA.py
+++ b/slither/tools/mutator/mutators/MIA.py
@@ -1,12 +1,12 @@
 from slither.core.cfg.node import NodeType
 from slither.formatters.utils.patches import create_patch
-from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaulClass
+from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaultClass
 
 
 class MIA(AbstractMutator):  # pylint: disable=too-few-public-methods
     NAME = "MIA"
     HELP = '"if" construct around statement'
-    FAULTCLASS = FaulClass.Checking
+    FAULTCLASS = FaultClass.Checking
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self):

--- a/slither/tools/mutator/mutators/MVIE.py
+++ b/slither/tools/mutator/mutators/MVIE.py
@@ -4,7 +4,7 @@ from slither.tools.mutator.utils.generic_patching import remove_assignement
 
 
 class MVIE(AbstractMutator):  # pylint: disable=too-few-public-methods
-    NAME = "MVIV"
+    NAME = "MVIE"
     HELP = "variable initialization using an expression"
     FAULTCLASS = FaultClass.Assignement
     FAULTNATURE = FaultNature.Missing

--- a/slither/tools/mutator/mutators/MVIE.py
+++ b/slither/tools/mutator/mutators/MVIE.py
@@ -1,12 +1,12 @@
 from slither.core.expressions import Literal
-from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaulClass
+from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaultClass
 from slither.tools.mutator.utils.generic_patching import remove_assignement
 
 
 class MVIE(AbstractMutator):  # pylint: disable=too-few-public-methods
     NAME = "MVIV"
     HELP = "variable initialization using an expression"
-    FAULTCLASS = FaulClass.Assignement
+    FAULTCLASS = FaultClass.Assignement
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self):

--- a/slither/tools/mutator/mutators/MVIV.py
+++ b/slither/tools/mutator/mutators/MVIV.py
@@ -1,12 +1,12 @@
 from slither.core.expressions import Literal
-from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaulClass
+from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator, FaultNature, FaultClass
 from slither.tools.mutator.utils.generic_patching import remove_assignement
 
 
 class MVIV(AbstractMutator):  # pylint: disable=too-few-public-methods
     NAME = "MVIV"
     HELP = "variable initialization using a value"
-    FAULTCLASS = FaulClass.Assignement
+    FAULTCLASS = FaultClass.Assignement
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self):

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -13,7 +13,7 @@ class IncorrectMutatorInitialization(Exception):
     pass
 
 
-class FaulClass(Enum):
+class FaultClass(Enum):
     Assignement = 0
     Checking = 1
     Interface = 2
@@ -31,7 +31,7 @@ class FaultNature(Enum):
 class AbstractMutator(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-methods
     NAME = ""
     HELP = ""
-    FAULTCLASS = FaulClass.Undefined
+    FAULTCLASS = FaultClass.Undefined
     FAULTNATURE = FaultNature.Undefined
 
     def __init__(self, slither: Slither, rate: int = 10, seed: Optional[int] = None):
@@ -49,7 +49,7 @@ class AbstractMutator(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-
                 f"HELP is not initialized {self.__class__.__name__}"
             )
 
-        if self.FAULTCLASS == FaulClass.Undefined:
+        if self.FAULTCLASS == FaultClass.Undefined:
             raise IncorrectMutatorInitialization(
                 f"FAULTCLASS is not initialized {self.__class__.__name__}"
             )

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -72,6 +72,10 @@ class AbstractMutator(metaclass=abc.ABCMeta):  # pylint: disable=too-few-public-
     def mutate(self) -> None:
         all_patches = self._mutate()
 
+        if "patches" not in all_patches:
+            logger.debug(f"No patches found by {self.NAME}")
+            return
+
         for file in all_patches["patches"]:
             original_txt = self.slither.source_code[file].encode("utf8")
             patched_txt = original_txt


### PR DESCRIPTION
A few small fixes to `slither-mutate`.

1. Rename `FaulClass` to `FaultClass`
2. Fix name of `MVIE` mutator
3. Prevent `KeyError` in `AbstractMutator::mutate` when no patches are produced