### PR TITLE
Handle custom upgradeability comments for contracts

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -1222,6 +1222,10 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                         break
         return self._is_upgradeable
 
+    @is_upgradeable.setter
+    def is_upgradeable(self, upgradeable: bool):
+        self._is_upgradeable = upgradeable
+
     @property
     def is_upgradeable_proxy(self) -> bool:
         from slither.core.cfg.node import NodeType
@@ -1246,6 +1250,10 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                                     self._is_upgradeable_proxy = True
                                     return self._is_upgradeable_proxy
         return self._is_upgradeable_proxy
+
+    @is_upgradeable_proxy.setter
+    def is_upgradeable_proxy(self, upgradeable_proxy: bool):
+        self._is_upgradeable_proxy = upgradeable_proxy
 
     @property
     def upgradeable_version(self) -> Optional[str]:

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -88,6 +88,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
 
         self._is_upgradeable: Optional[bool] = None
         self._is_upgradeable_proxy: Optional[bool] = None
+        self._upgradeable_version: Optional[str] = None
 
         self.is_top_level = False  # heavily used, so no @property
 
@@ -1245,6 +1246,14 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                                     self._is_upgradeable_proxy = True
                                     return self._is_upgradeable_proxy
         return self._is_upgradeable_proxy
+
+    @property
+    def upgradeable_version(self) -> Optional[str]:
+        return self._upgradeable_version
+
+    @upgradeable_version.setter
+    def upgradeable_version(self, version_name: str):
+        self._upgradeable_version = version_name
 
     # endregion
     ###################################################################################

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -703,7 +703,11 @@ class ContractSolc(CallerContextExpression):
         self._customErrorParsed = []
 
     def _handle_comment(self, attributes: Dict):
-        if "documentation" in attributes and "text" in attributes["documentation"]:
+        if (
+                "documentation" in attributes
+                and attributes["documentation"] is not None
+                and "text" in attributes["documentation"]
+        ):
             candidates = attributes["documentation"]["text"].replace("\n", ",").split(",")
 
             for candidate in candidates:

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -712,9 +712,9 @@ class ContractSolc(CallerContextExpression):
 
             for candidate in candidates:
                 if "@custom:security isProxy" in candidate:
-                    self._contract._is_upgradeable_proxy = True
+                    self._contract.is_upgradeable_proxy = True
                 if "@custom:security isUpgradeable" in candidate:
-                    self._contract._is_upgradeable = True
+                    self._contract.is_upgradeable = True
 
                 version_name = re.search(r'@custom:version name="([\w, .]*)"', candidate)
                 if version_name:

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -704,9 +704,9 @@ class ContractSolc(CallerContextExpression):
 
     def _handle_comment(self, attributes: Dict):
         if (
-                "documentation" in attributes
-                and attributes["documentation"] is not None
-                and "text" in attributes["documentation"]
+            "documentation" in attributes
+            and attributes["documentation"] is not None
+            and "text" in attributes["documentation"]
         ):
             candidates = attributes["documentation"]["text"].replace("\n", ",").split(",")
 
@@ -716,9 +716,7 @@ class ContractSolc(CallerContextExpression):
                 if "@custom:security isUpgradeable" in candidate:
                     self._contract._is_upgradeable = True
 
-                version_name = re.search(
-                    r'@custom:version name="([\w, .]*)"', candidate
-                )
+                version_name = re.search(r'@custom:version name="([\w, .]*)"', candidate)
                 if version_name:
                     self._contract.upgradeable_version = version_name.group(1)
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -65,8 +65,10 @@ class ContractSolc(CallerContextExpression):
         # Export info
         if self.is_compact_ast:
             self._contract.name = self._data["name"]
+            self._handle_comment(self._data)
         else:
             self._contract.name = self._data["attributes"][self.get_key()]
+            self._handle_comment(self._data["attributes"])
 
         self._contract.id = self._data["id"]
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Dict, Callable, TYPE_CHECKING, Union, Set
 
 from slither.core.declarations import Modifier, Event, EnumContract, StructureContract, Function
@@ -710,6 +711,12 @@ class ContractSolc(CallerContextExpression):
                     self._contract._is_upgradeable_proxy = True
                 if "@custom:security isUpgradeable" in candidate:
                     self._contract._is_upgradeable = True
+
+                version_name = re.search(
+                    r'@custom:version name="([\w, .]*)"', candidate
+                )
+                if version_name:
+                    self._contract.upgradeable_version = version_name.group(1)
 
     # endregion
     ###################################################################################

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -699,6 +699,16 @@ class ContractSolc(CallerContextExpression):
         self._usingForNotParsed = []
         self._customErrorParsed = []
 
+    def _handle_comment(self, attributes: Dict):
+        if "documentation" in attributes and "text" in attributes["documentation"]:
+            candidates = attributes["documentation"]["text"].replace("\n", ",").split(",")
+
+            for candidate in candidates:
+                if "@custom:security isProxy" in candidate:
+                    self._contract._is_upgradeable_proxy = True
+                if "@custom:security isUpgradeable" in candidate:
+                    self._contract._is_upgradeable = True
+
     # endregion
     ###################################################################################
     ###################################################################################


### PR DESCRIPTION
Addresses #1301 

Should probably be revisited later, once upgradeable proxy detection is improved, since `@custom:security isProxy` may be applicable to proxies that are not in fact upgradeable.