### PR TITLE
detect local shadowing of return vars

### DIFF
--- a/slither/detectors/shadowing/local.py
+++ b/slither/detectors/shadowing/local.py
@@ -49,6 +49,7 @@ contract Bug {
     OVERSHADOWED_MODIFIER = "modifier"
     OVERSHADOWED_STATE_VARIABLE = "state variable"
     OVERSHADOWED_EVENT = "event"
+    OVERSHADOWED_RETURN_VARIABLE = "return variable"
 
     def detect_shadowing_definitions(self, contract):  # pylint: disable=too-many-branches
         """Detects if functions, access modifiers, events, state variables, and local variables are named after
@@ -86,6 +87,15 @@ contract Bug {
                             overshadowed.append(
                                 (self.OVERSHADOWED_STATE_VARIABLE, scope_state_variable)
                             )
+                    # Check named return variables
+                    for named_return in function.returns:
+                        # Shadowed local delcarations in the same function will have "_scope_" in their name.
+                        # See `FunctionSolc._add_local_variable`
+                        if (
+                            "_scope_" in variable.name
+                            and variable.name.split("_scope_")[0] == named_return.name
+                        ):
+                            overshadowed.append((self.OVERSHADOWED_RETURN_VARIABLE, named_return))
 
                 # If we have found any overshadowed objects, we'll want to add it to our result list.
                 if overshadowed:

--- a/tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol
+++ b/tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol
@@ -24,3 +24,13 @@ contract FurtherExtendedContract is ExtendedContract {
 
     function shadowingParent(uint x) public pure { int y; uint z; uint w; uint v; }
 }
+
+contract LocalReturnVariables {
+    uint state;
+    function shadowedState() external view returns(uint state) {
+        return state;
+    } 
+    function good() external view returns(uint val1) {
+        return val1;
+    }
+}

--- a/tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol.0.4.25.LocalShadowing.json
+++ b/tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol.0.4.25.LocalShadowing.json
@@ -208,6 +208,129 @@
             "elements": [
                 {
                     "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 533,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            30
+                        ],
+                        "starting_column": 52,
+                        "ending_column": 62
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedState",
+                            "source_mapping": {
+                                "start": 486,
+                                "length": 88,
+                                "filename_relative": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    30,
+                                    31,
+                                    32
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 434,
+                                        "length": 225,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedState()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 470,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            29
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 15
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "LocalReturnVariables",
+                            "source_mapping": {
+                                "start": 434,
+                                "length": 225,
+                                "filename_relative": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    28,
+                                    29,
+                                    30,
+                                    31,
+                                    32,
+                                    33,
+                                    34,
+                                    35,
+                                    36,
+                                    37
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedState().state (tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol#30) shadows:\n\t- LocalReturnVariables.state (tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol#29) (state variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedState().state](tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol#L30) shadows:\n\t- [LocalReturnVariables.state](tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol#L29) (state variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.4.25/shadowing_local_variable.sol#L30",
+            "id": "1b0030affabcff703e57e4f388b86dbda0f412e51ba8d15248bcae9e4748a012",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
                     "name": "y",
                     "source_mapping": {
                         "start": 398,

--- a/tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol
+++ b/tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol
@@ -24,3 +24,17 @@ contract FurtherExtendedContract is ExtendedContract {
 
     function shadowingParent(uint x) public pure { int y; uint z; uint w; uint v; }
 }
+
+contract LocalReturnVariables {
+    uint state;
+    function shadowedState() external view returns(uint state) {
+        return state;
+    } 
+    function shadowedReturn() external view returns(uint local) {
+        uint local = 1;
+        return local;
+    } 
+    function good() external view returns(uint val1) {
+        return val1;
+    }
+}

--- a/tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol.0.5.16.LocalShadowing.json
+++ b/tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol.0.5.16.LocalShadowing.json
@@ -208,6 +208,137 @@
             "elements": [
                 {
                     "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 536,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            30
+                        ],
+                        "starting_column": 52,
+                        "ending_column": 62
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedState",
+                            "source_mapping": {
+                                "start": 489,
+                                "length": 88,
+                                "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    30,
+                                    31,
+                                    32
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 437,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedState()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 473,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            29
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 15
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "LocalReturnVariables",
+                            "source_mapping": {
+                                "start": 437,
+                                "length": 344,
+                                "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    28,
+                                    29,
+                                    30,
+                                    31,
+                                    32,
+                                    33,
+                                    34,
+                                    35,
+                                    36,
+                                    37,
+                                    38,
+                                    39,
+                                    40,
+                                    41
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedState().state (tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#30) shadows:\n\t- LocalReturnVariables.state (tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#29) (state variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedState().state](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L30) shadows:\n\t- [LocalReturnVariables.state](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L29) (state variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L30",
+            "id": "1b0030affabcff703e57e4f388b86dbda0f412e51ba8d15248bcae9e4748a012",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
                     "name": "y",
                     "source_mapping": {
                         "start": 401,
@@ -563,6 +694,161 @@
             "markdown": "[FurtherExtendedContract.shadowingParent(uint256).w](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L25) shadows:\n\t- [FurtherExtendedContract.w()](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L20-L23) (modifier)\n",
             "first_markdown_element": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L25",
             "id": "a94a2b9331482c75582868e6d3cc5c9b01487e7505f219abcf36a20d76e0b089",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
+                    "name": "local_scope_0",
+                    "source_mapping": {
+                        "start": 653,
+                        "length": 14,
+                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            34
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 23
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 583,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 437,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "local",
+                    "source_mapping": {
+                        "start": 631,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            33
+                        ],
+                        "starting_column": 53,
+                        "ending_column": 63
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 583,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 437,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedReturn().local_scope_0 (tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#34) shadows:\n\t- LocalReturnVariables.shadowedReturn().local (tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#33) (return variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedReturn().local_scope_0](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L34) shadows:\n\t- [LocalReturnVariables.shadowedReturn().local](tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L33) (return variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.5.16/shadowing_local_variable.sol#L34",
+            "id": "cd63bdf3f6420e4e109d20ec44b52fcbcbde1c5b6a0701fc6994b35960ab1e85",
             "check": "shadowing-local",
             "impact": "Low",
             "confidence": "High"

--- a/tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol
+++ b/tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol
@@ -24,3 +24,17 @@ contract FurtherExtendedContract is ExtendedContract {
 
     function shadowingParent(uint __x) public pure { int y; uint z; uint w; uint v; }
 }
+
+contract LocalReturnVariables {
+    uint state;
+    function shadowedState() external view returns(uint state) {
+        return state;
+    } 
+    function shadowedReturn() external view returns(uint local) {
+        uint local = 1;
+        return local;
+    } 
+    function good() external view returns(uint val1) {
+        return val1;
+    }
+}

--- a/tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol.0.6.11.LocalShadowing.json
+++ b/tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol.0.6.11.LocalShadowing.json
@@ -4,6 +4,137 @@
             "elements": [
                 {
                     "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 541,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            30
+                        ],
+                        "starting_column": 52,
+                        "ending_column": 62
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedState",
+                            "source_mapping": {
+                                "start": 494,
+                                "length": 88,
+                                "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    30,
+                                    31,
+                                    32
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedState()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 478,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            29
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 15
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "LocalReturnVariables",
+                            "source_mapping": {
+                                "start": 442,
+                                "length": 344,
+                                "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    28,
+                                    29,
+                                    30,
+                                    31,
+                                    32,
+                                    33,
+                                    34,
+                                    35,
+                                    36,
+                                    37,
+                                    38,
+                                    39,
+                                    40,
+                                    41
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 0
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedState().state (tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#30) shadows:\n\t- LocalReturnVariables.state (tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#29) (state variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedState().state](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L30) shadows:\n\t- [LocalReturnVariables.state](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L29) (state variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L30",
+            "id": "1b0030affabcff703e57e4f388b86dbda0f412e51ba8d15248bcae9e4748a012",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
                     "name": "y",
                     "source_mapping": {
                         "start": 406,
@@ -482,6 +613,161 @@
             "markdown": "[FurtherExtendedContract.shadowingParent(uint256).__x](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L25) shadows:\n\t- [FurtherExtendedContract.__x](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L17) (state variable)\n",
             "first_markdown_element": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L25",
             "id": "cd61765f88a1447471f5c75c7a488af44534d81be3998f5d01a6b5fa8f693327",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
+                    "name": "local_scope_0",
+                    "source_mapping": {
+                        "start": 658,
+                        "length": 14,
+                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            34
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 23
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 588,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "local",
+                    "source_mapping": {
+                        "start": 636,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            33
+                        ],
+                        "starting_column": 53,
+                        "ending_column": 63
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 588,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40,
+                                            41
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 0
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedReturn().local_scope_0 (tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#34) shadows:\n\t- LocalReturnVariables.shadowedReturn().local (tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#33) (return variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedReturn().local_scope_0](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L34) shadows:\n\t- [LocalReturnVariables.shadowedReturn().local](tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L33) (return variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.6.11/shadowing_local_variable.sol#L34",
+            "id": "cd63bdf3f6420e4e109d20ec44b52fcbcbde1c5b6a0701fc6994b35960ab1e85",
             "check": "shadowing-local",
             "impact": "Low",
             "confidence": "High"

--- a/tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol
+++ b/tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol
@@ -24,3 +24,17 @@ contract FurtherExtendedContract is ExtendedContract {
 
     function shadowingParent(uint __x) public pure { int y; uint z; uint w; uint v; }
 }
+
+contract LocalReturnVariables {
+    uint state;
+    function shadowedState() external view returns(uint state) {
+        return state;
+    } 
+    function shadowedReturn() external view returns(uint local) {
+        uint local = 1;
+        return local;
+    } 
+    function good() external view returns(uint val1) {
+        return val1;
+    }
+}

--- a/tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol.0.7.6.LocalShadowing.json
+++ b/tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol.0.7.6.LocalShadowing.json
@@ -4,6 +4,135 @@
             "elements": [
                 {
                     "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 541,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            30
+                        ],
+                        "starting_column": 52,
+                        "ending_column": 62
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedState",
+                            "source_mapping": {
+                                "start": 494,
+                                "length": 88,
+                                "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    30,
+                                    31,
+                                    32
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 2
+                                    }
+                                },
+                                "signature": "shadowedState()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "state",
+                    "source_mapping": {
+                        "start": 478,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            29
+                        ],
+                        "starting_column": 5,
+                        "ending_column": 15
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "contract",
+                            "name": "LocalReturnVariables",
+                            "source_mapping": {
+                                "start": 442,
+                                "length": 344,
+                                "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    28,
+                                    29,
+                                    30,
+                                    31,
+                                    32,
+                                    33,
+                                    34,
+                                    35,
+                                    36,
+                                    37,
+                                    38,
+                                    39,
+                                    40
+                                ],
+                                "starting_column": 1,
+                                "ending_column": 2
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedState().state (tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#30) shadows:\n\t- LocalReturnVariables.state (tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#29) (state variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedState().state](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L30) shadows:\n\t- [LocalReturnVariables.state](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L29) (state variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L30",
+            "id": "1b0030affabcff703e57e4f388b86dbda0f412e51ba8d15248bcae9e4748a012",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
                     "name": "y",
                     "source_mapping": {
                         "start": 406,
@@ -482,6 +611,159 @@
             "markdown": "[FurtherExtendedContract.shadowingParent(uint256).__x](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L25) shadows:\n\t- [FurtherExtendedContract.__x](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L17) (state variable)\n",
             "first_markdown_element": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L25",
             "id": "cd61765f88a1447471f5c75c7a488af44534d81be3998f5d01a6b5fa8f693327",
+            "check": "shadowing-local",
+            "impact": "Low",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "variable",
+                    "name": "local_scope_0",
+                    "source_mapping": {
+                        "start": 658,
+                        "length": 14,
+                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            34
+                        ],
+                        "starting_column": 9,
+                        "ending_column": 23
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 588,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 2
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "variable",
+                    "name": "local",
+                    "source_mapping": {
+                        "start": 636,
+                        "length": 10,
+                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            33
+                        ],
+                        "starting_column": 53,
+                        "ending_column": 63
+                    },
+                    "type_specific_fields": {
+                        "parent": {
+                            "type": "function",
+                            "name": "shadowedReturn",
+                            "source_mapping": {
+                                "start": 588,
+                                "length": 113,
+                                "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "filename_absolute": "/GENERIC_PATH",
+                                "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                "is_dependency": false,
+                                "lines": [
+                                    33,
+                                    34,
+                                    35,
+                                    36
+                                ],
+                                "starting_column": 5,
+                                "ending_column": 6
+                            },
+                            "type_specific_fields": {
+                                "parent": {
+                                    "type": "contract",
+                                    "name": "LocalReturnVariables",
+                                    "source_mapping": {
+                                        "start": 442,
+                                        "length": 344,
+                                        "filename_relative": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "filename_absolute": "/GENERIC_PATH",
+                                        "filename_short": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol",
+                                        "is_dependency": false,
+                                        "lines": [
+                                            28,
+                                            29,
+                                            30,
+                                            31,
+                                            32,
+                                            33,
+                                            34,
+                                            35,
+                                            36,
+                                            37,
+                                            38,
+                                            39,
+                                            40
+                                        ],
+                                        "starting_column": 1,
+                                        "ending_column": 2
+                                    }
+                                },
+                                "signature": "shadowedReturn()"
+                            }
+                        }
+                    }
+                }
+            ],
+            "description": "LocalReturnVariables.shadowedReturn().local_scope_0 (tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#34) shadows:\n\t- LocalReturnVariables.shadowedReturn().local (tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#33) (return variable)\n",
+            "markdown": "[LocalReturnVariables.shadowedReturn().local_scope_0](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L34) shadows:\n\t- [LocalReturnVariables.shadowedReturn().local](tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L33) (return variable)\n",
+            "first_markdown_element": "tests/detectors/shadowing-local/0.7.6/shadowing_local_variable.sol#L34",
+            "id": "cd63bdf3f6420e4e109d20ec44b52fcbcbde1c5b6a0701fc6994b35960ab1e85",
             "check": "shadowing-local",
             "impact": "Low",
             "confidence": "High"


### PR DESCRIPTION
This is an alternative approach to #1404 that modifies the existing `shadowing-local`. Closes https://github.com/crytic/slither/issues/1361