### PR TITLE
new detector: Unnamed Return Shadows Local

### DIFF
--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -85,3 +85,4 @@ from .statements.msg_value_in_loop import MsgValueInLoop
 from .statements.delegatecall_in_loop import DelegatecallInLoop
 from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
+from .shadowing.return_unnamed import UnnamedReturnShadowsLocal

--- a/slither/detectors/shadowing/return_unnamed.py
+++ b/slither/detectors/shadowing/return_unnamed.py
@@ -1,0 +1,83 @@
+"""
+Module detecting "Unnamed Return Shadows Local"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+
+class UnnamedReturnShadowsLocal(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'shadowing-return-unnamed'
+    HELP = 'Unnamed Return Shadows Local'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#unnamed-return-shadows-local"
+
+    WIKI_TITLE = 'Unnamed Return Shadows Local'
+    WIKI_DESCRIPTION = "Detects when return function without `return` statement has unnamed variables inside `returns`."
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function unnamed() external view returns(uint) {
+        uint val = 1;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """
+    1. Name return variables inside "returns(...)".
+    2. Add a `return` statement at the end of the function."""
+
+    ERR  = {}
+    INFO = []
+
+    def info(self): #3/3 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, unnamed_vars in self.ERR.items():
+                result.append(bug_location)
+                result.append(" does not have `return` and inside `returns` has unnamed variable/s:\n• ")
+                vars_left = len(unnamed_vars)
+                for var in unnamed_vars:
+                    result.append(f'"{var.type}" ')
+                    result.append(var)
+                    if vars_left>1: result.append('\n• ')
+                    vars_left-=1
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_unnamed_return_vars(self, function): #2/3 ↑
+        unnamed_return_vars = []
+
+        for var in function.returns:
+            if var.name=='':
+                unnamed_return_vars.append(var)
+        return unnamed_return_vars
+
+    def no_return_statement_in(self, function): #1/3 ↑
+        if len(function.nodes)==0: return False #ignore inherited interfaces
+        for node in function.nodes:
+            if node.type==NodeType.RETURN:
+                return False
+        return True
+
+    def _detect(self): # 0/3 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and self.no_return_statement_in(function):
+                                # ↓↓↓ error-potential zone ↓↓↓ #
+                    unnamed_return_vars = self.detect_unnamed_return_vars(function)
+                    if unnamed_return_vars:
+                        self.ERR[function] = unnamed_return_vars
+        return self.info()

--- a/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol
+++ b/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.8.7;
+
+contract UnnamedTest {
+    function unnamed0() external view returns(uint) {
+        uint val = 1;
+    } //returns: 0 (instead of 1)
+
+    function unnamed1() external view returns(uint, uint val2) {
+        uint val1 = 1;
+        val2 = 2;
+    } //returns: 0, 2 (instead of 1, 2)
+
+    function unnamed2() external view returns(uint, uint) {
+        uint val1 = 1;
+        uint val2 = 2;
+    } //returns: 0, 0 (instead of 1, 2)
+}

--- a/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol.0.8.7.UnnamedReturnShadowsLocal.json
+++ b/tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol.0.8.7.UnnamedReturnShadowsLocal.json
@@ -1,0 +1,474 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "unnamed0",
+                    "source_mapping": {
+                        "start": 51,
+                        "length": 77,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 93,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed0",
+                            "source_mapping": {
+                                "start": 51,
+                                "length": 77,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "unnamed1",
+                    "source_mapping": {
+                        "start": 162,
+                        "length": 107,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8,
+                            9,
+                            10,
+                            11
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 204,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed1",
+                            "source_mapping": {
+                                "start": 162,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "unnamed2",
+                    "source_mapping": {
+                        "start": 309,
+                        "length": 107,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13,
+                            14,
+                            15,
+                            16
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "UnnamedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 428,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "unnamed2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 351,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 47,
+                        "ending_column": 51
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed2",
+                            "source_mapping": {
+                                "start": 309,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "",
+                    "source_mapping": {
+                        "start": 357,
+                        "length": 4,
+                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 53,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "unnamed2",
+                            "source_mapping": {
+                                "start": 309,
+                                "length": 107,
+                                "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "UnnamedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 428,
+                                        "filename_relative": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "unnamed2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "UnnamedTest.unnamed0() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#4-6) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed0(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#4)\nUnnamedTest.unnamed1() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#8-11) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed1(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#8)\nUnnamedTest.unnamed2() (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13-16) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" UnnamedTest.unnamed2(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13)\n\u2022 \"uint256\" UnnamedTest.unnamed2(). (tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#13)\n",
+            "markdown": "[UnnamedTest.unnamed0()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4-L6) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed0().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4)\n[UnnamedTest.unnamed1()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L8-L11) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed1().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L8)\n[UnnamedTest.unnamed2()](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13-L16) does not have `return` and inside `returns` has unnamed variable/s:\n\u2022 \"uint256\" [UnnamedTest.unnamed2().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13)\n\u2022 \"uint256\" [UnnamedTest.unnamed2().](tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L13)\n",
+            "first_markdown_element": "tests/detectors/shadowing-return-unnamed/0.8.7/unnamed_return_shadows_local.sol#L4-L6",
+            "id": "5f56d421341dc10a2682219e595fc5a155244ebf835c21f028bc2b97680a51c9",
+            "check": "shadowing-return-unnamed",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1553,6 +1553,11 @@ ALL_TEST_OBJECTS = [
         "permit_domain_state_var_collision.sol",
         "0.8.0",
     ),
+    Test(
+        all_detectors.UnnamedReturnShadowsLocal,
+        "unnamed_return_shadows_local.sol",
+        "0.8.7",
+    ),
 ]
 
 


### PR DESCRIPTION
Detects when return function without `return` statement has unnamed variables inside `returns`.

Example:
```solidity
pragma solidity ^0.8.0;

contract Bug {
    function unnamed() external view returns(uint) {
        uint val = 1;
    } //returns 0
}
```