### PR TITLE
fix typo in output

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -776,7 +776,7 @@ def main_impl(all_detector_classes, all_printer_classes):
         if args.checklist:
             output_results_to_markdown(results_detectors, args.checklist_limit)
 
-        # Dont print the number of result for printers
+        # Don't print the number of result for printers
         if number_contracts == 0:
             logger.warning(red("No contract was analyzed"))
         if printer_classes:

--- a/slither/detectors/attributes/constant_pragma.py
+++ b/slither/detectors/attributes/constant_pragma.py
@@ -29,7 +29,7 @@ class ConstantPragma(AbstractDetector):
         versions = sorted(list(set(versions)))
 
         if len(versions) > 1:
-            info = ["Different versions of Solidity is used:\n"]
+            info = ["Different versions of Solidity are used:\n"]
             info += [f"\t- Version used: {[str(v) for v in versions]}\n"]
 
             for p in pragma:

--- a/tests/detectors/pragma/0.4.25/pragma.0.4.25.sol.0.4.25.ConstantPragma.json
+++ b/tests/detectors/pragma/0.4.25/pragma.0.4.25.sol.0.4.25.ConstantPragma.json
@@ -58,7 +58,7 @@
             "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- ^0.4.24 (tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#1)\n\t- ^0.4.25 (tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#1)\n",
             "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- [^0.4.24](tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#L1)\n\t- [^0.4.25](tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#L1",
-            "id": "4c6393f838949def61fef871f6771fee22a8783f10fcc084c78287fd2f1d60ed",
+            "id": "1b4bdffe0c7fc63e2a8d589f34ff29de46139cf79ff3b9cb13dee36502b8fbc6",
             "check": "pragma",
             "impact": "Informational",
             "confidence": "High"

--- a/tests/detectors/pragma/0.4.25/pragma.0.4.25.sol.0.4.25.ConstantPragma.json
+++ b/tests/detectors/pragma/0.4.25/pragma.0.4.25.sol.0.4.25.ConstantPragma.json
@@ -55,8 +55,8 @@
                     }
                 }
             ],
-            "description": "Different versions of Solidity is used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- ^0.4.24 (tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#1)\n\t- ^0.4.25 (tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#1)\n",
-            "markdown": "Different versions of Solidity is used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- [^0.4.24](tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#L1)\n\t- [^0.4.25](tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#L1)\n",
+            "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- ^0.4.24 (tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#1)\n\t- ^0.4.25 (tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#1)\n",
+            "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.4.24', '^0.4.25']\n\t- [^0.4.24](tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#L1)\n\t- [^0.4.25](tests/detectors/pragma/0.4.25/pragma.0.4.25.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.4.25/pragma.0.4.24.sol#L1",
             "id": "4c6393f838949def61fef871f6771fee22a8783f10fcc084c78287fd2f1d60ed",
             "check": "pragma",

--- a/tests/detectors/pragma/0.5.16/pragma.0.5.16.sol.0.5.16.ConstantPragma.json
+++ b/tests/detectors/pragma/0.5.16/pragma.0.5.16.sol.0.5.16.ConstantPragma.json
@@ -58,7 +58,7 @@
             "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- ^0.5.15 (tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#1)\n\t- ^0.5.16 (tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#1)\n",
             "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- [^0.5.15](tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#L1)\n\t- [^0.5.16](tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#L1",
-            "id": "fb131cf132ddad4e4550414541cc4b778b66e14a2a134874ad78197e54fbc020",
+            "id": "f3c6aef8c4d19f960e801fe9343d7cb4c290460cb7b4b14dca769269f0234b31",
             "check": "pragma",
             "impact": "Informational",
             "confidence": "High"

--- a/tests/detectors/pragma/0.5.16/pragma.0.5.16.sol.0.5.16.ConstantPragma.json
+++ b/tests/detectors/pragma/0.5.16/pragma.0.5.16.sol.0.5.16.ConstantPragma.json
@@ -55,8 +55,8 @@
                     }
                 }
             ],
-            "description": "Different versions of Solidity is used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- ^0.5.15 (tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#1)\n\t- ^0.5.16 (tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#1)\n",
-            "markdown": "Different versions of Solidity is used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- [^0.5.15](tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#L1)\n\t- [^0.5.16](tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#L1)\n",
+            "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- ^0.5.15 (tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#1)\n\t- ^0.5.16 (tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#1)\n",
+            "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.5.15', '^0.5.16']\n\t- [^0.5.15](tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#L1)\n\t- [^0.5.16](tests/detectors/pragma/0.5.16/pragma.0.5.16.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.5.16/pragma.0.5.15.sol#L1",
             "id": "fb131cf132ddad4e4550414541cc4b778b66e14a2a134874ad78197e54fbc020",
             "check": "pragma",

--- a/tests/detectors/pragma/0.6.11/pragma.0.6.11.sol.0.6.11.ConstantPragma.json
+++ b/tests/detectors/pragma/0.6.11/pragma.0.6.11.sol.0.6.11.ConstantPragma.json
@@ -58,7 +58,7 @@
             "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- ^0.6.10 (tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#1)\n\t- ^0.6.11 (tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#1)\n",
             "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- [^0.6.10](tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#L1)\n\t- [^0.6.11](tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#L1",
-            "id": "cca73553e40b6b9e04136a89efd83aea4283d56c8b3e49371384fc39e0a905e9",
+            "id": "05ad5ab9a596fc401c485ede8f164ebd0df3052e307bb036f70a64d47cbc2933",
             "check": "pragma",
             "impact": "Informational",
             "confidence": "High"

--- a/tests/detectors/pragma/0.6.11/pragma.0.6.11.sol.0.6.11.ConstantPragma.json
+++ b/tests/detectors/pragma/0.6.11/pragma.0.6.11.sol.0.6.11.ConstantPragma.json
@@ -55,8 +55,8 @@
                     }
                 }
             ],
-            "description": "Different versions of Solidity is used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- ^0.6.10 (tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#1)\n\t- ^0.6.11 (tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#1)\n",
-            "markdown": "Different versions of Solidity is used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- [^0.6.10](tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#L1)\n\t- [^0.6.11](tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#L1)\n",
+            "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- ^0.6.10 (tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#1)\n\t- ^0.6.11 (tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#1)\n",
+            "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.6.10', '^0.6.11']\n\t- [^0.6.10](tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#L1)\n\t- [^0.6.11](tests/detectors/pragma/0.6.11/pragma.0.6.11.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.6.11/pragma.0.6.10.sol#L1",
             "id": "cca73553e40b6b9e04136a89efd83aea4283d56c8b3e49371384fc39e0a905e9",
             "check": "pragma",

--- a/tests/detectors/pragma/0.7.6/pragma.0.7.6.sol.0.7.6.ConstantPragma.json
+++ b/tests/detectors/pragma/0.7.6/pragma.0.7.6.sol.0.7.6.ConstantPragma.json
@@ -58,7 +58,7 @@
             "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- ^0.7.5 (tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#1)\n\t- ^0.7.6 (tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#1)\n",
             "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- [^0.7.5](tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#L1)\n\t- [^0.7.6](tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#L1",
-            "id": "21aac87dfbfe74fd5fcee57ee3edcd75cb659d22b3845b2cc8508a8c44c87d1a",
+            "id": "bbddfc60b33090137a744cf0ebdfb2acbe88e3f353368626723e8bec7558f72f",
             "check": "pragma",
             "impact": "Informational",
             "confidence": "High"

--- a/tests/detectors/pragma/0.7.6/pragma.0.7.6.sol.0.7.6.ConstantPragma.json
+++ b/tests/detectors/pragma/0.7.6/pragma.0.7.6.sol.0.7.6.ConstantPragma.json
@@ -55,8 +55,8 @@
                     }
                 }
             ],
-            "description": "Different versions of Solidity is used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- ^0.7.5 (tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#1)\n\t- ^0.7.6 (tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#1)\n",
-            "markdown": "Different versions of Solidity is used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- [^0.7.5](tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#L1)\n\t- [^0.7.6](tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#L1)\n",
+            "description": "Different versions of Solidity are used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- ^0.7.5 (tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#1)\n\t- ^0.7.6 (tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#1)\n",
+            "markdown": "Different versions of Solidity are used:\n\t- Version used: ['^0.7.5', '^0.7.6']\n\t- [^0.7.5](tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#L1)\n\t- [^0.7.6](tests/detectors/pragma/0.7.6/pragma.0.7.6.sol#L1)\n",
             "first_markdown_element": "tests/detectors/pragma/0.7.6/pragma.0.7.5.sol#L1",
             "id": "21aac87dfbfe74fd5fcee57ee3edcd75cb659d22b3845b2cc8508a8c44c87d1a",
             "check": "pragma",


### PR DESCRIPTION
Fixes "Different versions of Solidity is used" -> "Different versions of Solidity are used" in slither output.

Also fixes the same string being used for comparisons in tests but I wasn't able to figure out how to run all the tests locally, I guess CI will run those checks for me..

I was able to run individual suites w specific calls into scripts eg `bash scripts/ci_test_data_dependency.sh` but some of these have suspicious output & still exit w code 0. I expected `bash scripts/ci_test.sh` to run all test suites w a clear indication when something failed but it exits w/out any output & exit code 0.. Maybe that means everything works as expected?