### PR TITLE
Disable embark CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         type: ["cli",
                "data_dependency",
-               "embark",
+               # "embark",
                "erc",
                "etherlime",
                "find_paths",


### PR DESCRIPTION
Recently embark has made our CI not reliable. However, not a lot of projects are still using embark. This PR disable embark from our CI until we figure out how to fix it.

Related: https://github.com/crytic/slither/pull/1124

It might be related to https://github.blog/2021-09-01-improving-git-protocol-security-github/