### PR TITLE
implement eq for literal

### DIFF
--- a/slither/core/expressions/literal.py
+++ b/slither/core/expressions/literal.py
@@ -31,3 +31,8 @@ class Literal(Expression):
             return str(convert_subdenomination(self._value, self.subdenomination))
         # be sure to handle any character
         return str(self._value)
+
+    def __eq__(self, other):
+        if not isinstance(other, Literal):
+            return False
+        return (self.value, self.subdenomination) == (other.value, other.subdenomination)


### PR DESCRIPTION
Fixes https://github.com/crytic/slither/issues/1286
IR generated after this PR:
```
Contract Setter
        Function Setter.set(uint256[1],uint256,uint256) (*)
                Expression: self[key] = value
                IRs:
                        REF_0(uint256) -> self[key]
                        REF_0 (->self) := value(uint256)
Contract SetterTest
        Function SetterTest.f(uint256,uint256) (*)
                Expression: params.set(key,value)
                IRs:
                        LIBRARY_CALL, dest:Setter, function:Setter.set(uint256[1],uint256,uint256), arguments:['params', 'key', 'value'] 
```