### PR TITLE
Prevent a TypeError on Function.__str__

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1724,6 +1724,6 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
     ###################################################################################
 
     def __str__(self):
-        return self._name
+        return self.name
 
     # endregion


### PR DESCRIPTION
`Function.__str__` used to return `self._name`. However, for special function types this value can be `None`, which causes `__str__` to raise a `TypeError` at runtime. This small change uses `self.name` instead, which is a property that returns valid strings for all special function types.

Fixes #1170 