### PR TITLE
new detector: Unnamed Return Shadows Local

### DIFF
--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -87,3 +87,4 @@ from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
 from .variables.omitted_return_variables import OmittedReturnVariables
 from .shadowing.return_local import ReturnShadowsLocal
+from .shadowing.return_unnamed import UnnamedReturnShadowsLocal

--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -86,3 +86,4 @@ from .statements.delegatecall_in_loop import DelegatecallInLoop
 from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
 from .variables.omitted_return_variables import OmittedReturnVariables
+from .shadowing.return_local import ReturnShadowsLocal

--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -85,3 +85,4 @@ from .statements.msg_value_in_loop import MsgValueInLoop
 from .statements.delegatecall_in_loop import DelegatecallInLoop
 from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
+from .variables.omitted_return_variables import OmittedReturnVariables

--- a/slither/detectors/shadowing/return_local.py
+++ b/slither/detectors/shadowing/return_local.py
@@ -1,0 +1,98 @@
+"""
+Module detecting "Return Shadows Local"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+import re
+
+class ReturnShadowsLocal(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'shadowing-return-local'
+    HELP = 'Return Shadows Local'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#return-shadows-local"
+
+    WIKI_TITLE = 'Return Shadows Local'
+    WIKI_DESCRIPTION = 'Detects when return function without `return` statement shadows self-related local variables.'
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function shadowed() external view returns(uint val) {
+        uint val = 1;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """
+    1. Don't re-declare the type of return variables.
+    2. Add a `return` statement at the end of the function."""
+
+    ERR = {}
+    INFO = []
+
+    def info(self): #4/4 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, shadower_shadowed_pair in self.ERR.items():
+                result.append(bug_location)
+                result.append(" does not have `return` and has its return variable/s:\n• ")
+                pairs_left = len(shadower_shadowed_pair)
+                for shadower, shadowed in shadower_shadowed_pair:
+                    result.append(shadowed) #in local
+                    result.append(' shadowed by ')
+                    result.append(shadower) #from "returns(...)""
+                    if pairs_left>1: result.append('\n• ')
+                    pairs_left-=1
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_shadower_shadowed_pair(self, function): #3/4 ↑
+        shadower_shadowed_pairs = []
+
+        for return_var in function.returns: #potentially shadower
+            for local_var in function.variables: #potentially shadowed
+                try: # to prevent e.g. wrong format errors
+                    #get shadowing info, e.g., from "name_scope_0" extract "_scope_0"
+                    scope_part = re.sub(f'^{return_var.name}', "", local_var.name)
+                    #save "return_var" if shadows "local_var"
+                    if re.search('^_scope_[0-9]$', scope_part):
+                        shadower_shadowed_pairs.append([return_var, local_var])
+                except Exception as e:
+                    print(e); continue
+        return shadower_shadowed_pairs
+
+    def return_vars_named_in(self, function): #2/4 ↑
+        for var in function.returns:
+            if var.name=='':
+                return False
+        return True
+
+    def no_return_statement_in(self, function): #1/3 ↑
+        if len(function.nodes)==0: return False #ignore inherited interfaces
+        for node in function.nodes:
+            if node.type==NodeType.RETURN:
+                return False
+        return True
+
+    def _detect(self): # 0/4 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and self.no_return_statement_in(function) and self.return_vars_named_in(function):
+                                # ↓↓↓ error-potential zone ↓↓↓ #
+                    shadower_shadowed_pairs = self.detect_shadower_shadowed_pair(function)
+                    if shadower_shadowed_pairs: #[[shadowed, shadower], ...]
+                        self.ERR[function] = shadower_shadowed_pairs
+        return self.info()

--- a/slither/detectors/shadowing/return_unnamed.py
+++ b/slither/detectors/shadowing/return_unnamed.py
@@ -1,0 +1,83 @@
+"""
+Module detecting "Unnamed Return Shadows Local"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+
+class UnnamedReturnShadowsLocal(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'shadowing-return-unnamed'
+    HELP = 'Unnamed Return Shadows Local'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#unnamed-return-shadows-local"
+
+    WIKI_TITLE = 'Unnamed Return Shadows Local'
+    WIKI_DESCRIPTION = "Detects when return function without `return` statement has unnamed variables inside `returns`."
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function unnamed() external view returns(uint) {
+        uint val = 1;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """
+    1. Name return variables inside "returns(...)".
+    2. Add a `return` statement at the end of the function."""
+
+    ERR  = {}
+    INFO = []
+
+    def info(self): #3/3 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, unnamed_vars in self.ERR.items():
+                result.append(bug_location)
+                result.append(" does not have `return` and inside `returns` has unnamed variable/s:\n• ")
+                vars_left = len(unnamed_vars)
+                for var in unnamed_vars:
+                    result.append(f'"{var.type}" ')
+                    result.append(var)
+                    if vars_left>1: result.append('\n• ')
+                    vars_left-=1
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_unnamed_return_vars(self, function): #2/3 ↑
+        unnamed_return_vars = []
+
+        for var in function.returns:
+            if var.name=='':
+                unnamed_return_vars.append(var)
+        return unnamed_return_vars
+
+    def no_return_statement_in(self, function): #1/3 ↑
+        if len(function.nodes)==0: return False #ignore inherited interfaces
+        for node in function.nodes:
+            if node.type==NodeType.RETURN:
+                return False
+        return True
+
+    def _detect(self): # 0/3 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and self.no_return_statement_in(function):
+                                # ↓↓↓ error-potential zone ↓↓↓ #
+                    unnamed_return_vars = self.detect_unnamed_return_vars(function)
+                    if unnamed_return_vars:
+                        self.ERR[function] = unnamed_return_vars
+        return self.info()

--- a/slither/detectors/variables/omitted_return_variables.py
+++ b/slither/detectors/variables/omitted_return_variables.py
@@ -1,0 +1,85 @@
+"""
+Module detecting "Omitted Return Variables"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+
+class OmittedReturnVariables(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'variable-omitted'
+    HELP = 'Omitted Return Variables'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#omitted-return-variables"
+
+    WIKI_TITLE = 'Omitted Return Variables'
+    WIKI_DESCRIPTION = 'Detects when return function omits to return the declared return variables.'
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function omitted() external view returns(uint val) {
+        val = 1;
+        return 0;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """Return declared return variables."""
+
+    ERR = {}
+    INFO = []
+
+    def info(self): #3/3 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, omitted_var_pairs in self.ERR.items():
+                result.append(bug_location)
+                result.append(' has an omitted return variable/s:\n• ')
+                for declared, returned in omitted_var_pairs:
+                    result.append('declared: ')
+                    left = len(declared)
+                    for var in declared:
+                        result.append(var)
+                        if left>1: result.append(', ')
+                        left-=1
+                    result.append('\n• returned: ')
+                    result.append(returned)
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_omitted(self, return_vars, function): #2/3 ↑
+        omitted_pairs = []
+        for node in function.nodes:
+            if node.type==NodeType.RETURN and node.variables_read!=return_vars:
+                omitted_pairs.append([return_vars, node])
+        return omitted_pairs
+
+    def get_return_vars_from(self, function): #1/3 ↑
+        return_vars_names = []
+        for var in function.returns:
+            if var.name=='': return [] #ignore unnamed
+            return_vars_names.append(var)
+        return return_vars_names
+
+    def _detect(self): # 0/3 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and len(function.nodes)>0: #ignore inherited interfaces
+                    return_vars = self.get_return_vars_from(function)
+                    if return_vars:
+                        omitted_return_vars = self.detect_omitted(return_vars, function)
+                        if omitted_return_vars:
+                            self.ERR[function] = omitted_return_vars
+        return self.info()

--- a/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol
+++ b/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.8.7;
+
+contract ShadowedTest {
+    function shadowed0() external view returns(uint val) {
+        uint val = 1;
+    } //returns: 0 (instead of 1)
+
+    function shadowed1() external view returns(uint val1, uint val2) {
+        uint val1 = 1;
+        val2 = 2;
+    } //returns: 0, 2 (instead of 1, 2)
+
+    function shadowed2() external view returns(uint val1, uint val2) {
+        uint val1 = 1;
+        uint val2 = 2;
+    } //returns: 0, 0 (instead of 1, 2)
+}

--- a/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol.0.8.7.ReturnShadowsLocal.json
+++ b/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol.0.8.7.ReturnShadowsLocal.json
@@ -1,0 +1,769 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "shadowed0",
+                    "source_mapping": {
+                        "start": 52,
+                        "length": 82,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val_scope_0",
+                    "source_mapping": {
+                        "start": 115,
+                        "length": 12,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            5
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 21
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed0",
+                            "source_mapping": {
+                                "start": 52,
+                                "length": 82,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val",
+                    "source_mapping": {
+                        "start": 95,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed0",
+                            "source_mapping": {
+                                "start": 52,
+                                "length": 82,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "shadowed1",
+                    "source_mapping": {
+                        "start": 168,
+                        "length": 113,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8,
+                            9,
+                            10,
+                            11
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1_scope_0",
+                    "source_mapping": {
+                        "start": 243,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed1",
+                            "source_mapping": {
+                                "start": 168,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 211,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed1",
+                            "source_mapping": {
+                                "start": 168,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "shadowed2",
+                    "source_mapping": {
+                        "start": 321,
+                        "length": 118,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13,
+                            14,
+                            15,
+                            16
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1_scope_0",
+                    "source_mapping": {
+                        "start": 396,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            14
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 364,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2_scope_1",
+                    "source_mapping": {
+                        "start": 419,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 375,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 59,
+                        "ending_column": 68
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "ShadowedTest.shadowed0() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#4-6) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed0().val_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#5) shadowed by ShadowedTest.shadowed0().val (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#4)\nShadowedTest.shadowed1() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#8-11) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed1().val1_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#9) shadowed by ShadowedTest.shadowed1().val1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#8)\nShadowedTest.shadowed2() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13-16) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed2().val1_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#14) shadowed by ShadowedTest.shadowed2().val1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13)\n\u2022 ShadowedTest.shadowed2().val2_scope_1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#15) shadowed by ShadowedTest.shadowed2().val2 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13)\n",
+            "markdown": "[ShadowedTest.shadowed0()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4-L6) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed0().val_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L5) shadowed by [ShadowedTest.shadowed0().val](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4)\n[ShadowedTest.shadowed1()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L8-L11) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed1().val1_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L9) shadowed by [ShadowedTest.shadowed1().val1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L8)\n[ShadowedTest.shadowed2()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13-L16) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed2().val1_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L14) shadowed by [ShadowedTest.shadowed2().val1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13)\n\u2022 [ShadowedTest.shadowed2().val2_scope_1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L15) shadowed by [ShadowedTest.shadowed2().val2](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13)\n",
+            "first_markdown_element": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4-L6",
+            "id": "5efdb185c2bcf7e560cffc007ed66d38bec47e4944e68b50d8346b7660d86b4c",
+            "check": "shadowing-return-local",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol
+++ b/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.8.7;
+
+contract UnnamedTest {
+    function unnamed0() external view returns(uint) {
+        uint val = 1;
+    } //returns: 0 (instead of 1)
+
+    function unnamed1() external view returns(uint, uint val2) {
+        uint val1 = 1;
+        val2 = 2;
+    } //returns: 0, 2 (instead of 1, 2)
+
+    function unnamed2() external view returns(uint, uint) {
+        uint val1 = 1;
+        uint val2 = 2;
+    } //returns: 0, 0 (instead of 1, 2)
+}

--- a/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol.0.8.7.UnnamedReturnShadowsLocal.json
+++ b/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol.0.8.7.UnnamedReturnShadowsLocal.json
@@ -1,0 +1,474 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "unnamed0",
+                    "source_mapping": {
+                        "start": 51,
+                        "length": 77,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 93,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 77,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "unnamed1",
+                    "source_mapping": {
+                        "start": 162,
+                        "length": 107,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8,
+                            9,
+                            10,
+                            11
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 204,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed1",
+                            "source_mapping": {
+                                "start": 162,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "unnamed2",
+                    "source_mapping": {
+                        "start": 309,
+                        "length": 107,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13,
+                            14,
+                            15,
+                            16
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 351,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed2",
+                            "source_mapping": {
+                                "start": 309,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 357,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 53,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed2",
+                            "source_mapping": {
+                                "start": 309,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "UnnamedTest.unnamed0() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#4-6) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed0(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#4)\nUnnamedTest.unnamed1() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#8-11) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed1(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#8)\nUnnamedTest.unnamed2() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13-16) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed2(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13)\n\u2022 \"uint256\" UnnamedTest.unnamed2(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13)\n",
+            "markdown": "[UnnamedTest.unnamed0()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4-L6) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed0().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4)\n[UnnamedTest.unnamed1()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L8-L11) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed1().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L8)\n[UnnamedTest.unnamed2()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13-L16) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed2().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13)\n\u2022 \"uint256\" [UnnamedTest.unnamed2().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13)\n",
+            "first_markdown_element": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4-L6",
+            "id": "5f56d421341dc10a2682219e595fc5a155244ebf835c21f028bc2b97680a51c9",
+            "check": "shadowing-return-unnamed",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol
+++ b/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.8.7;
+
+contract OmittedTest {
+    function omitted0() external view returns(uint val) {
+        val = 1;
+        return 0;
+    } //returns: 0 (instead of 1)
+
+    function omitted1() external view returns(uint val1) {
+        val1 = 1;
+        uint val2 = 0;
+        return val2;
+    } //returns: 0 (instead of 1)
+
+    function omitted2() external view returns(uint val1, uint val2) {
+        val1 = 1;
+        val2 = 2;
+        uint val3 = 3;
+        return (val3, 4);
+    }//returns: (3, 4) (instead of 1, 2)
+}

--- a/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol.0.8.7.OmittedReturnVariables.json
+++ b/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol.0.8.7.OmittedReturnVariables.json
@@ -1,0 +1,749 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "omitted0",
+                    "source_mapping": {
+                        "start": 51,
+                        "length": 94,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6,
+                            7
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val",
+                    "source_mapping": {
+                        "start": 93,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 55
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 94,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "0",
+                    "source_mapping": {
+                        "start": 130,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            6
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 17
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 94,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "omitted1",
+                    "source_mapping": {
+                        "start": 179,
+                        "length": 122,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9,
+                            10,
+                            11,
+                            12,
+                            13
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 221,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted1",
+                            "source_mapping": {
+                                "start": 179,
+                                "length": 122,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 283,
+                        "length": 11,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            12
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 20
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted1",
+                            "source_mapping": {
+                                "start": 179,
+                                "length": 122,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "omitted2",
+                    "source_mapping": {
+                        "start": 335,
+                        "length": 156,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 377,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 388,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 58,
+                        "ending_column": 67
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "(val3,4)",
+                    "source_mapping": {
+                        "start": 468,
+                        "length": 16,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            19
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 25
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "OmittedTest.omitted0() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#4-7) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted0().val (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#4)\n\u2022 returned: 0 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#6)\nOmittedTest.omitted1() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#9-13) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted1().val1 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#9)\n\u2022 returned: val2 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#12)\nOmittedTest.omitted2() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15-20) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted2().val1 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15), OmittedTest.omitted2().val2 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15)\n\u2022 returned: (val3,4) (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#19)\n",
+            "markdown": "[OmittedTest.omitted0()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4-L7) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted0().val](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4)\n\u2022 returned: [0](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L6)\n[OmittedTest.omitted1()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L9-L13) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted1().val1](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L9)\n\u2022 returned: [val2](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L12)\n[OmittedTest.omitted2()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15-L20) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted2().val1](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15), [OmittedTest.omitted2().val2](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15)\n\u2022 returned: [(val3,4)](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L19)\n",
+            "first_markdown_element": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4-L7",
+            "id": "86826923559cb686b3693ac385991faf22dc597ace4bac8c9acbe38920135196",
+            "check": "variable-omitted",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1553,6 +1553,11 @@ ALL_TEST_OBJECTS = [
         "permit_domain_state_var_collision.sol",
         "0.8.0",
     ),
+    Test(
+        all_detectors.OmittedReturnVariables,
+        "omitted_return_variables.sol",
+        "0.8.7",
+    ),
 ]
 
 

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1558,6 +1558,11 @@ ALL_TEST_OBJECTS = [
         "omitted_return_variables.sol",
         "0.8.7",
     ),
+    Test(
+        all_detectors.ReturnShadowsLocal,
+        "return_shadows_local.sol",
+        "0.8.7",
+    ),
 ]
 
 

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1563,6 +1563,11 @@ ALL_TEST_OBJECTS = [
         "return_shadows_local.sol",
         "0.8.7",
     ),
+    Test(
+        all_detectors.UnnamedReturnShadowsLocal,
+        "unnamed_return_shadows_local.sol",
+        "0.8.7",
+    ),
 ]
 
 


### PR DESCRIPTION
Detects when return function without `return` statement has unnamed variables inside `returns`.

Example:
```solidity
pragma solidity ^0.8.0;

contract Bug {
    function unnamed() external view returns(uint) {
        uint val = 1;
    } //returns 0
}
```