### PR TITLE
fix: typo in slither-read-storage cli helper text

### DIFF
--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -23,7 +23,7 @@ def parse_args() -> argparse.Namespace:
             + "To retrieve a contract's storage layout:\n"
             + "\tslither-read-storage $TARGET address --contract-name $NAME --layout\n"
             + "To retrieve a contract's storage layout and values:\n"
-            + "\tslither-read-storage $TARGET address --contract-name $NAME --layout --values\n"
+            + "\tslither-read-storage $TARGET address --contract-name $NAME --layout --value\n"
             + "TARGET can be a contract address or project directory"
         ),
     )


### PR DESCRIPTION
note:
- required argument is --value but helper text says --values