### PR TITLE
upgradeability: include inherited private variables, ignore immutables

### DIFF
--- a/slither/tools/upgradeability/checks/variable_initialization.py
+++ b/slither/tools/upgradeability/checks/variable_initialization.py
@@ -39,8 +39,8 @@ Using initialize functions to write initial values in state variables.
 
     def _check(self):
         results = []
-        for s in self.contract.state_variables:
-            if s.initialized and not s.is_constant:
+        for s in self.contract.state_variables_ordered:
+            if s.initialized and not (s.is_constant or s.is_immutable):
                 info = [s, " is a state variable with an initial value.\n"]
                 json = self.generate_result(info)
                 results.append(json)

--- a/slither/tools/upgradeability/checks/variables_order.py
+++ b/slither/tools/upgradeability/checks/variables_order.py
@@ -48,8 +48,16 @@ Do not change the order of the state variables in the updated contract.
     def _check(self):
         contract1 = self.contract
         contract2 = self.contract_v2
-        order1 = [variable for variable in contract1.state_variables if not variable.is_constant]
-        order2 = [variable for variable in contract2.state_variables if not variable.is_constant]
+        order1 = [
+            variable
+            for variable in contract1.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
+        order2 = [
+            variable
+            for variable in contract2.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
 
         results = []
         for idx, _ in enumerate(order1):
@@ -109,8 +117,16 @@ Avoid variables in the proxy. If a variable is in the proxy, ensure it has the s
     def _check(self):
         contract1 = self._contract1()
         contract2 = self._contract2()
-        order1 = [variable for variable in contract1.state_variables if not variable.is_constant]
-        order2 = [variable for variable in contract2.state_variables if not variable.is_constant]
+        order1 = [
+            variable
+            for variable in contract1.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
+        order2 = [
+            variable
+            for variable in contract2.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
 
         results = []
         for idx, _ in enumerate(order1):
@@ -228,8 +244,16 @@ Avoid variables in the proxy. If a variable is in the proxy, ensure it has the s
     def _check(self):
         contract1 = self._contract1()
         contract2 = self._contract2()
-        order1 = [variable for variable in contract1.state_variables if not variable.is_constant]
-        order2 = [variable for variable in contract2.state_variables if not variable.is_constant]
+        order1 = [
+            variable
+            for variable in contract1.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
+        order2 = [
+            variable
+            for variable in contract2.state_variables_ordered
+            if not (variable.is_constant or variable.is_immutable)
+        ]
 
         results = []
 


### PR DESCRIPTION
The upgradeability check doesn't consider inherited, private variable declarations nor does it consider immutability. This PR addresses that by using `state_variables_ordered` and checking that variables aren't immutable prior to flagging them.
```
// test.sol 
pragma solidity ^0.8.0;
contract A {
    uint private a = 1; // not currently detected 
}
contract B is A {
    uint a = 2;
    uint immutable b = 3; // fine to delegatecall (same as constant)
}
```
Command: `slither-check-upgradeability test.sol B`
Before:
```
B.a (test.sol#6) is a state variable with an initial value.
B.b (test.sol#7) is a state variable with an initial value.
```
After fix:
```
A.a (test.sol#3) is a state variable with an initial value.
B.a (test.sol#6) is a state variable with an initial value.
```