### PR TITLE
Add type to type_alias

### DIFF
--- a/slither/core/solidity_types/type_alias.py
+++ b/slither/core/solidity_types/type_alias.py
@@ -16,6 +16,18 @@ class TypeAlias(Type):
         self.underlying_type = underlying_type
 
     @property
+    def type(self) -> Type:
+        """
+        Return the underlying type. Alias for underlying_type
+
+
+        Returns:
+            Type: the underlying type
+
+        """
+        return self.underlying_type
+
+    @property
     def storage_size(self) -> Tuple[int, bool]:
         return self.underlying_type.storage_size
 


### PR DESCRIPTION
Adding `type` will help with directly access, like in https://github.com/crytic/slither/blob/7ea572723b4eddb18e716c4ae94e0d2100791127/slither/core/cfg/node.py#L911
