### PR TITLE
Dockerfile: upgrade from Ubuntu Bionic (18.04) to Focal (20.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL name=slither
 LABEL src="https://github.com/trailofbits/slither"
@@ -6,11 +6,12 @@ LABEL creator=trailofbits
 LABEL dockerfile_maintenance=trailofbits
 LABEL desc="Static Analyzer for Solidity"
 
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y git python3 python3-setuptools wget software-properties-common
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get upgrade -yq \
+  && apt-get install -yq gcc git python3 python3-dev python3-setuptools wget software-properties-common
 
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
+RUN wget -q https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
  && chmod +x solc-static-linux \
  && mv solc-static-linux /usr/bin/solc
 


### PR DESCRIPTION
It fixes the following Python error when running slither:

```
  AttributeError: module 'typing' has no attribute '_SpecialForm'
```