### PR TITLE
Too-many-digits detector issue fix

### DIFF
--- a/slither/detectors/statements/too_many_digits.py
+++ b/slither/detectors/statements/too_many_digits.py
@@ -5,6 +5,7 @@ Module detecting numbers with too many digits.
 import re
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from slither.slithir.variables import Constant
+from slither.core.solidity_types.elementary_type import Byte
 
 _HEX_ADDRESS_REGEXP = re.compile("(0[xX])?[0-9a-fA-F]{40}")
 
@@ -62,6 +63,9 @@ Use:
         for node in f.nodes:
             # each node contains a list of IR instruction
             for ir in node.irs:
+                # if statement variable type is `byte(s)`; skip.
+                if hasattr(ir, "lvalue") and ir.lvalue.type.name in Byte:
+                    continue
                 # iterate over all the variables read by the IR
                 for read in ir.read:
                     # if the variable is a constant
@@ -80,6 +84,7 @@ Use:
         for contract in self.compilation_unit.contracts_derived:
             # iterate over all functions
             for f in contract.functions:
+
                 # iterate over all the nodes
                 ret = self._detect_too_many_digits(f)
                 if ret:

--- a/slither/detectors/statements/too_many_digits.py
+++ b/slither/detectors/statements/too_many_digits.py
@@ -64,8 +64,9 @@ Use:
             # each node contains a list of IR instruction
             for ir in node.irs:
                 # if statement variable type is `byte(s)`; skip.
-                if hasattr(ir, "lvalue") and ir.lvalue.type.name in Byte:
-                    continue
+                if hasattr(ir, "lvalue") and hasattr(ir.lvalue.type, "name"):
+                    if ir.lvalue.type.name in Byte:
+                        continue
                 # iterate over all the variables read by the IR
                 for read in ir.read:
                     # if the variable is a constant


### PR DESCRIPTION
Fix to issue [#1223](https://github.com/crytic/slither/issues/1223)

### Code to replicate issue
```
pragma solidity ^0.8.0;
contract BeaconProxy {
  function test() public returns(uint) {
  return 16777216;
  }
}

contract C {
 struct S {
   address o;
 }

 function test() public returns (bytes memory){
   bytes memory code = type(BeaconProxy).creationCode;

   return code;
 }
}
```
### Log Output
```
C.test() (contracts/Beacon.sol#13-17) uses literals with too many digits:
        - code = type()(BeaconProxy).creationCode (contracts/Beacon.sol#14)
```
