### PR TITLE
new detector: Omitted Return Variables

### DIFF
--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -85,3 +85,4 @@ from .statements.msg_value_in_loop import MsgValueInLoop
 from .statements.delegatecall_in_loop import DelegatecallInLoop
 from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
+from .variables.omitted_return_variables import OmittedReturnVariables

--- a/slither/detectors/variables/omitted_return_variables.py
+++ b/slither/detectors/variables/omitted_return_variables.py
@@ -1,0 +1,85 @@
+"""
+Module detecting "Omitted Return Variables"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+
+class OmittedReturnVariables(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'variable-omitted'
+    HELP = 'Omitted Return Variables'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#omitted-return-variables"
+
+    WIKI_TITLE = 'Omitted Return Variables'
+    WIKI_DESCRIPTION = 'Detects when return function omits to return the declared return variables.'
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function omitted() external view returns(uint val) {
+        val = 1;
+        return 0;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """Return declared return variables."""
+
+    ERR = {}
+    INFO = []
+
+    def info(self): #3/3 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, omitted_var_pairs in self.ERR.items():
+                result.append(bug_location)
+                result.append(' has an omitted return variable/s:\n• ')
+                for declared, returned in omitted_var_pairs:
+                    result.append('declared: ')
+                    left = len(declared)
+                    for var in declared:
+                        result.append(var)
+                        if left>1: result.append(', ')
+                        left-=1
+                    result.append('\n• returned: ')
+                    result.append(returned)
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_omitted(self, return_vars, function): #2/3 ↑
+        omitted_pairs = []
+        for node in function.nodes:
+            if node.type==NodeType.RETURN and node.variables_read!=return_vars:
+                omitted_pairs.append([return_vars, node])
+        return omitted_pairs
+
+    def get_return_vars_from(self, function): #1/3 ↑
+        return_vars_names = []
+        for var in function.returns:
+            if var.name=='': return [] #ignore unnamed
+            return_vars_names.append(var)
+        return return_vars_names
+
+    def _detect(self): # 0/3 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and len(function.nodes)>0: #ignore inherited interfaces
+                    return_vars = self.get_return_vars_from(function)
+                    if return_vars:
+                        omitted_return_vars = self.detect_omitted(return_vars, function)
+                        if omitted_return_vars:
+                            self.ERR[function] = omitted_return_vars
+        return self.info()

--- a/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol
+++ b/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.8.7;
+
+contract OmittedTest {
+    function omitted0() external view returns(uint val) {
+        val = 1;
+        return 0;
+    } //returns: 0 (instead of 1)
+
+    function omitted1() external view returns(uint val1) {
+        val1 = 1;
+        uint val2 = 0;
+        return val2;
+    } //returns: 0 (instead of 1)
+
+    function omitted2() external view returns(uint val1, uint val2) {
+        val1 = 1;
+        val2 = 2;
+        uint val3 = 3;
+        return (val3, 4);
+    }//returns: (3, 4) (instead of 1, 2)
+}

--- a/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol.0.8.7.OmittedReturnVariables.json
+++ b/tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol.0.8.7.OmittedReturnVariables.json
@@ -1,0 +1,749 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "omitted0",
+                    "source_mapping": {
+                        "start": 51,
+                        "length": 94,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6,
+                            7
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val",
+                    "source_mapping": {
+                        "start": 93,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 55
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 94,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "0",
+                    "source_mapping": {
+                        "start": 130,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            6
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 17
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 94,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6,
+                                    7
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "omitted1",
+                    "source_mapping": {
+                        "start": 179,
+                        "length": 122,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9,
+                            10,
+                            11,
+                            12,
+                            13
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 221,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted1",
+                            "source_mapping": {
+                                "start": 179,
+                                "length": 122,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 283,
+                        "length": 11,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            12
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 20
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted1",
+                            "source_mapping": {
+                                "start": 179,
+                                "length": 122,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "omitted2",
+                    "source_mapping": {
+                        "start": 335,
+                        "length": 156,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "OmittedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 504,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20,
+                                    21,
+                                    22
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "omitted2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 377,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 388,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 58,
+                        "ending_column": 67
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node",
+                    "name": "(val3,4)",
+                    "source_mapping": {
+                        "start": 468,
+                        "length": 16,
+                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            19
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 25
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "omitted2",
+                            "source_mapping": {
+                                "start": 335,
+                                "length": 156,
+                                "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    15,
+                                    16,
+                                    17,
+                                    18,
+                                    19,
+                                    20
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "OmittedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 504,
+                                        "filename_relative": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18,
+                                            19,
+                                            20,
+                                            21,
+                                            22
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "omitted2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "OmittedTest.omitted0() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#4-7) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted0().val (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#4)\n\u2022 returned: 0 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#6)\nOmittedTest.omitted1() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#9-13) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted1().val1 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#9)\n\u2022 returned: val2 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#12)\nOmittedTest.omitted2() (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15-20) has an omitted return variable/s:\n\u2022 declared: OmittedTest.omitted2().val1 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15), OmittedTest.omitted2().val2 (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#15)\n\u2022 returned: (val3,4) (tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#19)\n",
+            "markdown": "[OmittedTest.omitted0()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4-L7) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted0().val](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4)\n\u2022 returned: [0](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L6)\n[OmittedTest.omitted1()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L9-L13) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted1().val1](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L9)\n\u2022 returned: [val2](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L12)\n[OmittedTest.omitted2()](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15-L20) has an omitted return variable/s:\n\u2022 declared: [OmittedTest.omitted2().val1](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15), [OmittedTest.omitted2().val2](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L15)\n\u2022 returned: [(val3,4)](tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L19)\n",
+            "first_markdown_element": "tests/detectors/variable-omitted/0.8.7/omitted_return_variables.sol#L4-L7",
+            "id": "86826923559cb686b3693ac385991faf22dc597ace4bac8c9acbe38920135196",
+            "check": "variable-omitted",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1553,6 +1553,11 @@ ALL_TEST_OBJECTS = [
         "permit_domain_state_var_collision.sol",
         "0.8.0",
     ),
+    Test(
+        all_detectors.OmittedReturnVariables,
+        "omitted_return_variables.sol",
+        "0.8.7",
+    ),
 ]
 
 


### PR DESCRIPTION
Detects when the return function omits to return the declared return variables.

Example:
```solidity
pragma solidity ^0.8.0;

contract Bug {
    function omitted() external view returns(uint val) {
        val = 1;
        return 0;
    } //returns 0
}