### PR TITLE
new detector: Return Shadows Local

### DIFF
--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -85,3 +85,4 @@ from .statements.msg_value_in_loop import MsgValueInLoop
 from .statements.delegatecall_in_loop import DelegatecallInLoop
 from .functions.protected_variable import ProtectedVariables
 from .functions.permit_domain_signature_collision import DomainSeparatorCollision
+from .shadowing.return_local import ReturnShadowsLocal

--- a/slither/detectors/shadowing/return_local.py
+++ b/slither/detectors/shadowing/return_local.py
@@ -1,0 +1,98 @@
+"""
+Module detecting "Return Shadows Local"
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.core.cfg.node import NodeType
+import re
+
+class ReturnShadowsLocal(AbstractDetector):
+    """
+    Documentation
+    """
+
+    ARGUMENT = 'shadowing-return-local'
+    HELP = 'Return Shadows Local'
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.HIGH
+
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#return-shadows-local"
+
+    WIKI_TITLE = 'Return Shadows Local'
+    WIKI_DESCRIPTION = 'Detects when return function without `return` statement shadows self-related local variables.'
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """"
+```solidity
+pragma solidity ^0.8.0;
+
+contract Bug {
+    function shadowed() external view returns(uint val) {
+        uint val = 1;
+    } //returns 0
+}
+```"""
+    # endregion wiki_exploit_scenario
+
+    WIKI_RECOMMENDATION = """
+    1. Don't re-declare the type of return variables.
+    2. Add a `return` statement at the end of the function."""
+
+    ERR = {}
+    INFO = []
+
+    def info(self): #4/4 (end) ↰
+        if len(self.ERR)>0:
+            result = []
+            for bug_location, shadower_shadowed_pair in self.ERR.items():
+                result.append(bug_location)
+                result.append(" does not have `return` and has its return variable/s:\n• ")
+                pairs_left = len(shadower_shadowed_pair)
+                for shadower, shadowed in shadower_shadowed_pair:
+                    result.append(shadowed) #in local
+                    result.append(' shadowed by ')
+                    result.append(shadower) #from "returns(...)""
+                    if pairs_left>1: result.append('\n• ')
+                    pairs_left-=1
+                result.append('\n')
+            self.INFO.append(self.generate_result(result))
+        return self.INFO
+
+    def detect_shadower_shadowed_pair(self, function): #3/4 ↑
+        shadower_shadowed_pairs = []
+
+        for return_var in function.returns: #potentially shadower
+            for local_var in function.variables: #potentially shadowed
+                try: # to prevent e.g. wrong format errors
+                    #get shadowing info, e.g., from "name_scope_0" extract "_scope_0"
+                    scope_part = re.sub(f'^{return_var.name}', "", local_var.name)
+                    #save "return_var" if shadows "local_var"
+                    if re.search('^_scope_[0-9]$', scope_part):
+                        shadower_shadowed_pairs.append([return_var, local_var])
+                except Exception as e:
+                    print(e); continue
+        return shadower_shadowed_pairs
+
+    def return_vars_named_in(self, function): #2/4 ↑
+        for var in function.returns:
+            if var.name=='':
+                return False
+        return True
+
+    def no_return_statement_in(self, function): #1/3 ↑
+        if len(function.nodes)==0: return False #ignore inherited interfaces
+        for node in function.nodes:
+            if node.type==NodeType.RETURN:
+                return False
+        return True
+
+    def _detect(self): # 0/4 (start) ⤴
+        for contract in self.contracts:
+            if contract.is_interface: continue #ignore interfaces
+            for function in contract.functions:
+                if function.return_type and self.no_return_statement_in(function) and self.return_vars_named_in(function):
+                                # ↓↓↓ error-potential zone ↓↓↓ #
+                    shadower_shadowed_pairs = self.detect_shadower_shadowed_pair(function)
+                    if shadower_shadowed_pairs: #[[shadowed, shadower], ...]
+                        self.ERR[function] = shadower_shadowed_pairs
+        return self.info()

--- a/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol
+++ b/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.8.7;
+
+contract ShadowedTest {
+    function shadowed0() external view returns(uint val) {
+        uint val = 1;
+    } //returns: 0 (instead of 1)
+
+    function shadowed1() external view returns(uint val1, uint val2) {
+        uint val1 = 1;
+        val2 = 2;
+    } //returns: 0, 2 (instead of 1, 2)
+
+    function shadowed2() external view returns(uint val1, uint val2) {
+        uint val1 = 1;
+        uint val2 = 2;
+    } //returns: 0, 0 (instead of 1, 2)
+}

--- a/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol.0.8.7.ReturnShadowsLocal.json
+++ b/tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol.0.8.7.ReturnShadowsLocal.json
@@ -1,0 +1,769 @@
+[
+    [
+        {
+            "elements": [
+                {
+                    "type": "function",
+                    "name": "shadowed0",
+                    "source_mapping": {
+                        "start": 52,
+                        "length": 82,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4,
+                            5,
+                            6
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed0()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val_scope_0",
+                    "source_mapping": {
+                        "start": 115,
+                        "length": 12,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            5
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 21
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed0",
+                            "source_mapping": {
+                                "start": 52,
+                                "length": 82,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val",
+                    "source_mapping": {
+                        "start": 95,
+                        "length": 8,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            4
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 56
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed0",
+                            "source_mapping": {
+                                "start": 52,
+                                "length": 82,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    4,
+                                    5,
+                                    6
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed0()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "shadowed1",
+                    "source_mapping": {
+                        "start": 168,
+                        "length": 113,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8,
+                            9,
+                            10,
+                            11
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed1()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1_scope_0",
+                    "source_mapping": {
+                        "start": 243,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            9
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed1",
+                            "source_mapping": {
+                                "start": 168,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 211,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            8
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed1",
+                            "source_mapping": {
+                                "start": 168,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    8,
+                                    9,
+                                    10,
+                                    11
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed1()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "name": "shadowed2",
+                    "source_mapping": {
+                        "start": 321,
+                        "length": 118,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13,
+                            14,
+                            15,
+                            16
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 6
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "ShadowedTest",
+                            "source_mapping": {
+                                "start": 24,
+                                "length": 451,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    8,
+                                    9,
+                                    10,
+                                    11,
+                                    12,
+                                    13,
+                                    14,
+                                    15,
+                                    16,
+                                    17,
+                                    18
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        },
+                        "signature": "shadowed2()"
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1_scope_0",
+                    "source_mapping": {
+                        "start": 396,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            14
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val1",
+                    "source_mapping": {
+                        "start": 364,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 48,
+                        "ending_column": 57
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2_scope_1",
+                    "source_mapping": {
+                        "start": 419,
+                        "length": 13,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            15
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 22
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "val2",
+                    "source_mapping": {
+                        "start": 375,
+                        "length": 9,
+                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            13
+                        ],
+                        "starting_column": 59,
+                        "ending_column": 68
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowed2",
+                            "source_mapping": {
+                                "start": 321,
+                                "length": 118,
+                                "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    13,
+                                    14,
+                                    15,
+                                    16
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "ShadowedTest",
+                                    "source_mapping": {
+                                        "start": 24,
+                                        "length": 451,
+                                        "filename_relative": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            3,
+                                            4,
+                                            5,
+                                            6,
+                                            7,
+                                            8,
+                                            9,
+                                            10,
+                                            11,
+                                            12,
+                                            13,
+                                            14,
+                                            15,
+                                            16,
+                                            17,
+                                            18
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowed2()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "ShadowedTest.shadowed0() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#4-6) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed0().val_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#5) shadowed by ShadowedTest.shadowed0().val (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#4)\nShadowedTest.shadowed1() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#8-11) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed1().val1_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#9) shadowed by ShadowedTest.shadowed1().val1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#8)\nShadowedTest.shadowed2() (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13-16) does not have `return` and has its return variable/s:\n\u2022 ShadowedTest.shadowed2().val1_scope_0 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#14) shadowed by ShadowedTest.shadowed2().val1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13)\n\u2022 ShadowedTest.shadowed2().val2_scope_1 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#15) shadowed by ShadowedTest.shadowed2().val2 (tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#13)\n",
+            "markdown": "[ShadowedTest.shadowed0()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4-L6) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed0().val_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L5) shadowed by [ShadowedTest.shadowed0().val](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4)\n[ShadowedTest.shadowed1()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L8-L11) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed1().val1_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L9) shadowed by [ShadowedTest.shadowed1().val1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L8)\n[ShadowedTest.shadowed2()](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13-L16) does not have `return` and has its return variable/s:\n\u2022 [ShadowedTest.shadowed2().val1_scope_0](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L14) shadowed by [ShadowedTest.shadowed2().val1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13)\n\u2022 [ShadowedTest.shadowed2().val2_scope_1](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L15) shadowed by [ShadowedTest.shadowed2().val2](tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L13)\n",
+            "first_markdown_element": "tests/detectors/shadowing-return-local/0.8.7/return_shadows_local.sol#L4-L6",
+            "id": "5efdb185c2bcf7e560cffc007ed66d38bec47e4944e68b50d8346b7660d86b4c",
+            "check": "shadowing-return-local",
+            "impact": "Low",
+            "confidence": "High"
+        }
+    ]
+]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -1553,6 +1553,11 @@ ALL_TEST_OBJECTS = [
         "permit_domain_state_var_collision.sol",
         "0.8.0",
     ),
+    Test(
+        all_detectors.ReturnShadowsLocal,
+        "return_shadows_local.sol",
+        "0.8.7",
+    ),
 ]
 
 


### PR DESCRIPTION
Detector for: [issue](https://github.com/crytic/slither/issues/1361)
Detects when return function without `return` statement shadows self-related local variables.

Example:
```solidity
pragma solidity ^0.8.0;

contract Bug {
    function shadowed() external view returns(uint val) {
        uint val = 1;
    } //returns 0
}
```