### PR TITLE
Filter upgradeability checks by name/impact

### DIFF
--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -35,6 +35,8 @@ def parse_args(
         usage="slither-check-upgradeability contract.sol ContractName",
     )
 
+    group_checks = parser.add_argument_group("Checks")
+
     parser.add_argument("contract.sol", help="Codebase to analyze")
     parser.add_argument("ContractName", help="Contract name (logic contract)")
 
@@ -53,7 +55,7 @@ def parse_args(
         default=False,
     )
 
-    parser.add_argument(
+    group_checks.add_argument(
         "--detect",
         help="Comma-separated list of detectors, defaults to all, "
         f"available detectors: {', '.join(d.ARGUMENT for d in check_classes)}",
@@ -62,7 +64,15 @@ def parse_args(
         default="all",
     )
 
-    parser.add_argument(
+    group_checks.add_argument(
+        "--list-detectors",
+        help="List available detectors",
+        action=ListDetectors,
+        nargs=0,
+        default=False,
+    )
+
+    group_checks.add_argument(
         "--exclude",
         help="Comma-separated list of detectors that should be excluded",
         action="store",
@@ -70,11 +80,31 @@ def parse_args(
         default=None,
     )
 
-    parser.add_argument(
-        "--list-detectors",
-        help="List available detectors",
-        action=ListDetectors,
-        nargs=0,
+    group_checks.add_argument(
+        "--exclude-informational",
+        help="Exclude informational impact analyses",
+        action="store_true",
+        default=False,
+    )
+
+    group_checks.add_argument(
+        "--exclude-low",
+        help="Exclude low impact analyses",
+        action="store_true",
+        default=False,
+    )
+
+    group_checks.add_argument(
+        "--exclude-medium",
+        help="Exclude medium impact analyses",
+        action="store_true",
+        default=False,
+    )
+
+    group_checks.add_argument(
+        "--exclude-high",
+        help="Exclude high impact analyses",
+        action="store_true",
         default=False,
     )
 
@@ -144,6 +174,25 @@ def choose_checks(
                 raise Exception(f"Error: {detector} is not a detector")
         detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)
         return detectors_to_run
+
+    if args.exclude_informational:
+        detectors_to_run = [
+            d for d in detectors_to_run if d.IMPACT != DetectorClassification.INFORMATIONAL
+        ]
+    if args.exclude_low:
+        detectors_to_run = [
+            d for d in detectors_to_run if d.IMPACT != DetectorClassification.LOW
+        ]
+    if args.exclude_medium:
+        detectors_to_run = [
+            d for d in detectors_to_run if d.IMPACT != DetectorClassification.MEDIUM
+        ]
+    if args.exclude_high:
+        detectors_to_run = [
+            d for d in detectors_to_run if d.IMPACT != DetectorClassification.HIGH
+        ]
+
+    detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)
     return detectors_to_run
 
 

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -30,9 +30,7 @@ logger: logging.Logger = logging.getLogger("Slither")
 logger.setLevel(logging.INFO)
 
 
-def parse_args(
-    check_classes: List[Type[AbstractCheck]]
-) -> argparse.Namespace:
+def parse_args(check_classes: List[Type[AbstractCheck]]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Slither Upgradeability Checks. For usage information see https://github.com/crytic/slither/wiki/Upgradeability-Checks.",
         usage="slither-check-upgradeability contract.sol ContractName",
@@ -183,17 +181,11 @@ def choose_checks(
             d for d in detectors_to_run if d.IMPACT != CheckClassification.INFORMATIONAL
         ]
     if args.exclude_low:
-        detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != CheckClassification.LOW
-        ]
+        detectors_to_run = [d for d in detectors_to_run if d.IMPACT != CheckClassification.LOW]
     if args.exclude_medium:
-        detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != CheckClassification.MEDIUM
-        ]
+        detectors_to_run = [d for d in detectors_to_run if d.IMPACT != CheckClassification.MEDIUM]
     if args.exclude_high:
-        detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != CheckClassification.HIGH
-        ]
+        detectors_to_run = [d for d in detectors_to_run if d.IMPACT != CheckClassification.HIGH]
 
     detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)
     return detectors_to_run

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -14,7 +14,10 @@ from slither.exceptions import SlitherException
 from slither.utils.colors import red
 from slither.utils.output import output_to_json
 from slither.tools.upgradeability.checks import all_checks
-from slither.tools.upgradeability.checks.abstract_checks import AbstractCheck
+from slither.tools.upgradeability.checks.abstract_checks import (
+    AbstractCheck,
+    CheckClassification,
+)
 from slither.tools.upgradeability.utils.command_line import (
     output_detectors_json,
     output_wiki,
@@ -177,19 +180,19 @@ def choose_checks(
 
     if args.exclude_informational:
         detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != DetectorClassification.INFORMATIONAL
+            d for d in detectors_to_run if d.IMPACT != CheckClassification.INFORMATIONAL
         ]
     if args.exclude_low:
         detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != DetectorClassification.LOW
+            d for d in detectors_to_run if d.IMPACT != CheckClassification.LOW
         ]
     if args.exclude_medium:
         detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != DetectorClassification.MEDIUM
+            d for d in detectors_to_run if d.IMPACT != CheckClassification.MEDIUM
         ]
     if args.exclude_high:
         detectors_to_run = [
-            d for d in detectors_to_run if d.IMPACT != DetectorClassification.HIGH
+            d for d in detectors_to_run if d.IMPACT != CheckClassification.HIGH
         ]
 
     detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -187,7 +187,7 @@ def choose_checks(
     if args.exclude_high:
         detectors_to_run = [d for d in detectors_to_run if d.IMPACT != CheckClassification.HIGH]
 
-    detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)
+    # detectors_to_run = sorted(detectors_to_run, key=lambda x: x.IMPACT)
     return detectors_to_run
 
 


### PR DESCRIPTION
Implements #936.

Follows the same approach as the equivalent argument options in the main Slither module, with options to selectively enable/disable checks by name using comma separated lists, and to exclude checks according to impact level.

Does not currently provide an option to enable only a given impact level (i.e., the opposite of `--exclude-<IMPACT>`), but implementing this would be trivial if desired.