### PR TITLE
slither-doctor: PATH checks

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -1,22 +1,19 @@
 ---
-name: CI (slither-doctor)
+name: CI
 
 defaults:
   run:
     shell: bash
 
 on:
-  push:
-    branches:
-      - master
-      - dev
+  workflow_dispatch:
   pull_request:
     paths:
       - 'slither/tools/doctor/**'
       - '.github/workflows/doctor.yml'
 
 jobs:
-  doctor:
+  slither-doctor:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Try venv Slither
         run: |
           python3 -m venv venv
-          source venv/bin/activate
+          source venv/bin/activate || source venv/Scripts/activate
           hash -r
           pip3 install .
 

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -1,0 +1,74 @@
+---
+name: CI (slither-doctor)
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    paths:
+      - 'slither/tools/doctor/**'
+      - '.github/workflows/doctor.yml'
+
+jobs:
+  doctor:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-2022"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Try system-wide Slither
+        run: |
+          pip3 install .
+
+          # escape cwd so python doesn't pick up local module
+          cd /
+
+          echo "Via module"
+          python3 -m slither.tools.doctor .
+
+          echo "Via binary"
+          slither-doctor .
+
+      - name: Try user Slither
+        run: |
+          pip3 install --user .
+
+          # escape cwd so python doesn't pick up local module
+          cd /
+
+          echo "Via module"
+          python3 -m slither.tools.doctor .
+
+          echo "Via binary"
+          slither-doctor .
+
+      - name: Try venv Slither
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          hash -r
+          pip3 install .
+
+          # escape cwd so python doesn't pick up local module
+          cd /
+
+          echo "Via module"
+          python3 -m slither.tools.doctor .
+
+          echo "Via binary"
+          slither-doctor .

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -20,6 +20,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
         python: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          # strange failure
+          - os: windows-2022
+            python: 3.8
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -33,42 +33,54 @@ jobs:
 
       - name: Try system-wide Slither
         run: |
+          echo "::group::Install slither"
           pip3 install .
+          echo "::endgroup::"
 
           # escape cwd so python doesn't pick up local module
           cd /
 
-          echo "Via module"
+          echo "::group::Via module"
           python3 -m slither.tools.doctor .
+          echo "::endgroup::"
 
-          echo "Via binary"
+          echo "::group::Via binary"
           slither-doctor .
+          echo "::endgroup::"
 
       - name: Try user Slither
         run: |
+          echo "::group::Install slither"
           pip3 install --user .
+          echo "::endgroup::"
 
           # escape cwd so python doesn't pick up local module
           cd /
 
-          echo "Via module"
+          echo "::group::Via module"
           python3 -m slither.tools.doctor .
+          echo "::endgroup::"
 
-          echo "Via binary"
+          echo "::group::Via binary"
           slither-doctor .
+          echo "::endgroup::"
 
       - name: Try venv Slither
         run: |
+          echo "::group::Install slither"
           python3 -m venv venv
           source venv/bin/activate || source venv/Scripts/activate
           hash -r
           pip3 install .
+          echo "::endgroup::"
 
           # escape cwd so python doesn't pick up local module
           cd /
 
-          echo "Via module"
+          echo "::group::Via module"
           python3 -m slither.tools.doctor .
+          echo "::endgroup::"
 
-          echo "Via binary"
+          echo "::group::Via binary"
           slither-doctor .
+          echo "::endgroup::"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
+        "packaging",
         "prettytable>=0.7.2",
         "pycryptodome>=3.4.6",
         # "crytic-compile>=0.2.4",

--- a/slither/tools/doctor/__main__.py
+++ b/slither/tools/doctor/__main__.py
@@ -1,4 +1,6 @@
 import argparse
+import logging
+import sys
 
 from crytic_compile import cryticparser
 
@@ -25,6 +27,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main():
+    # log on stdout to keep output in order
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
+
     args = parse_args()
     kwargs = vars(args)
 

--- a/slither/tools/doctor/checks/__init__.py
+++ b/slither/tools/doctor/checks/__init__.py
@@ -1,6 +1,7 @@
 from typing import Callable, List
 from dataclasses import dataclass
 
+from slither.tools.doctor.checks.paths import check_slither_path
 from slither.tools.doctor.checks.platform import compile_project, detect_platform
 from slither.tools.doctor.checks.versions import show_versions
 
@@ -12,6 +13,7 @@ class Check:
 
 
 ALL_CHECKS: List[Check] = [
+    Check("PATH configuration", check_slither_path),
     Check("Software versions", show_versions),
     Check("Project platform", detect_platform),
     Check("Project compilation", compile_project),

--- a/slither/tools/doctor/checks/paths.py
+++ b/slither/tools/doctor/checks/paths.py
@@ -1,12 +1,41 @@
 from pathlib import Path
 from typing import List, Optional, Tuple
 import shutil
+import sys
 import sysconfig
 
 from slither.utils.colors import yellow, green, red
 
 
+def path_is_relative_to(path: Path, relative_to: Path) -> bool:
+    """
+    Check if a path is relative to another one.
+
+    Compatibility wrapper for Path.is_relative_to
+    """
+    if sys.version_info >= (3, 9, 0):
+        return path.is_relative_to(relative_to)
+
+    path_parts = path.resolve().parts
+    relative_to_parts = relative_to.resolve().parts
+
+    if len(path_parts) < len(relative_to_parts):
+        return False
+
+    for (a, b) in zip(path_parts, relative_to_parts):
+        if a != b:
+            return False
+
+    return True
+
+
 def check_path_config(name: str) -> Tuple[bool, Optional[Path], List[Path]]:
+    """
+    Check if a given Python binary/script is in PATH.
+    :return: Returns if the binary on PATH corresponds to this installation,
+             its path (if present), and a list of possible paths where this
+             binary might be found.
+    """
     binary_path = shutil.which(name)
     possible_paths = []
 
@@ -21,9 +50,9 @@ def check_path_config(name: str) -> Tuple[bool, Optional[Path], List[Path]]:
     if binary_path is not None:
         binary_path = Path(binary_path)
         this_code = Path(__file__)
-        this_binary = list(filter(lambda x: this_code.is_relative_to(x[1]), possible_paths))
+        this_binary = list(filter(lambda x: path_is_relative_to(this_code, x[1]), possible_paths))
         binary_here = len(this_binary) > 0 and all(
-            binary_path.is_relative_to(script) for script, _ in this_binary
+            path_is_relative_to(binary_path, script) for script, _ in this_binary
         )
 
     return binary_here, binary_path, list(set(script for script, _ in possible_paths))

--- a/slither/tools/doctor/checks/paths.py
+++ b/slither/tools/doctor/checks/paths.py
@@ -69,8 +69,8 @@ def check_slither_path(**_kwargs) -> None:
         else:
             print(
                 yellow(
-                    f"This path does not correspond to this slither-doctor installation.\n"
-                    + "Double-check the order of directories in PATH if you have several slither installations."
+                    "This path does not correspond to this slither-doctor installation.\n"
+                    + "Double-check the order of directories in PATH if you have several Slither installations."
                 )
             )
             show_paths = True

--- a/slither/tools/doctor/checks/paths.py
+++ b/slither/tools/doctor/checks/paths.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from typing import List, Optional, Tuple
+import shutil
+import sysconfig
+
+from slither.utils.colors import yellow, green, red
+
+
+def check_path_config(name: str) -> Tuple[bool, Optional[Path], List[Path]]:
+    binary_path = shutil.which(name)
+    possible_paths = []
+
+    for scheme in sysconfig.get_scheme_names():
+        script_path = Path(sysconfig.get_path("scripts", scheme))
+        purelib_path = Path(sysconfig.get_path("purelib", scheme))
+        script_binary_path = shutil.which(name, path=script_path)
+        if script_binary_path is not None:
+            possible_paths.append((script_path, purelib_path))
+
+    binary_here = False
+    if binary_path is not None:
+        binary_path = Path(binary_path)
+        this_code = Path(__file__)
+        this_binary = list(filter(lambda x: this_code.is_relative_to(x[1]), possible_paths))
+        binary_here = len(this_binary) > 0 and all(
+            binary_path.is_relative_to(script) for script, _ in this_binary
+        )
+
+    return binary_here, binary_path, list(set(script for script, _ in possible_paths))
+
+
+def check_slither_path(**_kwargs) -> None:
+    binary_here, binary_path, possible_paths = check_path_config("slither")
+    show_paths = False
+
+    if binary_path:
+        print(green(f"`slither` found in PATH at `{binary_path}`."))
+        if binary_here:
+            print(green("Its location matches this slither-doctor installation."))
+        else:
+            print(
+                yellow(
+                    f"This path does not correspond to this slither-doctor installation.\n"
+                    + "Double-check the order of directories in PATH if you have several slither installations."
+                )
+            )
+            show_paths = True
+    else:
+        print(red("`slither` was not found in PATH."))
+        show_paths = True
+
+    if show_paths:
+        print()
+        print("Consider adding one of the following directories to PATH:")
+        for path in possible_paths:
+            print(f"  * {path}")

--- a/slither/tools/doctor/checks/versions.py
+++ b/slither/tools/doctor/checks/versions.py
@@ -3,19 +3,19 @@ import json
 from typing import Optional
 import urllib
 
-from packaging.version import parse, LegacyVersion, Version
+from packaging.version import parse, Version
 
 from slither.utils.colors import yellow, green
 
 
-def get_installed_version(name: str) -> Optional[LegacyVersion | Version]:
+def get_installed_version(name: str) -> Optional[Version]:
     try:
         return parse(metadata.version(name))
     except metadata.PackageNotFoundError:
         return None
 
 
-def get_github_version(name: str) -> Optional[LegacyVersion | Version]:
+def get_github_version(name: str) -> Optional[Version]:
     try:
         with urllib.request.urlopen(
             f"https://api.github.com/repos/crytic/{name}/releases/latest"

--- a/slither/tools/doctor/checks/versions.py
+++ b/slither/tools/doctor/checks/versions.py
@@ -45,7 +45,9 @@ def show_versions(**_kwargs) -> None:
 
     for name, (installed, latest) in versions.items():
         color = yellow if name in outdated else green
-        print(f"{name + ':':<16}{color(installed or 'N/A'):<16} (latest is {latest or 'Unknown'})")
+        print(
+            f"{name + ':':<16}{color(str(installed) or 'N/A'):<16} (latest is {str(latest) or 'Unknown'})"
+        )
 
     if len(outdated) > 0:
         print()


### PR DESCRIPTION
This PR adds a new check to slither-doctor, that validates if `$PATH` is set correctly in the system.

When all looks good, it will print the following:

<img width="430" alt="Screenshot 2023-01-04 at 20 18 06" src="https://user-images.githubusercontent.com/2642849/210668087-a86bde85-77e8-48f2-8233-59c680e94c33.png">

However, if the path is misconfigured it will print a red message and suggest a folder you should add to `$PATH` (for this example I broke my PATH config on purpose). Users can run slither-doctor as `python3 -m slither.tools.doctor` even if their PATH is misconfigured:

<img width="516" alt="Screenshot 2023-01-04 at 20 20 41" src="https://user-images.githubusercontent.com/2642849/210668359-fb662ce3-1e69-4893-a7fb-d99ab8c96437.png">

This will also warn if you somehow have another Slither installation earlier in PATH (exemplified here by running slither-doctor from a non-activated venv, while there's a system-wide installation of slither)

<img width="649" alt="Screenshot 2023-01-04 at 20 24 26" src="https://user-images.githubusercontent.com/2642849/210668799-644a32de-9337-439c-ade0-df87908d5cdc.png">
