### PR TITLE
Optimization: use a more efficient regexp for hexadecimal check

### DIFF
--- a/slither/detectors/statements/too_many_digits.py
+++ b/slither/detectors/statements/too_many_digits.py
@@ -6,7 +6,7 @@ import re
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from slither.slithir.variables import Constant
 
-_HEX_ADDRESS_REGEXP = re.compile("(0x)?[0-9a-f]{40}", re.IGNORECASE | re.ASCII)
+_HEX_ADDRESS_REGEXP = re.compile("(0[xX])?[0-9a-fA-F]{40}")
 
 
 def is_hex_address(value) -> bool:


### PR DESCRIPTION
Quick benchmarks (reusing values from https://github.com/ethereum/eth-utils/pull/223/commits/f0139f0d4e98370344a27254b777f7e62ac260f2, I know TX hash is irrelevant here, but results should be the same for addresses):

- When `value` is hexadecimal string (TX hash):
  - before: 1.0965 sec
  - after : 0.3652 sec (-66.7 %)

- When `value` is not hexadecimal string (TX hash + 'g'):
  - before: 1.4546 sec
  - after : 0.7022 sec (-51.7 %)