### PR TITLE
Add the `--no-fail-pedantic` flag

### DIFF
--- a/scripts/ci_test_cli.sh
+++ b/scripts/ci_test_cli.sh
@@ -9,12 +9,12 @@ if ! slither "tests/config/test.sol" --solc-ast --no-fail-pedantic; then
     exit 1
 fi
 
-if ! slither "tests/config/test.sol" --solc-disable-warnings; then
+if ! slither "tests/config/test.sol" --solc-disable-warnings --no-fail-pedantic; then
     echo "--solc-disable-warnings failed"
     exit 1
 fi
 
-if ! slither "tests/config/test.sol" --disable-color; then
+if ! slither "tests/config/test.sol" --disable-color --no-fail-pedantic; then
     echo "--disable-color failed"
     exit 1
 fi

--- a/scripts/ci_test_cli.sh
+++ b/scripts/ci_test_cli.sh
@@ -4,7 +4,7 @@
 
 solc-select use 0.7.0
 
-if ! slither "tests/config/test.sol" --solc-ast; then
+if ! slither "tests/config/test.sol" --solc-ast --no-fail-pedantic; then
     echo "--solc-ast failed"
     exit 1
 fi

--- a/scripts/ci_test_truffle.sh
+++ b/scripts/ci_test_truffle.sh
@@ -14,7 +14,7 @@ nvm use --lts
 npm install -g truffle
 truffle unbox metacoin
 
-if ! slither .; then
+if ! slither . --no-fail-pedantic; then
     echo "Truffle test failed"
     exit 1
 fi

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -288,12 +288,6 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
     usage += "\t- 0x.. // a contract on mainet\n"
     usage += f"\t- NETWORK:0x.. // a contract on a different network. Supported networks: {','.join(x[:-1] for x in SUPPORTED_NETWORK)}\n"
 
-    class NoFailPedanticAction(argparse.Action):
-        """Custom argparse action that sets args.fail_pedantic to False if --no-fail-pedantic is used"""
-
-        def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, "fail_pedantic", False)
-
     parser = argparse.ArgumentParser(
         description="For usage information, see https://github.com/crytic/slither/wiki/Usage",
         usage=usage,
@@ -411,8 +405,8 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
     group_detector.add_argument(
         "--no-fail-pedantic",
         help="Don't fail immediately if a finding is detected",
-        nargs=0,
-        action=NoFailPedanticAction,
+        dest="fail_pedantic",
+        action="store_false",
         required=False,
     )
 

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -397,14 +397,14 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
 
     group_detector.add_argument(
         "--fail-pedantic",
-        help="Fail if any finding is detected",
+        help="Return the number of findings in the exit code",
         action="store_true",
         default=defaults_flag_in_config["fail_pedantic"],
     )
 
     group_detector.add_argument(
         "--no-fail-pedantic",
-        help="Don't fail immediately if a finding is detected",
+        help="Do not return the number of findings in the exit code. Opposite of --fail-pedantic",
         dest="fail_pedantic",
         action="store_false",
         required=False,

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -411,7 +411,9 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
     group_detector.add_argument(
         "--no-fail-pedantic",
         help="Don't fail immediately if a finding is detected",
+        nargs=0,
         action=NoFailPedanticAction,
+        required=False,
     )
 
     group_detector.add_argument(

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -288,6 +288,12 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
     usage += "\t- 0x.. // a contract on mainet\n"
     usage += f"\t- NETWORK:0x.. // a contract on a different network. Supported networks: {','.join(x[:-1] for x in SUPPORTED_NETWORK)}\n"
 
+    class NoFailPedanticAction(argparse.Action):
+        """Custom argparse action that sets args.fail_pedantic to False if --no-fail-pedantic is used"""
+
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, "fail_pedantic", False)
+
     parser = argparse.ArgumentParser(
         description="For usage information, see https://github.com/crytic/slither/wiki/Usage",
         usage=usage,
@@ -400,6 +406,12 @@ def parse_args(detector_classes, printer_classes):  # pylint: disable=too-many-s
         help="Fail if any finding is detected",
         action="store_true",
         default=defaults_flag_in_config["fail_pedantic"],
+    )
+
+    group_detector.add_argument(
+        "--no-fail-pedantic",
+        help="Don't fail immediately if a finding is detected",
+        action=NoFailPedanticAction,
     )
 
     group_detector.add_argument(

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -34,7 +34,7 @@ defaults_flag_in_config = {
     "exclude_low": False,
     "exclude_medium": False,
     "exclude_high": False,
-    "fail_pedantic": False,
+    "fail_pedantic": True,
     "fail_low": False,
     "fail_medium": False,
     "fail_high": False,


### PR DESCRIPTION
This PR adds the `--no-fail-pedantic` flag, which is the opposite of `--fail-pedantic`. It also changes the default which is now to set `--fail-pedantic` to `True`.