### PR TITLE
fix shell rendering in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
       description: |
           Please copy and paste any relevant log output. This 
           will be automatically formatted into code, so no need for backticks.
-          render: shell
+      render: shell
       label: "Relevant log output:"
     id: logs
     type: textarea


### PR DESCRIPTION
The "Relevant log output" wasn't rendering as a code snippet due to some extra indentation