### PR TITLE
fix: include shadowed state variables in contract's state_variables property

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -49,4 +49,5 @@ jobs:
           pytest tests/slithir/test_ternary_expressions.py
           pytest tests/test_functions_ids.py
           pytest tests/test_function.py
+          pytest tests/test_state_variables.py
           pytest tests/test_source_mapping.py

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -301,9 +301,9 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     @property
     def variables(self) -> List["StateVariable"]:
         """
-        list(StateVariable): List of the state variables. Alias to self.state_variables
+        list(StateVariable): List of the state variables. Alias to self.state_variables_ordered
         """
-        return list(self.state_variables)
+        return self.state_variables_ordered
 
     @property
     def variables_as_dict(self) -> Dict[str, "StateVariable"]:
@@ -312,21 +312,21 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     @property
     def state_variables(self) -> List["StateVariable"]:
         """
-        list(StateVariable): List of the state variables.
+        list(StateVariable): List of the state variables. Alias to self.state_variables_ordered
         """
-        return list(self._variables.values())
+        return self.state_variables_ordered
 
     @property
     def state_variables_entry_points(self) -> List["StateVariable"]:
         """
         list(StateVariable): List of the state variables that are public.
         """
-        return [var for var in self._variables.values() if var.visibility == "public"]
+        return [var for var in self.state_variables_ordered if var.visibility == "public"]
 
     @property
     def state_variables_ordered(self) -> List["StateVariable"]:
         """
-        list(StateVariable): List of the state variables by order of declaration.
+        list(StateVariable): List of the state variables by order of declaration (including inherited).
         """
         return list(self._variables_ordered)
 
@@ -338,14 +338,14 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         """
         list(StateVariable): List of the inherited state variables
         """
-        return [s for s in self.state_variables if s.contract != self]
+        return [s for s in self.state_variables_ordered if s.contract != self]
 
     @property
     def state_variables_declared(self) -> List["StateVariable"]:
         """
         list(StateVariable): List of the state variables declared within the contract (not inherited)
         """
-        return [s for s in self.state_variables if s.contract == self]
+        return [s for s in self.state_variables_ordered if s.contract == self]
 
     @property
     def slithir_variables(self) -> List["SlithIRVariable"]:

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -340,6 +340,8 @@ class ContractSolc(CallerContextExpression):
             var_parser = StateVariableSolc(var, varNotParsed)
             self._variables_parser.append(var_parser)
 
+            # This does not handle inherited variables that are shadowed in the derived contract
+            # https://github.com/crytic/slither/issues/1322
             self._contract.variables_as_dict[var.name] = var
             self._contract.add_variables_ordered([var])
 

--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -253,7 +253,7 @@ class SlitherReadStorage:
                     func,
                     [
                         (contract, var)
-                        for var in contract.variables
+                        for var in contract.state_variables_ordered
                         if not var.is_constant and not var.is_immutable
                     ],
                 )

--- a/tests/test_state_variables.py
+++ b/tests/test_state_variables.py
@@ -1,0 +1,83 @@
+"""
+tests for `slither.core.declarations.Contract`.
+tests that `tests/test_state_variables.sol` instantiates
+contract with correct state variables
+"""
+import collections
+from solc_select import solc_select
+from slither import Slither
+from slither.core.solidity_types import ElementaryType, ArrayType
+from slither.core.expressions import Literal
+
+
+solc_select.switch_global_version("0.8.4", always_install=True)
+slither = Slither("tests/test_state_variables.sol")
+base = slither.get_contract_from_name("BaseContract")[0]
+derived = slither.get_contract_from_name("DerivedContract")[0]
+
+
+def test_state_variable_properties():
+    base_vars = base.variables_as_dict
+
+    one = base_vars["one"]
+    assert one.name == "one", "wrong name"
+    assert one.canonical_name == "BaseContract.one", "wrong canonical_name"
+    assert one.type == ElementaryType("uint256"), "wrong type"
+    assert one.visibility == "public", "wrong visibility"
+
+    base_gap = base_vars["__gap"]
+    assert base_gap.name == "__gap", "wrong name"
+    assert base_gap.canonical_name == "BaseContract.__gap", "wrong canonical_name"
+    assert base_gap.type == ArrayType(
+        ElementaryType("uint256"), Literal("50", ElementaryType("uint256"))
+    ), "wrong type"
+    assert base_gap.visibility == "private", "wrong visibility"
+
+    two = base_vars["two"]
+    assert two.name == "two", "wrong name"
+    assert two.canonical_name == "BaseContract.two", "wrong canonical_name"
+    assert two.type == ElementaryType("uint256"), "wrong type"
+    assert two.visibility == "internal", "wrong visibility"
+
+    derived_vars = derived.variables_as_dict
+
+    three = derived_vars["three"]
+    assert three.name == "three", "wrong name"
+    assert three.canonical_name == "DerivedContract.three", "wrong canonical_name"
+    assert three.type == ElementaryType("uint256"), "wrong type"
+    assert three.visibility == "public", "wrong visibility"
+
+    derived_gap = derived_vars["__gap"]
+    assert derived_gap.name == "__gap", "wrong name"
+    assert derived_gap.canonical_name == "DerivedContract.__gap", "wrong canonical_name"
+    assert derived_gap.type == ArrayType(
+        ElementaryType("uint256"), Literal("50", ElementaryType("uint256"))
+    ), "wrong type"
+    assert derived_gap.visibility == "private", "wrong visibility"
+
+    four = derived_vars["four"]
+    assert four.name == "four", "wrong name"
+    assert four.canonical_name == "DerivedContract.four", "wrong canonical_name"
+    assert four.type == ElementaryType("uint256"), "wrong type"
+    assert four.visibility == "internal", "wrong visibility"
+
+
+# check whether lists with duplicate, unsorted items are equal
+compare = lambda x, y: collections.Counter(x) == collections.Counter(y)
+
+
+def test_contract_state_variable_getters():
+    # the base contract should declare all variables which the derived inherits
+    assert compare(base.state_variables_declared, derived.state_variables_inherited)
+    # the base contract should not inherit any variables (no inheritance)
+    assert base.state_variables_inherited == []
+    # the derived state variables should be the aggregate of the declared and inherited
+    assert compare(
+        derived.state_variables,
+        derived.state_variables_declared + derived.state_variables_inherited,
+    )
+    # the entry points should be all state variables filtered for only publicly visible variables
+    assert compare(
+        derived.state_variables_entry_points,
+        list(filter(lambda x: x.visibility == "public", derived.state_variables)),
+    )

--- a/tests/test_state_variables.sol
+++ b/tests/test_state_variables.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.8.4;
+
+contract BaseContract{
+    uint256 public one;
+    uint256[50] private __gap;
+    uint256 internal two;
+}
+
+contract DerivedContract is BaseContract{
+    uint256 public three;
+    uint256[50] private __gap;
+    uint256 internal four;
+}


### PR DESCRIPTION
fixes https://github.com/crytic/slither/issues/1322