### PR TITLE
Support for nested tuples added

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -18,6 +18,8 @@ from slither.core.expressions import (
     CallExpression,
     Identifier,
     MemberAccess,
+    AssignmentOperation,
+    TupleExpression,
 )
 from slither.core.solidity_types import ArrayType, ElementaryType, TypeAlias
 from slither.core.solidity_types.type import Type
@@ -150,21 +152,32 @@ class ExpressionToSlithIR(ExpressionVisitor):
         return self._result
 
     def _post_assignement_operation(self, expression):
-        left = get(expression.expression_left)
-        right = get(expression.expression_right)
+        expr_left = expression.expression_left
+        expr_right = expression.expression_right
+        left = get(expr_left)
+        right = get(expr_right)
         if isinstance(left, list):  # tuple expression:
-            if isinstance(right, list):  # unbox assigment
-                assert len(left) == len(right)
-                for idx, _ in enumerate(left):
-                    if not left[idx] is None:
-                        operation = convert_assignment(
-                            left[idx],
-                            right[idx],
-                            expression.type,
-                            expression.expression_return_type,
-                        )
-                        operation.set_expression(expression)
-                        self._result.append(operation)
+            if isinstance(right, list):  # unbox assignment
+                assert len(expr_left.expressions) == len(expr_right.expressions)
+                for idx, _ in enumerate(expr_left.expressions):
+                    if not expr_left.expressions[idx] is None:
+                        if isinstance(expr_left.expressions[idx], TupleExpression):  # nested tuple
+                            nested_expression = AssignmentOperation(
+                                expr_left.expressions[idx],
+                                expr_right.expressions[idx],
+                                expression.type,
+                                expression.expression_return_type
+                            )
+                            self._post_assignement_operation(nested_expression)
+                        else:
+                            operation = convert_assignment(
+                                left[idx],
+                                right[idx],
+                                expression.type,
+                                expression.expression_return_type,
+                            )
+                            operation.set_expression(expression)
+                            self._result.append(operation)
                 set_val(expression, None)
             else:
                 assert isinstance(right, TupleVariable)
@@ -500,7 +513,8 @@ class ExpressionToSlithIR(ExpressionVisitor):
         set_val(expression, val)
 
     def _post_tuple_expression(self, expression):
-        expressions = [get(e) if e else None for e in expression.expressions]
+        # don't use get(e) here, since e.context[key] may still be needed in case of nested tuples
+        expressions = [e.context[key] if e else None for e in expression.expressions]
         if len(expressions) == 1:
             val = expressions[0]
         else:

--- a/tests/slithir/test_tuples.py
+++ b/tests/slithir/test_tuples.py
@@ -1,0 +1,56 @@
+from slither import Slither
+from slither.core.declarations import Function
+from slither.core.variables.local_variable import LocalVariable
+from slither.slithir.operations import Assignment
+from slither.slithir.variables import Constant
+
+
+def test_tuples() -> None:
+    slither = Slither("./tests/slithir/tuples.sol")
+    contract = slither.contracts[0]
+    functions = contract.functions
+    check_f1_f2(functions[0])
+    check_f1_f2(functions[1])
+    check_f3(functions[2])
+
+
+def check_f1_f2(function: Function):
+    assert len(function.slithir_operations) == 2
+    op1 = function.slithir_operations[0]
+    assert isinstance(op1, Assignment)
+    assert isinstance(op1.lvalue, LocalVariable)
+    assert isinstance(op1.rvalue, Constant)
+    assert op1.lvalue.name == "x"
+    assert op1.rvalue.name == "7"
+
+
+def check_f3(function: Function):
+    assert len(function.slithir_operations) == 5
+    op1 = function.slithir_operations[0]
+    op2 = function.slithir_operations[1]
+    op3 = function.slithir_operations[2]
+    op4 = function.slithir_operations[3]
+    assert isinstance(op1, Assignment)
+    assert isinstance(op2, Assignment)
+    assert isinstance(op3, Assignment)
+    assert isinstance(op4, Assignment)
+    assert isinstance(op1.lvalue, LocalVariable)
+    assert isinstance(op1.rvalue, Constant)
+    assert isinstance(op2.lvalue, LocalVariable)
+    assert isinstance(op2.rvalue, Constant)
+    assert isinstance(op3.lvalue, LocalVariable)
+    assert isinstance(op3.rvalue, Constant)
+    assert isinstance(op4.lvalue, LocalVariable)
+    assert isinstance(op4.rvalue, Constant)
+    assert op1.lvalue.name == "x"
+    assert op1.rvalue.name == "1"
+    assert op2.lvalue.name == "y"
+    assert op2.rvalue.name == "2"
+    assert op3.lvalue.name == "z"
+    assert op3.rvalue.name == "3"
+    assert op4.lvalue.name == "t"
+    assert op4.rvalue.name == "4"
+
+
+if __name__ == "__main__":
+    test_tuples()

--- a/tests/slithir/tuples.sol
+++ b/tests/slithir/tuples.sol
@@ -1,0 +1,26 @@
+contract Tuples 
+{
+    function f1() public returns(uint) 
+    {
+        uint x;
+        ((x, ), ) = ((7, 7) ,7);
+        return x;
+    }
+    
+    function f2() public returns(uint)
+    {
+        uint x;
+        (x, ) = (7, 7);
+        return x;
+    }
+
+    function f3() public returns(uint) 
+    {
+        uint x;
+        uint y;
+        uint z;
+        uint t;
+        ((x, (y, z), t), ) = ((1, (2, 3) ,4), 5);
+        return x;
+    } 
+}


### PR DESCRIPTION
Fixes #306.

Current `_post_assignement_operation` implementation assumed there are no nested tuples - it just iterated over left and right expression and tried to call `convert_assignment`, which was failing for nested tuples due to the check made at `Assignment` constructor (`is_valid_lvalue` to be precise).

I have changed the function by checking whether the left expression is `TupleExpression` and, if that is the case, calling `_post_assignement_operation` recursively with newly created `AssignmentOperation`. Otherwise, the function behaves as usual.

Some simple tests are added as well, to ensure that `slither` will handle nested tuples in the future.

**Note:** I'm still not very familiar with `slithir` intermediate form, so in case the tests assume incorrect output, please let me know.