### PR TITLE
support abi.encodeCall

### DIFF
--- a/slither/core/declarations/solidity_variables.py
+++ b/slither/core/declarations/solidity_variables.py
@@ -70,6 +70,7 @@ SOLIDITY_FUNCTIONS: Dict[str, List[str]] = {
     "abi.encodePacked()": ["bytes"],
     "abi.encodeWithSelector()": ["bytes"],
     "abi.encodeWithSignature()": ["bytes"],
+    "abi.encodeCall()": ["bytes"],
     "bytes.concat()": ["bytes"],
     "string.concat()": ["string"],
     # abi.decode returns an a list arbitrary types

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1139,6 +1139,7 @@ def can_be_solidity_func(ir) -> bool:
         "encodePacked",
         "encodeWithSelector",
         "encodeWithSignature",
+        "encodeCall",
         "decode",
     ]
 


### PR DESCRIPTION
abi.encodeCall is not supported as a `SolidityFunction`/`SolidityCall`. This adds support

@0xalpharush / @montyly  If you have time, can you help explain how to set up an ast_parsing test to me? I plan to add tests, but could use a little guidance