### PR TITLE
Return proper function names for `fallback()` and `receive()`

### DIFF
--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -35,8 +35,10 @@ from slither.slithir.variables import Constant
 def _get_name(f: Union[Function, Variable]) -> str:
     # Return the name of the function or variable
     if isinstance(f, Function):
-        if f.is_fallback or f.is_receive:
-            return "()"
+        if f.is_fallback:
+            return "fallback()"
+        elif f.is_receive:
+            return "receive()"
     return f.solidity_signature
 
 


### PR DESCRIPTION
Makes slither return proper function names for `fallback()` and `receive()` instead of `()`. Implements the following suggestion: https://github.com/crytic/slither/issues/1331#issuecomment-1208637675 by @plotchy

Closes #1331 