### PR TITLE
Call value ternary

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -308,7 +308,7 @@ class FunctionSolc(CallerContextExpression):
         for node_parser in self._node_to_yulobject.values():
             node_parser.analyze_expressions()
 
-        self._filter_ternary()
+        self._rewrite_ternary_as_if_else()
 
         self._remove_alone_endif()
 
@@ -1336,7 +1336,7 @@ class FunctionSolc(CallerContextExpression):
     ###################################################################################
     ###################################################################################
 
-    def _filter_ternary(self) -> bool:
+    def _rewrite_ternary_as_if_else(self) -> bool:
         ternary_found = True
         updated = False
         while ternary_found:

--- a/slither/solc_parsing/declarations/modifier.py
+++ b/slither/solc_parsing/declarations/modifier.py
@@ -87,7 +87,7 @@ class ModifierSolc(FunctionSolc):
         for node in self._node_to_nodesolc.values():
             node.analyze_expressions(self)
 
-        self._filter_ternary()
+        self._rewrite_ternary_as_if_else()
         self._remove_alone_endif()
 
         # self._analyze_read_write()

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -135,6 +135,7 @@ class SplitTernaryExpression:
     ) -> None:
         for next_expr in expression.expressions:
             # TODO: can we get rid of `NoneType` expressions in `TupleExpression`?
+            # montyly: this might happen with unnamed tuple (ex: (,,,) = f()), but it needs to be checked
             if next_expr:
                 if isinstance(next_expr, IndexAccess):
                     self.convert_index_access(next_expr, true_expression, false_expression)

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -3,7 +3,7 @@
     as they should be immutable
 """
 import copy
-from typing import Union, Callable, Tuple, Optional
+from typing import Union, Callable
 from slither.core.expressions import UnaryOperation
 from slither.core.expressions.assignment_operation import AssignmentOperation
 from slither.core.expressions.binary_operation import BinaryOperation
@@ -68,7 +68,7 @@ class SplitTernaryExpression:
         false_expression: Union[AssignmentOperation, MemberAccess],
         f: Callable,
     ) -> bool:
-        # parentetical expression (.. ? .. : ..)
+        # look ahead for parenthetical expression (.. ? .. : ..)
         if (
             isinstance(next_expr, TupleExpression)
             and len(next_expr.expressions) == 1
@@ -112,7 +112,7 @@ class SplitTernaryExpression:
                 self.copy_expression(
                     next_expr, true_expression.expression, false_expression.expression
                 )
-
+        # pylint: disable=too-many-nested-blocks
         elif isinstance(expression, (AssignmentOperation, BinaryOperation, TupleExpression)):
             true_expression._expressions = []
             false_expression._expressions = []

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -102,7 +102,7 @@ class SplitTernaryExpression:
         ):
             return
 
-        elif isinstance(expression, (AssignmentOperation, BinaryOperation, TupleExpression)):
+        if isinstance(expression, (AssignmentOperation, BinaryOperation, TupleExpression)):
             true_expression._expressions = []
             false_expression._expressions = []
             self.convert_expressions(expression, true_expression, false_expression)

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -68,6 +68,13 @@ class SplitTernaryExpression:
         false_expression: Union[AssignmentOperation, MemberAccess],
         f: Callable,
     ) -> bool:
+        # parentetical expression (.. ? .. : ..)
+        if (
+            isinstance(next_expr, TupleExpression)
+            and len(next_expr.expressions) == 1
+            and isinstance(next_expr.expressions[0], ConditionalExpression)
+        ):
+            next_expr = next_expr.expressions[0]
 
         if isinstance(next_expr, ConditionalExpression):
             f(true_expression, copy.copy(next_expr.then_expression))

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -28,15 +28,18 @@ def f_expressions(
     e._expressions.append(x)
 
 
-def f_call(e, x):
+def f_call(e: CallExpression, x):
     e._arguments.append(x)
 
+
+def f_call_value(e: CallExpression, x):
+    e._value = x
 
 def f_expression(e, x):
     e._expression = x
 
 
-def f_called(e, x):
+def f_called(e: CallExpression, x):
     e._called = x
 
 
@@ -122,6 +125,15 @@ class SplitTernaryExpression:
             # (.. ? .. : ..).add
             if self.apply_copy(next_expr, true_expression, false_expression, f_called):
                 self.copy_expression(next_expr, true_expression.called, false_expression.called)
+
+            next_expr = expression.call_value
+            # case of (..).func{value: .. ? .. : ..}()
+            if self.apply_copy(next_expr, true_expression, false_expression, f_call_value):
+                    self.copy_expression(
+                        next_expr,
+                        true_expression.call_value,
+                        false_expression.call_value,
+                    )
 
             true_expression._arguments = []
             false_expression._arguments = []

--- a/tests/slithir/ternary_expressions.sol
+++ b/tests/slithir/ternary_expressions.sol
@@ -1,3 +1,6 @@
+interface NameReg {
+    function addressOf() external payable;
+}
 contract C {
     // TODO
     // 1) support variable declarations
@@ -21,4 +24,12 @@ contract C {
     function d(bool cond, bytes calldata x) external {
         bytes1 a = x[cond ? 1 : 2];
     }
+
+    function e(address one, address two) public {
+        return NameReg(one).addressOf{value: msg.sender == two ? 1 : 2, gas: true ? 2 : gasleft()}();
+    }
+    // TODO: nested ternary 
+    // function f(address one, address two) public {
+    //     return NameReg(one).addressOf{value: msg.sender == two ? 1 : 2, gas: true ? (1 == 1 ? 1 : 2) : gasleft()}();
+    // }
 }

--- a/tests/slithir/ternary_expressions.sol
+++ b/tests/slithir/ternary_expressions.sol
@@ -30,7 +30,7 @@ contract C {
         uint x = Test(one).test{value: msg.sender == two ? 1 : 2, gas: true ? 2 : gasleft()}();
     }
 
-    // Parenthteical expression
+    // Parenthetical expression
     function f(address one, address two) public {
         uint x = Test(one).test{value: msg.sender == two ? 1 : 2, gas: true ? (1 == 1 ? 1 : 2) : gasleft()}();
     }

--- a/tests/slithir/ternary_expressions.sol
+++ b/tests/slithir/ternary_expressions.sol
@@ -1,5 +1,6 @@
-interface NameReg {
-    function addressOf() external payable;
+interface Test {
+    function test() external payable returns (uint);
+    function testTuple() external payable returns (uint, uint);
 }
 contract C {
     // TODO
@@ -26,10 +27,16 @@ contract C {
     }
 
     function e(address one, address two) public {
-        return NameReg(one).addressOf{value: msg.sender == two ? 1 : 2, gas: true ? 2 : gasleft()}();
+        uint x = Test(one).test{value: msg.sender == two ? 1 : 2, gas: true ? 2 : gasleft()}();
     }
-    // TODO: nested ternary 
-    // function f(address one, address two) public {
-    //     return NameReg(one).addressOf{value: msg.sender == two ? 1 : 2, gas: true ? (1 == 1 ? 1 : 2) : gasleft()}();
-    // }
+
+    // Parenthteical expression
+    function f(address one, address two) public {
+        uint x = Test(one).test{value: msg.sender == two ? 1 : 2, gas: true ? (1 == 1 ? 1 : 2) : gasleft()}();
+    }
+
+    // Unused tuple variable
+    function g(address one) public {
+        (, uint x) = Test(one).testTuple();
+    }
 }

--- a/tests/slithir/test_ternary_expressions.py
+++ b/tests/slithir/test_ternary_expressions.py
@@ -9,10 +9,10 @@ def test_ternary_conversions() -> None:
     slither = Slither("./tests/slithir/ternary_expressions.sol")
     for contract in slither.contracts:
         for function in contract.functions:
+            vars_declared = 0
+            vars_assigned = 0
             for node in function.nodes:
                 if node.type in [NodeType.IF, NodeType.IFLOOP]:
-                    vars_declared = 0
-                    vars_assigned = 0
 
                     # Iterate over true and false son
                     for inner_node in node.sons:
@@ -31,7 +31,7 @@ def test_ternary_conversions() -> None:
                             if isinstance(ir, Assignment):
                                 vars_assigned += 1
 
-                    assert vars_declared == vars_assigned
+            assert vars_declared == vars_assigned
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- support ternaries in gas and value options of call expressions
- handle unused tuple variables
- refactor index access to be like the rest of the conversions
Close #1153, close https://github.com/crytic/slither/issues/1371, close https://github.com/crytic/slither/issues/1198
Replace https://github.com/crytic/slither/pull/1217