### PR TITLE
use state_variables_ordered  API

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -253,7 +253,7 @@ class SlitherReadStorage:
                     func,
                     [
                         (contract, var)
-                        for var in contract.variables
+                        for var in contract.state_variables_ordered
                         if not var.is_constant and not var.is_immutable
                     ],
                 )


### PR DESCRIPTION
it should be used over `(state_)variables` as it includes inherited, private variables, too. fixes #1322