### PR TITLE
Missing references fix

### DIFF
--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -2,7 +2,6 @@ import logging
 import re
 from typing import Dict, TYPE_CHECKING
 
-from slither.core.declarations import Contract
 from slither.core.declarations.solidity_variables import (
     SOLIDITY_VARIABLES_COMPOSED,
     SolidityVariableComposed,
@@ -38,7 +37,6 @@ from slither.core.solidity_types import (
     ElementaryType,
     UserDefinedType,
 )
-from slither.core.variables.variable import Variable
 from slither.solc_parsing.declarations.caller_context import CallerContextExpression
 from slither.solc_parsing.exceptions import ParsingError, VariableNotFound
 from slither.solc_parsing.expressions.find_variable import find_variable

--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -6,7 +6,7 @@ from slither.core.declarations.custom_error_contract import CustomErrorContract
 from slither.core.declarations.custom_error_top_level import CustomErrorTopLevel
 from slither.core.declarations.function_contract import FunctionContract
 from slither.core.expressions.literal import Literal
-from slither.core.solidity_types import TypeAlias
+from slither.core.solidity_types import TypeAlias, TypeAliasTopLevel, TypeAliasContract
 from slither.core.solidity_types.array_type import ArrayType
 from slither.core.solidity_types.elementary_type import (
     ElementaryType,
@@ -199,6 +199,9 @@ def _add_type_references(type_found: Type, src: str, sl: "SlitherCompilationUnit
 
     if isinstance(type_found, UserDefinedType):
         type_found.type.add_reference_from_raw_source(src, sl)
+    elif isinstance(type_found, (TypeAliasTopLevel, TypeAliasContract)):
+        type_found.type.add_reference_from_raw_source(src, sl)
+        type_found.add_reference_from_raw_source(src, sl)
 
 
 # TODO: since the add of FileScope, we can probably refactor this function and makes it a lot simpler
@@ -362,6 +365,7 @@ def parse_type(
             if name in renaming:
                 name = renaming[name]
             if name in user_defined_types:
+                _add_type_references(user_defined_types[name], t["src"], sl)
                 return user_defined_types[name]
             type_found = _find_from_type_name(
                 name,
@@ -382,6 +386,7 @@ def parse_type(
         if name in renaming:
             name = renaming[name]
         if name in user_defined_types:
+            _add_type_references(user_defined_types[name], t["src"], sl)
             return user_defined_types[name]
         type_found = _find_from_type_name(
             name,

--- a/tests/src_mapping/ReferencesUserDefinedAliases.sol
+++ b/tests/src_mapping/ReferencesUserDefinedAliases.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.8.16;
+
+type aliasTopLevel is uint;
+
+contract C
+{
+    type aliasContractLevel is uint;
+}
+
+contract Test
+{
+    aliasTopLevel a;
+    C.aliasContractLevel b;
+}
+
+function f(aliasTopLevel, C.aliasContractLevel)
+{
+
+}

--- a/tests/src_mapping/ReferencesUserDefinedTypesCasting.sol
+++ b/tests/src_mapping/ReferencesUserDefinedTypesCasting.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.8.16;
+
+interface A
+{
+    function a() external;
+}
+
+contract C
+{
+    function g(address _address) private
+    {
+        A(_address).a();
+    }
+}
+
+function f(address _address)
+{
+    A(_address).a();
+}


### PR DESCRIPTION
There is a problem with user defined aliases (using `type [...] is [...]` statement) - their `references` list is not updated during parsing.
Also, user defined types (contracts, interfaces, etc.) have missing references when casting (`TypeConversion` expressions).
This PR fixes these issues and is needed to simplify code in #1592.