### PR TITLE
correct instances of typo throughout repo: initiliaze -> initialize

### DIFF
--- a/slither/detectors/statements/unprotected_upgradeable.py
+++ b/slither/detectors/statements/unprotected_upgradeable.py
@@ -102,7 +102,7 @@ class UnprotectedUpgradeable(AbstractDetector):
                             info = (
                                 [
                                     contract,
-                                    " is an upgradeable contract that does not protect its initiliaze functions: ",
+                                    " is an upgradeable contract that does not protect its initialize functions: ",
                                 ]
                                 + initialize_functions
                                 + [

--- a/slither/tools/upgradeability/checks/initialization.py
+++ b/slither/tools/upgradeability/checks/initialization.py
@@ -15,7 +15,7 @@ class MultipleInitTarget(Exception):
     pass
 
 
-def _has_initiliaze_modifier(function: Function):
+def _has_initialize_modifier(function: Function):
     if not function.modifiers:
         return False
     return any((m.name == "initializer") for m in function.modifiers)
@@ -25,7 +25,7 @@ def _get_initialize_functions(contract):
     return [
         f
         for f in contract.functions
-        if (f.name == "initialize" or _has_initiliaze_modifier(f)) and f.is_implemented
+        if (f.name == "initialize" or _has_initialize_modifier(f)) and f.is_implemented
     ]
 
 
@@ -313,7 +313,7 @@ contract DerivedDerived is Derived{
 }
 
 ```
-`Base.initialize(uint)` is called two times in `DerivedDerived.initiliaze` execution, leading to a potential corruption.
+`Base.initialize(uint)` is called two times in `DerivedDerived.initialize` execution, leading to a potential corruption.
 """
     # endregion wiki_exploit_scenario
 

--- a/tests/detectors/uninitialized-state/0.4.25/uninitialized.sol
+++ b/tests/detectors/uninitialized-state/0.4.25/uninitialized.sol
@@ -43,16 +43,16 @@ contract Test2 {
     using Lib for Lib.MyStruct;
 
     Lib.MyStruct st;
-    Lib.MyStruct stInitiliazed;
+    Lib.MyStruct stinitialized;
     uint v; // v is used as parameter of the lib, but is never init
 
     function init(){
-        stInitiliazed.set(v);
+        stinitialized.set(v);
     }
 
     function use(){
         // random operation to use the structure
-        require(st.val  == stInitiliazed.val);
+        require(st.val  == stinitialized.val);
     }
 
 }

--- a/tests/detectors/uninitialized-state/0.5.16/uninitialized.sol
+++ b/tests/detectors/uninitialized-state/0.5.16/uninitialized.sol
@@ -43,16 +43,16 @@ contract Test2 {
     using Lib for Lib.MyStruct;
 
     Lib.MyStruct st;
-    Lib.MyStruct stInitiliazed;
+    Lib.MyStruct stinitialized;
     uint v; // v is used as parameter of the lib, but is never init
 
     function init() public{
-        stInitiliazed.set(v);
+        stinitialized.set(v);
     }
 
     function use() view public{
         // random operation to use the structure
-        require(st.val  == stInitiliazed.val);
+        require(st.val  == stinitialized.val);
     }
 
 }

--- a/tests/detectors/uninitialized-state/0.6.11/uninitialized.sol
+++ b/tests/detectors/uninitialized-state/0.6.11/uninitialized.sol
@@ -43,16 +43,16 @@ contract Test2 {
     using Lib for Lib.MyStruct;
 
     Lib.MyStruct st;
-    Lib.MyStruct stInitiliazed;
+    Lib.MyStruct stinitialized;
     uint v; // v is used as parameter of the lib, but is never init
 
     function init() public{
-        stInitiliazed.set(v);
+        stinitialized.set(v);
     }
 
     function use() view public{
         // random operation to use the structure
-        require(st.val  == stInitiliazed.val);
+        require(st.val  == stinitialized.val);
     }
 
 }

--- a/tests/detectors/uninitialized-state/0.7.6/uninitialized.sol
+++ b/tests/detectors/uninitialized-state/0.7.6/uninitialized.sol
@@ -43,16 +43,16 @@ contract Test2 {
     using Lib for Lib.MyStruct;
 
     Lib.MyStruct st;
-    Lib.MyStruct stInitiliazed;
+    Lib.MyStruct stinitialized;
     uint v; // v is used as parameter of the lib, but is never init
 
     function init() public{
-        stInitiliazed.set(v);
+        stinitialized.set(v);
     }
 
     function use() view public{
         // random operation to use the structure
-        require(st.val  == stInitiliazed.val);
+        require(st.val  == stinitialized.val);
     }
 
 }

--- a/tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol.0.4.25.UnprotectedUpgradeable.json
+++ b/tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol.0.4.25.UnprotectedUpgradeable.json
@@ -141,8 +141,8 @@
                     }
                 }
             ],
-            "description": "Buggy (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#3-15) is an upgradeable contract that does not protect its initiliaze functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#10-13)",
-            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initiliaze functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L10-L13)",
+            "description": "Buggy (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#3-15) is an upgradeable contract that does not protect its initialize functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#10-13)",
+            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initialize functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L10-L13)",
             "first_markdown_element": "tests/detectors/unprotected-upgrade/0.4.25/Buggy.sol#L3-L15",
             "id": "aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe",
             "check": "unprotected-upgrade",

--- a/tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol.0.5.16.UnprotectedUpgradeable.json
+++ b/tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol.0.5.16.UnprotectedUpgradeable.json
@@ -141,8 +141,8 @@
                     }
                 }
             ],
-            "description": "Buggy (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#3-15) is an upgradeable contract that does not protect its initiliaze functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#10-13)",
-            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initiliaze functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L10-L13)",
+            "description": "Buggy (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#3-15) is an upgradeable contract that does not protect its initialize functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#10-13)",
+            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initialize functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L10-L13)",
             "first_markdown_element": "tests/detectors/unprotected-upgrade/0.5.16/Buggy.sol#L3-L15",
             "id": "aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe",
             "check": "unprotected-upgrade",

--- a/tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol.0.6.11.UnprotectedUpgradeable.json
+++ b/tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol.0.6.11.UnprotectedUpgradeable.json
@@ -141,8 +141,8 @@
                     }
                 }
             ],
-            "description": "Buggy (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#3-15) is an upgradeable contract that does not protect its initiliaze functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#10-13)",
-            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initiliaze functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L10-L13)",
+            "description": "Buggy (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#3-15) is an upgradeable contract that does not protect its initialize functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#10-13)",
+            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initialize functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L10-L13)",
             "first_markdown_element": "tests/detectors/unprotected-upgrade/0.6.11/Buggy.sol#L3-L15",
             "id": "aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe",
             "check": "unprotected-upgrade",

--- a/tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol.0.7.6.UnprotectedUpgradeable.json
+++ b/tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol.0.7.6.UnprotectedUpgradeable.json
@@ -141,8 +141,8 @@
                     }
                 }
             ],
-            "description": "Buggy (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#3-15) is an upgradeable contract that does not protect its initiliaze functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#10-13)",
-            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initiliaze functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L10-L13)",
+            "description": "Buggy (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#3-15) is an upgradeable contract that does not protect its initialize functions: Buggy.initialize() (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#6-9). Anyone can delete the contract with: Buggy.kill() (tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#10-13)",
+            "markdown": "[Buggy](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L3-L15) is an upgradeable contract that does not protect its initialize functions: [Buggy.initialize()](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L6-L9). Anyone can delete the contract with: [Buggy.kill()](tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L10-L13)",
             "first_markdown_element": "tests/detectors/unprotected-upgrade/0.7.6/Buggy.sol#L3-L15",
             "id": "aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe",
             "check": "unprotected-upgrade",


### PR DESCRIPTION
WIP, though, and would like advising--when replacing all instances, 4 related tests fail.

Advice on how to get those tests passing to get this corrected welcome.

```python
~/code/forks/slither$ pytest ./tests/test_detectors.py
========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.9.5, pytest-7.1.1, pluggy-1.0.0
rootdir: /home/kyle/code/forks/slither
plugins: mock-3.7.0, cov-3.0.0
collected 291 items                                                                                                                                                                                      

tests/test_detectors.py .......................................................................................................................................................................... [ 58%]
......................F..F..F..F.........................................................................................                                                                          [100%]

================================================================================================ FAILURES ================================================================================================
_________________________________________ test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.4.25/Buggy.sol] _________________________________________

test_item = <tests.test_detectors.Test object at 0x7fba0cb16280>

    @pytest.mark.parametrize("test_item", ALL_TESTS, ids=id_test)
    def test_detector(test_item: Test):
        test_dir_path = pathlib.Path(
            pathlib.Path().absolute(),
            "tests",
            "detectors",
            test_item.detector.ARGUMENT,
            test_item.solc_ver,
        )
        test_file_path = str(pathlib.Path(test_dir_path, test_item.test_file))
        expected_result_path = str(pathlib.Path(test_dir_path, test_item.expected_result).absolute())
    
        set_solc(test_item)
        sl = Slither(test_file_path)
        sl.register_detector(test_item.detector)
        results = sl.run_detectors()
    
        with open(expected_result_path, encoding="utf8") as f:
            expected_result = json.load(f)
    
        results_as_string = json.dumps(results)
    
        for additional_file in test_item.additional_files:
            additional_path = str(pathlib.Path(test_dir_path, additional_file).absolute())
            additional_path = additional_path.replace("\\", "\\\\")
            results_as_string = results_as_string.replace(additional_path, GENERIC_PATH)
        test_file_path = test_file_path.replace("\\", "\\\\")
        results_as_string = results_as_string.replace(test_file_path, GENERIC_PATH)
        results = json.loads(results_as_string)
    
        diff = DeepDiff(results, expected_result, ignore_order=True, verbose_level=2)
        if diff:
            pprint(diff)
            diff_as_dict = diff.to_dict()
    
            if "iterable_item_added" in diff_as_dict:
                print("#### Findings added")
                for finding_added in diff_as_dict["iterable_item_added"].values():
                    print(finding_added["description"])
            if "iterable_item_removed" in diff_as_dict:
                print("#### Findings removed")
                for finding_added in diff_as_dict["iterable_item_removed"].values():
                    print(finding_added["description"])
>           assert False
E           assert False

tests/test_detectors.py:1391: AssertionError
------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------
{'values_changed': {"root[0][0]['id']": {'new_value': 'aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe',
                                         'old_value': 'd85b90230632a30f7ffb5140a791d4a9ae8b0be045c5b27175f3c477e189c08c'}}}
_________________________________________ test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.5.16/Buggy.sol] _________________________________________

test_item = <tests.test_detectors.Test object at 0x7fba0cb163a0>

    @pytest.mark.parametrize("test_item", ALL_TESTS, ids=id_test)
    def test_detector(test_item: Test):
        test_dir_path = pathlib.Path(
            pathlib.Path().absolute(),
            "tests",
            "detectors",
            test_item.detector.ARGUMENT,
            test_item.solc_ver,
        )
        test_file_path = str(pathlib.Path(test_dir_path, test_item.test_file))
        expected_result_path = str(pathlib.Path(test_dir_path, test_item.expected_result).absolute())
    
        set_solc(test_item)
        sl = Slither(test_file_path)
        sl.register_detector(test_item.detector)
        results = sl.run_detectors()
    
        with open(expected_result_path, encoding="utf8") as f:
            expected_result = json.load(f)
    
        results_as_string = json.dumps(results)
    
        for additional_file in test_item.additional_files:
            additional_path = str(pathlib.Path(test_dir_path, additional_file).absolute())
            additional_path = additional_path.replace("\\", "\\\\")
            results_as_string = results_as_string.replace(additional_path, GENERIC_PATH)
        test_file_path = test_file_path.replace("\\", "\\\\")
        results_as_string = results_as_string.replace(test_file_path, GENERIC_PATH)
        results = json.loads(results_as_string)
    
        diff = DeepDiff(results, expected_result, ignore_order=True, verbose_level=2)
        if diff:
            pprint(diff)
            diff_as_dict = diff.to_dict()
    
            if "iterable_item_added" in diff_as_dict:
                print("#### Findings added")
                for finding_added in diff_as_dict["iterable_item_added"].values():
                    print(finding_added["description"])
            if "iterable_item_removed" in diff_as_dict:
                print("#### Findings removed")
                for finding_added in diff_as_dict["iterable_item_removed"].values():
                    print(finding_added["description"])
>           assert False
E           assert False

tests/test_detectors.py:1391: AssertionError
------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------
{'values_changed': {"root[0][0]['id']": {'new_value': 'aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe',
                                         'old_value': 'd85b90230632a30f7ffb5140a791d4a9ae8b0be045c5b27175f3c477e189c08c'}}}
_________________________________________ test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.6.11/Buggy.sol] _________________________________________

test_item = <tests.test_detectors.Test object at 0x7fba0cb164c0>

    @pytest.mark.parametrize("test_item", ALL_TESTS, ids=id_test)
    def test_detector(test_item: Test):
        test_dir_path = pathlib.Path(
            pathlib.Path().absolute(),
            "tests",
            "detectors",
            test_item.detector.ARGUMENT,
            test_item.solc_ver,
        )
        test_file_path = str(pathlib.Path(test_dir_path, test_item.test_file))
        expected_result_path = str(pathlib.Path(test_dir_path, test_item.expected_result).absolute())
    
        set_solc(test_item)
        sl = Slither(test_file_path)
        sl.register_detector(test_item.detector)
        results = sl.run_detectors()
    
        with open(expected_result_path, encoding="utf8") as f:
            expected_result = json.load(f)
    
        results_as_string = json.dumps(results)
    
        for additional_file in test_item.additional_files:
            additional_path = str(pathlib.Path(test_dir_path, additional_file).absolute())
            additional_path = additional_path.replace("\\", "\\\\")
            results_as_string = results_as_string.replace(additional_path, GENERIC_PATH)
        test_file_path = test_file_path.replace("\\", "\\\\")
        results_as_string = results_as_string.replace(test_file_path, GENERIC_PATH)
        results = json.loads(results_as_string)
    
        diff = DeepDiff(results, expected_result, ignore_order=True, verbose_level=2)
        if diff:
            pprint(diff)
            diff_as_dict = diff.to_dict()
    
            if "iterable_item_added" in diff_as_dict:
                print("#### Findings added")
                for finding_added in diff_as_dict["iterable_item_added"].values():
                    print(finding_added["description"])
            if "iterable_item_removed" in diff_as_dict:
                print("#### Findings removed")
                for finding_added in diff_as_dict["iterable_item_removed"].values():
                    print(finding_added["description"])
>           assert False
E           assert False

tests/test_detectors.py:1391: AssertionError
------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------
{'values_changed': {"root[0][0]['id']": {'new_value': 'aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe',
                                         'old_value': 'd85b90230632a30f7ffb5140a791d4a9ae8b0be045c5b27175f3c477e189c08c'}}}
_________________________________________ test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.7.6/Buggy.sol] __________________________________________

test_item = <tests.test_detectors.Test object at 0x7fba0cb165e0>

    @pytest.mark.parametrize("test_item", ALL_TESTS, ids=id_test)
    def test_detector(test_item: Test):
        test_dir_path = pathlib.Path(
            pathlib.Path().absolute(),
            "tests",
            "detectors",
            test_item.detector.ARGUMENT,
            test_item.solc_ver,
        )
        test_file_path = str(pathlib.Path(test_dir_path, test_item.test_file))
        expected_result_path = str(pathlib.Path(test_dir_path, test_item.expected_result).absolute())
    
        set_solc(test_item)
        sl = Slither(test_file_path)
        sl.register_detector(test_item.detector)
        results = sl.run_detectors()
    
        with open(expected_result_path, encoding="utf8") as f:
            expected_result = json.load(f)
    
        results_as_string = json.dumps(results)
    
        for additional_file in test_item.additional_files:
            additional_path = str(pathlib.Path(test_dir_path, additional_file).absolute())
            additional_path = additional_path.replace("\\", "\\\\")
            results_as_string = results_as_string.replace(additional_path, GENERIC_PATH)
        test_file_path = test_file_path.replace("\\", "\\\\")
        results_as_string = results_as_string.replace(test_file_path, GENERIC_PATH)
        results = json.loads(results_as_string)
    
        diff = DeepDiff(results, expected_result, ignore_order=True, verbose_level=2)
        if diff:
            pprint(diff)
            diff_as_dict = diff.to_dict()
    
            if "iterable_item_added" in diff_as_dict:
                print("#### Findings added")
                for finding_added in diff_as_dict["iterable_item_added"].values():
                    print(finding_added["description"])
            if "iterable_item_removed" in diff_as_dict:
                print("#### Findings removed")
                for finding_added in diff_as_dict["iterable_item_removed"].values():
                    print(finding_added["description"])
>           assert False
E           assert False

tests/test_detectors.py:1391: AssertionError
------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------
{'values_changed': {"root[0][0]['id']": {'new_value': 'aceca400ce0b482809a70df612af22e24d154c5c89c24d630ec0ee5a366d09fe',
                                         'old_value': 'd85b90230632a30f7ffb5140a791d4a9ae8b0be045c5b27175f3c477e189c08c'}}}
============================================================================================ warnings summary ============================================================================================
tests/test_detectors.py:19
  /home/kyle/code/forks/slither/tests/test_detectors.py:19: PytestCollectionWarning: cannot collect test class 'Test' because it has a __init__ constructor (from: tests/test_detectors.py)
    class Test:  # pylint: disable=too-few-public-methods

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== short test summary info =========================================================================================
FAILED tests/test_detectors.py::test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.4.25/Buggy.sol] - assert False
FAILED tests/test_detectors.py::test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.5.16/Buggy.sol] - assert False
FAILED tests/test_detectors.py::test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.6.11/Buggy.sol] - assert False
FAILED tests/test_detectors.py::test_detector[<class 'slither.detectors.statements.unprotected_upgradeable.UnprotectedUpgradeable'>: 0.7.6/Buggy.sol] - assert False
=============================================================================== 4 failed, 287 passed, 1 warning in 24.65s ================================================================================

```