### PR TITLE
Constants detector: Also detect Contract types

### DIFF
--- a/slither/detectors/variables/possible_const_state_variables.py
+++ b/slither/detectors/variables/possible_const_state_variables.py
@@ -46,7 +46,7 @@ class ConstCandidateStateVars(AbstractDetector):
 
     @staticmethod
     def _valid_candidate(v):
-        return _is_valid_type(v) and not (v.is_constant or v.is_immutable)
+        return self._is_valid_type(v) and not (v.is_constant or v.is_immutable)
 
     # https://solidity.readthedocs.io/en/v0.5.2/contracts.html#constant-state-variables
     valid_solidity_function = [

--- a/slither/detectors/variables/possible_const_state_variables.py
+++ b/slither/detectors/variables/possible_const_state_variables.py
@@ -3,8 +3,10 @@ Module detecting state variables that could be declared as constant
 """
 from slither.core.compilation_unit import SlitherCompilationUnit
 from slither.core.solidity_types.elementary_type import ElementaryType
+from slither.core.solidity_types.user_defined_type import UserDefinedType
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from slither.visitors.expression.export_values import ExportValues
+from slither.core.declarations import Contract
 from slither.core.declarations.solidity_variables import SolidityFunction
 from slither.core.variables.state_variable import StateVariable
 from slither.formatters.variables.possible_const_state_variables import custom_format
@@ -29,9 +31,22 @@ class ConstCandidateStateVars(AbstractDetector):
     WIKI_DESCRIPTION = "Constant state variables should be declared constant to save gas."
     WIKI_RECOMMENDATION = "Add the `constant` attributes to state variables that never change."
 
+
+    @staticmethod
+    def _is_valid_type(v):
+        t = v.type
+        if isinstance(t, ElementaryType):
+            return True
+        if isinstance(t, UserDefinedType):
+            type_t = t.type
+            if isinstance(type_t, Contract):
+                return True
+        return False
+        
+
     @staticmethod
     def _valid_candidate(v):
-        return isinstance(v.type, ElementaryType) and not (v.is_constant or v.is_immutable)
+        return _is_valid_type(v) and not (v.is_constant or v.is_immutable)
 
     # https://solidity.readthedocs.io/en/v0.5.2/contracts.html#constant-state-variables
     valid_solidity_function = [

--- a/slither/detectors/variables/possible_const_state_variables.py
+++ b/slither/detectors/variables/possible_const_state_variables.py
@@ -37,10 +37,8 @@ class ConstCandidateStateVars(AbstractDetector):
         t = v.type
         if isinstance(t, ElementaryType):
             return True
-        if isinstance(t, UserDefinedType):
-            type_t = t.type
-            if isinstance(type_t, Contract):
-                return True
+        if isinstance(t, UserDefinedType) and isinstance(t.type, Contract):
+            return True
         return False
         
 

--- a/slither/detectors/variables/possible_const_state_variables.py
+++ b/slither/detectors/variables/possible_const_state_variables.py
@@ -44,7 +44,7 @@ class ConstCandidateStateVars(AbstractDetector):
 
     @staticmethod
     def _valid_candidate(v):
-        return self._is_valid_type(v) and not (v.is_constant or v.is_immutable)
+        return ConstCandidateStateVars._is_valid_type(v) and not (v.is_constant or v.is_immutable)
 
     # https://solidity.readthedocs.io/en/v0.5.2/contracts.html#constant-state-variables
     valid_solidity_function = [


### PR DESCRIPTION
Presently the constants detector does not detect Contract types.

Eg.

```
IERC20 public token = IERC20(0x0000000000000000000000000000000000000000);
```

This is not a big deal as hardcoding addresses like that is generally an anti-pattern. However, if someone ever forks the detector for immutable flagging, than this will definitely come in handy!

Please do test before merging: we use the slither python API and not the detector framework ourselves.

This pull request specifically checks that if the candidate type is not Elementary, it must be a user defined Contract.


Let us know if it makes sense to invert the check and perhaps focus on ignoring dynamic types instead (because this PR still doesn't catch const enums I think for example, or re-typed int's, though that's also easily extendable)