### PR TITLE
Fix Wrong Argument Annoations in Slither

### DIFF
--- a/slither/slither.py
+++ b/slither/slither.py
@@ -53,7 +53,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         Keyword Args:
             solc (str): solc binary location (default 'solc')
             disable_solc_warnings (bool): True to disable solc warnings (default false)
-            solc_arguments (str): solc arguments (default '')
+            solc_args (str): solc arguments (default '')
             ast_format (str): ast format (default '--ast-compact-json')
             filter_paths (list(str)): list of path to filter (default [])
             triage_mode (bool): if true, switch to triage mode (default false)


### PR DESCRIPTION
Few days ago, when I was trying to pass the `solc` compiling options to `Slither` by using the argument `solc_args`, e.g., `Slither(my_contract, solc_arguments=my_args)`, it did not function. I checked the `crytic-compile` source code and found that the argument `crytic-compile` actually takes is `solc_args` instead of `solc_arguments`, as the link [here](https://github.com/crytic/crytic-compile/blob/master/crytic_compile/platform/solc.py#L232) and following code segment shows. The argument annotation in slither.py is wrong and it will mislead developers to pass the `solc` compiling options with wrong keys.

```python
    solc: str = kwargs.get("solc", "solc")
    solc_disable_warnings: bool = kwargs.get("solc_disable_warnings", False)
    solc_arguments: str = kwargs.get("solc_args", "")
    solc_remaps: Optional[Union[str, List[str]]] = kwargs.get("solc_remaps", None)
```