### PR TITLE
Unify path filtering across POSIX and Windows

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import pathlib
+import posixpath
 import re
 from typing import Optional, Dict, List, Set, Union
 
@@ -173,7 +174,7 @@ class SlitherCore(Context):
             return False
         mapping_elements_with_lines = (
             (
-                str(pathlib.Path(elem["source_mapping"]["filename_absolute"]).resolve()),
+                posixpath.normpath(elem["source_mapping"]["filename_absolute"]),
                 elem["source_mapping"]["lines"],
             )
             for elem in r["elements"]

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -4,7 +4,7 @@
 import json
 import logging
 import os
-import posixpath
+import pathlib
 import re
 from typing import Optional, Dict, List, Set, Union
 
@@ -173,7 +173,7 @@ class SlitherCore(Context):
             return False
         mapping_elements_with_lines = (
             (
-                posixpath.normpath(elem["source_mapping"]["filename_absolute"]),
+                str(pathlib.Path(elem["source_mapping"]["filename_absolute"]).resolve()),
                 elem["source_mapping"]["lines"],
             )
             for elem in r["elements"]
@@ -218,8 +218,12 @@ class SlitherCore(Context):
             for elem in r["elements"]
             if "source_mapping" in elem
         ]
-        source_mapping_elements = map(
-            lambda x: posixpath.normpath(x) if x else x, source_mapping_elements
+
+        # Use POSIX-style paths so that filter_paths works across different
+        # OSes. Convert to a list so elements don't get consumed and are lost
+        # while evaluating the first pattern
+        source_mapping_elements = list(
+            map(lambda x: pathlib.Path(x).resolve().as_posix() if x else x, source_mapping_elements)
         )
         matching = False
 


### PR DESCRIPTION
Path filtering is performed on absolute paths, which causes regexps
to not work uniformly across OSes, due to the different path separator
(forward vs backward slashes). This converts paths to POSIX-style
before filtering, so that regexps can be written in a single style
and work across all systems.

Fixes: #1191