### PR TITLE
Unused ternary param

### DIFF
--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -74,6 +74,11 @@ class SplitTernaryExpression:
     def copy_expression(
         self, expression: Expression, true_expression: Expression, false_expression: Expression
     ) -> None:
+        # case of unused
+        # (, var) = func()
+        if not expression:
+            return
+
         if self.condition:
             return
 


### PR DESCRIPTION
Fixes https://github.com/crytic/slither/issues/1153
I'm not sure if there's a better way to address unused tuple members, but this works.

slither 0xed3a954c0adfc8e3f85d92729c051ff320648e30 --print slithir
```
Expression: guni.token1() == DAI
                IRs:
                        TMP_121(address) = HIGH_LEVEL_CALL, dest:guni(IGUNIToken), function:token1, arguments:[]  
                        TMP_122(bool) = TMP_121 == DAI
                        CONDITION TMP_122
                Expression: (None,amount) = resolver.getRebalanceParams(address(guni),bal0,bal0,((((sqrtPriceX96 * sqrtPriceX96) >> 96) * 1e18) >> 96) * otherTokenTo18Conv)
                IRs:
                        TMP_123 = CONVERT guni to address
                        TMP_124(uint256) = sqrtPriceX96 * sqrtPriceX96
                        TMP_125(uint256) = TMP_124 >> 96
                        TMP_126(uint256) = TMP_125 * 1000000000000000000
                        TMP_127(uint256) = TMP_126 >> 96
                        TMP_128(uint256) = TMP_127 * otherTokenTo18Conv
                        TUPLE_4(bool,uint256) = HIGH_LEVEL_CALL, dest:resolver(IGUNIResolver), function:getRebalanceParams, arguments:['TMP_123', 'bal0', 'bal0', 'TMP_128']  
                        amount(uint256)= UNPACK TUPLE_4 index: 1 
                Expression: (None,amount) = resolver.getRebalanceParams(address(guni),0,0,((((sqrtPriceX96 * sqrtPriceX96) >> 96) * 1e18) >> 96) * otherTokenTo18Conv)
                IRs:
                        TMP_129 = CONVERT guni to address
                        TMP_130(uint256) = sqrtPriceX96 * sqrtPriceX96
                        TMP_131(uint256) = TMP_130 >> 96
                        TMP_132(uint256) = TMP_131 * 1000000000000000000
                        TMP_133(uint256) = TMP_132 >> 96
                        TMP_134(uint256) = TMP_133 * otherTokenTo18Conv
                        TUPLE_5(bool,uint256) = HIGH_LEVEL_CALL, dest:resolver(IGUNIResolver), function:getRebalanceParams, arguments:['TMP_129', '0', '0', 'TMP_134']  
                        amount(uint256)= UNPACK TUPLE_5 index: 1 
```