### PR TITLE
Fixed Pypi Markdown render

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     dependency_links=["git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile"],
     license="AGPL-3.0",
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     entry_points={
         "console_scripts": [
             "slither = slither.__main__:main",

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     dependency_links=["git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile"],
     license="AGPL-3.0",
     long_description=long_description,
+    long_description_content_type='text/markdown',
     entry_points={
         "console_scripts": [
             "slither = slither.__main__:main",


### PR DESCRIPTION
Added long_description_content_type value to have Pypi website correctly
render Readme.md with markdown
Fixes #1287 