### PR TITLE
Fix custom error signature lookback

### DIFF
--- a/slither/core/declarations/custom_error.py
+++ b/slither/core/declarations/custom_error.py
@@ -56,7 +56,12 @@ class CustomError(SourceMapping):
         Contract and converted into address
         :return: the solidity signature
         """
-        assert self._solidity_signature is not None
+        # Ideally this should be an assert
+        # But due to a logic limitation in the solc parsing (find_variable)
+        # We need to raise an error if the custom error sig was not yet built
+        # (set_solidity_sig was not called before find_variable)
+        if self._solidity_signature is None:
+            raise ValueError("Custom Error not yet built")
         return self._solidity_signature
 
     def set_solidity_sig(self) -> None:

--- a/slither/solc_parsing/expressions/find_variable.py
+++ b/slither/solc_parsing/expressions/find_variable.py
@@ -137,9 +137,15 @@ def _find_top_level(
     # For example, a top variable that use another top level variable
     # IF more top level objects are added to Solidity, we have to be careful with the order of the lookup
     # in this function
-    for custom_error in scope.custom_errors:
-        if custom_error.solidity_signature == var_name:
-            return custom_error, False
+    try:
+        for custom_error in scope.custom_errors:
+            if custom_error.solidity_signature == var_name:
+                return custom_error, False
+    except ValueError:
+        # This can happen as custom error sol signature might not have been built
+        # when find_variable was called
+        # TODO refactor find_variable to prevent this from happening
+        pass
 
     return None, False
 
@@ -208,9 +214,15 @@ def _find_in_contract(
     # This is because when the dic is populated the underlying object is not yet parsed
     # As a result, we need to iterate over all the custom errors here instead of using the dict
     custom_errors = contract.custom_errors
-    for custom_error in custom_errors:
-        if var_name == custom_error.solidity_signature:
-            return custom_error
+    try:
+        for custom_error in custom_errors:
+            if var_name == custom_error.solidity_signature:
+                return custom_error
+    except ValueError:
+        # This can happen as custom error sol signature might not have been built
+        # when find_variable was called
+        # TODO refactor find_variable to prevent this from happening
+        pass
 
     # If the enum is refered as its name rather than its canonicalName
     enums = {e.name: e for e in contract.enums}


### PR DESCRIPTION
This is a hotfix, and better solution will require to refactor the find_variable function