### PR TITLE
Added reference URLs to JSON output

### DIFF
--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -231,6 +231,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         output.data["check"] = self.ARGUMENT
         output.data["impact"] = classification_txt[self.IMPACT]
         output.data["confidence"] = classification_txt[self.CONFIDENCE]
+        output.data["reference"] = f"{self.WIKI}"
 
         return output
 


### PR DESCRIPTION
Added relevant URL links to the wiki page in the JSON output for each
detector triggered.

Fixes #1224 

Dumps reference url in the json file for each detector object. 