### PR TITLE
fix triage prompt not displaying

### DIFF
--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -189,7 +189,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         if results and self.slither.triage_mode:
             while True:
                 indexes = input(
-                    f'Results to hide during next runs: "0,1,...,{len(results)}" or "All" (enter to not hide results): '
+                    f'Results to hide during next runs: "0,1,...,{len(results)}" or "All" (enter to not hide results):\n'
                 )
                 if indexes == "All":
                     self.slither.save_results_to_hide(results)


### PR DESCRIPTION
Closes https://github.com/crytic/slither/issues/1354, https://github.com/crytic/slither/issues/922, https://github.com/crytic/slither/issues/885

Right now, all of the prompts do not show until the last result is output... adding a new line makes a prompt show for each detectors' results (idk why this is).