### PR TITLE
Update to gh super linter 4.9.2 + linters

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -36,7 +36,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Black
-        uses: github/super-linter/slim@v4.8.7
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
           python-version: 3.6
       - name: Install dependencies
         run: |
-          # FIXME: patched crytic-compile is used to support Windows.
-          # Install from pip once branch is merged and crytic-compile released
-          pip install "crytic-compile@https://github.com/crytic/crytic-compile/archive/refs/heads/dev-windows-long-paths.zip"
 
           python setup.py install
           # Used by ci_test.sh

--- a/.github/workflows/detectors.yml
+++ b/.github/workflows/detectors.yml
@@ -33,9 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # FIXME: patched crytic-compile is used to support Windows.
-          # Install from pip once branch is merged and crytic-compile released
-          pip install "crytic-compile@https://github.com/crytic/crytic-compile/archive/refs/heads/dev-windows-long-paths.zip"
 
           python setup.py install
           pip install deepdiff

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -33,9 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # FIXME: patched crytic-compile is used to support Windows.
-          # Install from pip once branch is merged and crytic-compile released
-          pip install "crytic-compile@https://github.com/crytic/crytic-compile/archive/refs/heads/dev-windows-long-paths.zip"
 
           python setup.py install
           pip install deepdiff

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Lint everything else
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/.github/workflows/parser.yml
+++ b/.github/workflows/parser.yml
@@ -33,9 +33,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # FIXME: patched crytic-compile is used to support Windows.
-          # Install from pip once branch is merged and crytic-compile released
-          pip install "crytic-compile@https://github.com/crytic/crytic-compile/archive/refs/heads/dev-windows-long-paths.zip"
 
           python setup.py install
           pip install deepdiff

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -36,7 +36,7 @@ jobs:
           cp pyproject.toml .github/linters
 
       - name: Pylint
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v4.9.2
         if: always()
         env:
           # run linter on everything to catch preexisting problems

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ To run them locally in the root dir of the repository:
 - `pylint slither tests --rcfile pyproject.toml`
 - `black . --config pyproject.toml`
 
-We use pylint `2.12.2` black `21.10b0`.
+We use pylint `2.13.4`, black `22.3.0`.
+
 ### Detectors tests
 
 For each new detector, at least one regression tests must be present.

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     install_requires=[
         "prettytable>=0.7.2",
         "pysha3>=1.0.2",
-        "crytic-compile>=0.2.2",
-        # "crytic-compile",
+        # "crytic-compile>=0.2.2",
+        "crytic-compile",
     ],
-    # dependency_links=["git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile"],
+    dependency_links=["git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile"],
     license="AGPL-3.0",
     long_description=long_description,
     entry_points={

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -43,8 +43,8 @@ Int = [
     "int256",
 ]
 
-Max_Int = {k: 2 ** (8 * i - 1) - 1 if i > 0 else 2 ** 255 - 1 for i, k in enumerate(Int)}
-Min_Int = {k: -(2 ** (8 * i - 1)) if i > 0 else -(2 ** 255) for i, k in enumerate(Int)}
+Max_Int = {k: 2 ** (8 * i - 1) - 1 if i > 0 else 2**255 - 1 for i, k in enumerate(Int)}
+Min_Int = {k: -(2 ** (8 * i - 1)) if i > 0 else -(2**255) for i, k in enumerate(Int)}
 
 Uint = [
     "uint",
@@ -82,7 +82,7 @@ Uint = [
     "uint256",
 ]
 
-Max_Uint = {k: 2 ** (8 * i) - 1 if i > 0 else 2 ** 256 - 1 for i, k in enumerate(Uint)}
+Max_Uint = {k: 2 ** (8 * i) - 1 if i > 0 else 2**256 - 1 for i, k in enumerate(Uint)}
 Min_Uint = {k: 0 for k in Uint}
 
 

--- a/slither/detectors/attributes/unimplemented_interface.py
+++ b/slither/detectors/attributes/unimplemented_interface.py
@@ -87,7 +87,7 @@ contract Something {
             if not intended_interface_is_subset_parent:
                 # Should not be a subset of an earlier determined intended_interface or derive from it
                 intended_interface_is_subset_intended = False
-                for intended_interface in intended_interfaces:
+                for intended_interface in list(intended_interfaces):
                     sigs_intended_interface = {
                         f.full_name for f in intended_interface.functions_entry_points
                     }

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -89,14 +89,10 @@ Solidity defines a [naming convention](https://solidity.readthedocs.io/en/v0.4.2
                 if func.is_constructor:
                     continue
                 if not self.is_mixed_case(func.name):
-                    if (
-                        func.visibility
-                        in [
-                            "internal",
-                            "private",
-                        ]
-                        and self.is_mixed_case_with_underscore(func.name)
-                    ):
+                    if func.visibility in [
+                        "internal",
+                        "private",
+                    ] and self.is_mixed_case_with_underscore(func.name):
                         continue
                     if func.name.startswith("echidna_") or func.name.startswith("crytic_"):
                         continue

--- a/slither/detectors/source/rtlo.py
+++ b/slither/detectors/source/rtlo.py
@@ -1,7 +1,7 @@
 import re
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 
-
+# pylint: disable=bidirectional-unicode
 class RightToLeftOverride(AbstractDetector):
     """
     Detect the usage of a Right-To-Left-Override (U+202E) character

--- a/slither/detectors/statements/type_based_tautology.py
+++ b/slither/detectors/statements/type_based_tautology.py
@@ -11,7 +11,7 @@ from slither.core.solidity_types.elementary_type import Int, Uint
 def typeRange(t):
     bits = int(t.split("int")[1])
     if t in Uint:
-        return 0, (2 ** bits) - 1
+        return 0, (2**bits) - 1
     if t in Int:
         v = (2 ** (bits - 1)) - 1
         return -v, v

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -170,10 +170,10 @@ def _fits_under_integer(val: int, can_be_int: bool, can_be_uint) -> List[str]:
     assert can_be_int | can_be_uint
     while n <= 256:
         if can_be_uint:
-            if val <= 2 ** n - 1:
+            if val <= 2**n - 1:
                 ret.append(f"uint{n}")
         if can_be_int:
-            if val <= (2 ** n) / 2 - 1:
+            if val <= (2**n) / 2 - 1:
                 ret.append(f"int{n}")
         n = n + 8
     return ret

--- a/slither/solc_parsing/yul/parse_yul.py
+++ b/slither/solc_parsing/yul/parse_yul.py
@@ -279,6 +279,7 @@ class YulBlock(YulScope):
 
     """
 
+    # pylint: disable=redefined-slots-in-subclass
     __slots__ = ["_entrypoint", "_parent_func", "_nodes", "node_scope"]
 
     def __init__(

--- a/slither/utils/integer_conversion.py
+++ b/slither/utils/integer_conversion.py
@@ -23,6 +23,6 @@ def convert_string_to_int(val: Union[str, int]) -> int:
                     f"{base}e{expo} is too large to fit in any Solidity integer size"
                 )
             return 0
-        return int(Decimal(base) * Decimal(10 ** expo))
+        return int(Decimal(base) * Decimal(10**expo))
 
     return int(Decimal(val))

--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -43,7 +43,7 @@ class ConstantFolding(ExpressionVisitor):
         left = get_val(expression.expression_left)
         right = get_val(expression.expression_right)
         if expression.type == BinaryOperationType.POWER:
-            set_val(expression, left ** right)
+            set_val(expression, left**right)
         elif expression.type == BinaryOperationType.MULTIPLICATION:
             set_val(expression, left * right)
         elif expression.type == BinaryOperationType.DIVISION:


### PR DESCRIPTION
This PR cleanup our CI to use a fix version of gh super linter, to avoid
breaking the CI on new super linter release. Additionally it update our linters, the new versions:

- pylint 2.13.4
- black 22.3.0

Similar to https://github.com/crytic/crytic-compile/pull/252