### PR TITLE
fix: text for too recent version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@ setup(
     description="Slither is a Solidity static analysis framework written in Python 3.",
     url="https://github.com/crytic/slither",
     author="Trail of Bits",
-    version="0.8.3",
+    version="0.9.0",
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
         "prettytable>=0.7.2",
         "pysha3>=1.0.2",
-        # "crytic-compile>=0.2.3",
-        "crytic-compile@git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile",
+        "crytic-compile>=0.2.4",
+        # "crytic-compile@git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile",
     ],
     extras_require={
         "dev": [

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -59,7 +59,7 @@ Consider using the latest version of Solidity for testing."""
     OLD_VERSION_TXT = "allows old versions"
     LESS_THAN_TXT = "uses lesser than"
 
-    TOO_RECENT_VERSION_TXT = "necessitates a version too recent to be trusted. Consider deploying with 0.6.12/0.7.6/0.8.7"
+    TOO_RECENT_VERSION_TXT = "necessitates a version too recent to be trusted. Consider deploying with 0.6.12/0.7.6/0.8.16"
     BUGGY_VERSION_TXT = (
         "is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)"
     )


### PR DESCRIPTION
https://github.com/crytic/slither/pull/1389 changed the recommended solc versions but did not update the version text