### PR TITLE
List storage differences between two blocks.

### DIFF
--- a/slither/tools/read_storage/README.md
+++ b/slither/tools/read_storage/README.md
@@ -22,6 +22,7 @@ optional arguments:
   --value                           Toggle used to include values in output.
   --max-depth MAX_DEPTH             Max depth to search in data structure.
   --block BLOCK_NUMBER              Block number to retrieve storage from (requires archive rpc node)
+  --diff-block DIFF_BLOCK_NUMBER    Calculate storage differences between BLOCK_NUMBER and DIFF_BLOCK_NUMBER. Implies --value.
 ```
 
 ### Examples
@@ -60,6 +61,12 @@ Retrieve the ERC20 balance slot of an account:
 
 ```shell
 slither-read-storage 0xa2327a938Febf5FEC13baCFb16Ae10EcBc4cbDCF --variable-name balances --key 0xab5801a7d398351b8be11c439e05c5b3259aec9b
+```
+
+Compare token balances of an account at blocks 16237722 and 16231904:
+
+```shell
+slither-read-storage 0x6B175474E89094C44Da98b954EedeAC495271d0F --block 16237722 --diff-block 16231904 --variable-name balanceOf --key 0xf977814e90da44bfa03b6295a0616a897441acec --rpc-url $RPC_URL
 ```
 
 To retrieve the actual balance, pass `--variable-name balances` and `--key 0xab5801a7d398351b8be11c439e05c5b3259aec9b`. (`balances` is a `mapping(address => uint)`)

--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -150,10 +150,17 @@ def print_diff_table(orig_block: int, diff_block: int, orig_info: SlotInfo, diff
         else:
             table_equal.add_row(row)
 
-    print("\n\nSlots with same value:\n======================\n")
-    print(table_equal)
-    print("\n\nSlots with different value:\n===========================\n")
-    print(table_different)
+    if len(table_equal._rows) > 0:
+        print("\n\nSlots with same value:\n======================\n")
+        print(table_equal)
+    else:
+        print("\n\nNo slots with same value found.\n===============================\n")
+
+    if len(table_different._rows) > 0:
+        print("\n\nSlots with different value:\n===========================\n")
+        print(table_different)
+    else:
+        print("\n\nNo slots with different value found.\n====================================\n")
 
 
 def main() -> None:
@@ -215,6 +222,7 @@ def main() -> None:
         srs.walk_slot_info(srs.get_slot_values)
 
     if args.diff_block:
+        orig_block = srs.block
         slots_block_orig = copy.deepcopy(srs.slot_info)
 
         srs.block = diff_block
@@ -226,7 +234,7 @@ def main() -> None:
         srs.walk_slot_info(srs.get_slot_values)
         slots_block_diff = copy.deepcopy(srs.slot_info)
 
-        print_diff_table(args.block, diff_block, slots_block_orig, slots_block_diff)
+        print_diff_table(orig_block, diff_block, slots_block_orig, slots_block_diff)
 
     if args.table:
         srs.walk_slot_info(srs.convert_slot_info_to_rows)

--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -216,9 +216,16 @@ def main() -> None:
 
     if args.diff_block:
         slots_block_orig = copy.deepcopy(srs.slot_info)
+
         srs.block = diff_block
+        # This takes into account differences in dynamic arrays
+        if args.variable_name:
+            srs.get_target_variables(**vars(args))
+        else:
+            srs.get_storage_layout()
         srs.walk_slot_info(srs.get_slot_values)
         slots_block_diff = copy.deepcopy(srs.slot_info)
+
         print_diff_table(args.block, diff_block, slots_block_orig, slots_block_diff)
 
     if args.table:

--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -12,6 +12,7 @@ from slither import Slither
 from slither.tools.read_storage.read_storage import SlitherReadStorage, SlotInfo
 from slither.utils.myprettytable import MyPrettyTable
 
+
 def parse_args() -> argparse.Namespace:
     """Parse the underlying arguments for the program.
     Returns:
@@ -131,19 +132,18 @@ def print_diff_table(orig_block: int, diff_block: int, orig_info: SlotInfo, diff
         newer_info = diff_info
 
     field_names = [
-        field.name for field in dataclasses.fields(SlotInfo) if (field.name != "elems" and field.name != "value")
+        field.name
+        for field in dataclasses.fields(SlotInfo)
+        if (field.name not in ("elems", "value"))
     ]
 
-    field_names.extend([ 
-        "value at " + str(older_block), 
-        "value at " + str(newer_block)
-    ])
-    
-    table_equal     = MyPrettyTable(field_names)
+    field_names.extend(["value at " + str(older_block), "value at " + str(newer_block)])
+
+    table_equal = MyPrettyTable(field_names)
     table_different = MyPrettyTable(field_names)
 
     for elem in orig_info:
-        row= [getattr(older_info[elem], field) for field in field_names[:-2]]
+        row = [getattr(older_info[elem], field) for field in field_names[:-2]]
         row.extend([older_info[elem].value, newer_info[elem].value])
         if older_info[elem].value != newer_info[elem].value:
             table_different.add_row(row)
@@ -186,7 +186,9 @@ def main() -> None:
         try:
             diff_block = int(args.diff_block)
         except ValueError:
-            raise Exception("--diff-block argument must be an integer representing a valid block number.")
+            raise Exception(
+                "--diff-block argument must be an integer representing a valid block number."
+            )
 
     if args.rpc_url:
         # Remove target prefix e.g. rinkeby:0x0 -> 0x0.


### PR DESCRIPTION
This PR implements logic to calculate the difference between storage slots at two different blocks.

A new command line option (`--diff-block`) is added to `slither-read-storage`. This will allow to compare between storage state at the block specified by `--block` (`latest`, by default) and `--diff-block`.

Using this option will print two tables after execution: the first one shows the values that haven't changed, the second one the modified values.

Should address #1315 when complete.