### PR TITLE
Update Dockerfile and add Actions workflow to build it

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - dev-update-dockerfile
+      - dev
     tags:
       - '*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+      - dev-update-dockerfile
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Set Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=branch,prefix=testing-
+            type=edge
+
+      - name: GitHub Container Registry Login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          target: final
+          file: Dockerfile
+          pull: true
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
-FROM ubuntu:focal
+# syntax=docker/dockerfile:1.3
+FROM ubuntu:jammy AS python-wheels
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    gcc \
+    python3-dev \
+    python3-pip
+
+COPY . /slither
+
+RUN cd /slither && \
+    echo pip3 install --no-cache-dir --upgrade pip && \
+    pip3 wheel -w /wheels . pip setuptools wheel
+
+
+FROM ubuntu:jammy AS final
 
 LABEL name=slither
 LABEL src="https://github.com/trailofbits/slither"
@@ -8,8 +22,7 @@ LABEL desc="Static Analyzer for Solidity"
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get upgrade -yq \
-  && apt-get install -yq gcc git python3 python3-dev python3-setuptools wget software-properties-common
+  && apt-get install -y python3-pip wget
 
 RUN wget -q https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
  && chmod +x solc-static-linux \
@@ -24,6 +37,10 @@ RUN [ "c9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580  /usr/bi
 COPY --chown=slither:slither . /home/slither/slither
 WORKDIR /home/slither/slither
 
-RUN python3 setup.py install --user
 ENV PATH="/home/slither/.local/bin:${PATH}"
+
+# no-index ensures we install the freshly-built wheels
+RUN --mount=type=bind,target=/mnt,source=/wheels,from=python-wheels \
+    pip3 install --user --no-cache-dir --upgrade --no-index --find-links /mnt pip slither-analyzer
+
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /slither
 
 RUN cd /slither && \
     echo pip3 install --no-cache-dir --upgrade pip && \
-    pip3 wheel -w /wheels . pip setuptools wheel
+    pip3 wheel -w /wheels . solc-select pip setuptools wheel
 
 
 FROM ubuntu:jammy AS final
@@ -22,17 +22,10 @@ LABEL desc="Static Analyzer for Solidity"
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y python3-pip wget
-
-RUN wget -q https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
- && chmod +x solc-static-linux \
- && mv solc-static-linux /usr/bin/solc
+  && apt-get install -y --no-install-recommends python3-pip
 
 RUN useradd -m slither
 USER slither
-
-# If this fails, the solc-static-linux binary has changed while it should not.
-RUN [ "c9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580  /usr/bin/solc" = "$(sha256sum /usr/bin/solc)" ]
 
 COPY --chown=slither:slither . /home/slither/slither
 WORKDIR /home/slither/slither
@@ -41,6 +34,8 @@ ENV PATH="/home/slither/.local/bin:${PATH}"
 
 # no-index ensures we install the freshly-built wheels
 RUN --mount=type=bind,target=/mnt,source=/wheels,from=python-wheels \
-    pip3 install --user --no-cache-dir --upgrade --no-index --find-links /mnt pip slither-analyzer
+    pip3 install --user --no-cache-dir --upgrade --no-index --find-links /mnt pip slither-analyzer solc-select
+
+RUN solc-select install 0.4.25 && solc-select use 0.4.25
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:jammy AS python-wheels
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gcc \
     python3-dev \
-    python3-pip
+    python3-pip \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY . /slither
 
@@ -22,7 +23,8 @@ LABEL desc="Static Analyzer for Solidity"
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y --no-install-recommends python3-pip
+  && apt-get install -y --no-install-recommends python3-pip \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m slither
 USER slither


### PR DESCRIPTION
This PR:
 * updates the Dockerfile base to Ubuntu Jammy (22.04)
 * separates build and install processes into two stages
 * replaces fixed solc binary with solc-select
 * adds a workflow that builds the container for
   *  linux/amd64 (x86_64 systems),
   *  linux/arm64 (ARM 64-bit systems, eg. Mac M1 with Docker Desktop)
   *  linux/arm/v7 (ARM 32-bit systems, eg. some SBC systems)
 * publishes the container on GHCR:
   * matching tagged builds for tag releases,
   * `edge` tag matching the latest `master` commit
   * `latest` tag matching the latest release
   * `testing-foo` matching the latest commit in branch `foo` (must be also enabled in the workflow `on: ..` section)

Closes: #937, #1330 