### PR TITLE
Add `state_variable_slots` property to contract.py

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -388,6 +388,23 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                 variables_used[variable].add(variable)
             self._state_variables_used_in_reentrant_targets = variables_used
         return self._state_variables_used_in_reentrant_targets
+    
+    @property
+    def state_variable_slots(self) -> Dict["StateVariable", int]:
+        """
+        Returns a dictionary mapping StateVariable objects to their storage slot
+        """
+        current_slot = 0
+        current_bytes = 0
+        variable_slots = {}
+        for variable in self.state_variables_ordered:
+            (size, new_slot_only) = variable.type.storage_size
+            if (new_slot_only and current_bytes > 0) or (32 - current_bytes < size):
+                current_slot += 1
+                current_bytes = 0
+            variable_slots[variable] = current_slot
+            current_bytes += size
+        return variable_slots
 
     # endregion
     ###################################################################################


### PR DESCRIPTION
I am using this in my fork, and thought it would be a nice and useful enough addition on its own to make opening a PR worthwhile. I will be using it in a new upgradeability check I am working on, which will detect all of the differences between V1 and V2 of an implementation contract, for informational purposes and to feed into the differential fuzzing test framework I aim to design. Knowing the storage slot for each state variable will be useful when using cheat codes to read from a contract's storage and compare the values between two versions.