### PR TITLE
update readme & usage message to reference up-to-date flags

### DIFF
--- a/slither/tools/read_storage/README.md
+++ b/slither/tools/read_storage/README.md
@@ -18,7 +18,7 @@ optional arguments:
   --struct-var STRUCT_VAR           The name of the variable whose value will be returned from a struct.
   --storage-address STORAGE_ADDRESS The address of the storage contract (if a proxy pattern is used).
   --contract-name CONTRACT_NAME     The name of the logic contract.
-  --layout                          Toggle used to write a JSON file with the entire storage layout.
+  --json FILE                       Write the entire storage layout in JSON format to the specified FILE
   --value                           Toggle used to include values in output.
   --max-depth MAX_DEPTH             Max depth to search in data structure.
 ```
@@ -28,19 +28,19 @@ optional arguments:
 Retrieve the storage slots of a local contract:
 
 ```shell
-slither-read-storage file.sol 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --layout 
+slither-read-storage file.sol 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --json storage_layout.json
 ```
 
 Retrieve the storage slots of a contract verified on an Etherscan-like platform:
 
 ```shell
-slither-read-storage 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --layout
+slither-read-storage 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --json storage_layout.json
 ```
 
 To retrieve the values as well, pass `--value` and `--rpc-url $RPC_URL`:
 
 ```shell
-slither-read-storage 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --layout --rpc-url $RPC_URL --value
+slither-read-storage 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --json storage_layout.json --rpc-url $RPC_URL --value
 ```
 
 To view only the slot of the `slot0` structure variable, pass `--variable-name slot0`:
@@ -79,7 +79,7 @@ slither-read-storage 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF --variable-name 
   Take Avalanche, for instance:
 
   ```shell
-  slither-read-storage avax:0x0000000000000000000000000000000000000000 --layout --value --rpc-url $AVAX_RPC_URL
+  slither-read-storage avax:0x0000000000000000000000000000000000000000 --json storage_layout.json --value --rpc-url $AVAX_RPC_URL
   ```
 
 ## Limitations

--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -21,9 +21,9 @@ def parse_args() -> argparse.Namespace:
             "\nTo retrieve a single variable's value:\n"
             + "\tslither-read-storage $TARGET address --variable-name $NAME\n"
             + "To retrieve a contract's storage layout:\n"
-            + "\tslither-read-storage $TARGET address --contract-name $NAME --layout\n"
+            + "\tslither-read-storage $TARGET address --contract-name $NAME --json storage_layout.json\n"
             + "To retrieve a contract's storage layout and values:\n"
-            + "\tslither-read-storage $TARGET address --contract-name $NAME --layout --value\n"
+            + "\tslither-read-storage $TARGET address --contract-name $NAME --json storage_layout.json --value\n"
             + "TARGET can be a contract address or project directory"
         ),
     )


### PR DESCRIPTION
Little tweak that updates `slither-read-storage` docs to no longer reference the depreciated `--layout` cli arg