### PR TITLE
Update divide_before_multiply.py

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -315,7 +315,7 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
 
     group_printer.add_argument(
         "--print",
-        help="Comma-separated list fo contract information printers, "
+        help="Comma-separated list of contract information printers, "
         f"available printers: {', '.join(d.ARGUMENT for d in printer_classes)}",
         action="store",
         dest="printers_to_run",

--- a/slither/detectors/statements/divide_before_multiply.py
+++ b/slither/detectors/statements/divide_before_multiply.py
@@ -189,7 +189,7 @@ In general, it's usually a good idea to re-arrange arithmetic to perform multipl
                     nodes.sort(key=lambda x: x.node_id)
 
                     for node in nodes:
-                        info += ["\t-", node, "\n"]
+                        info += ["\t- ", node, "\n"]
 
                     res = self.generate_result(info)
                     results.append(res)


### PR DESCRIPTION
Missing space in string causes formatting issues when this detector is included in `--checklist` output.

Included screenshot of broken formatting, with the last entry being manually fixed by adding the space after the `-`

![image](https://user-images.githubusercontent.com/6581761/182653014-b66eee7b-6a4e-4a98-aa7f-1aea2858a541.png)
