### PR TITLE
feat: Codex vuln detector -  devtooligan updates

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -305,7 +305,35 @@ def parse_args(
         "--codex",
         help="Enable codex (require an OpenAI API Key)",
         action="store_true",
-        default=False,
+        default=defaults_flag_in_config["codex"],
+    )
+
+    parser.add_argument(
+        "--codex-contracts",
+        help="Comma separated list of contracts to submit to OpenAI Codex",
+        action="store",
+        default=defaults_flag_in_config["codex_contracts"],
+    )
+
+    parser.add_argument(
+        "--codex-model",
+        help="Name of the Codex model to use (affects pricing).  Defaults to 'text-davinci-003'",
+        action="store",
+        default=defaults_flag_in_config["codex_model"],
+    )
+
+    parser.add_argument(
+        "--codex-temperature",
+        help="Temperature to use with Codex.  Lower number indicates a more precise answer while higher numbers return more creative answers.  Defaults to 0",
+        action="store",
+        default=defaults_flag_in_config["codex_temperature"],
+    )
+
+    parser.add_argument(
+        "--codex-max-tokens",
+        help="Maximum amount of tokens to use on the response.  This number plus the size of the prompt can be no larger than the limit (4097 for text-davinci-003)",
+        action="store",
+        default=defaults_flag_in_config["codex_max_tokens"],
     )
 
     cryticparser.init(parser)

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -83,8 +83,12 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
 
         self.line_prefix = kwargs.get("change_line_prefix", "#")
 
-        # Indicate if codex-related features should be used
+        # Indicate if Codex related features should be used
         self.codex_enabled = kwargs.get("codex", False)
+        self.codex_contracts = kwargs.get("codex_contracts")
+        self.codex_model = kwargs.get("codex_model")
+        self.codex_temperature = kwargs.get("codex_temperature")
+        self.codex_max_tokens = kwargs.get("codex_max_tokens")
 
         self._parsers: List[SlitherCompilationUnitSolc] = []
         try:

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -29,6 +29,11 @@ JSON_OUTPUT_TYPES = [
 
 # Those are the flags shared by the command line and the config file
 defaults_flag_in_config = {
+    "codex": False,
+    "codex_contracts": "all",
+    "codex_model": "text-davinci-003",
+    "codex_temperature": 0,
+    "codex_max_tokens": 300,
     "detectors_to_run": "all",
     "printers_to_run": None,
     "detectors_to_exclude": None,


### PR DESCRIPTION
Highlights of this pr:
- Parameterize the inputs to the OpenAI codex call: `model`, `temperature`, and `max_tokens`
- Add `--codex-contracts` argument which takes a comma-delimited list of contracts and, if specified, it will limit the Codex detector to only those contracts.  I found this a great way to save money when working with a large contract with a deeply nested inheritance tree.  Someday, may want to expand this feature to all detectors.
- It also changes the prompt to something I was having more luck with.  It no longer asks a "Yes" or "No" question, so the prompt now also requires the use of a keyword if vulns are found.

I did spend some time implementing a "retries" system.  But for some reason, the retried "queries" were all identical.  I guess I was hoping it would exhibit similar behavior to the chatbot when "retry" is pressed, which results in a different response.  So I've removed that feature but will continue to look into it.