### PR TITLE
Bugs fixed in strongly connected components and cyclomatic complexity algorithms

### DIFF
--- a/slither/utils/code_complexity.py
+++ b/slither/utils/code_complexity.py
@@ -52,7 +52,7 @@ def compute_strongly_connected_components(function: "Function") -> List[List["No
             for father in node.fathers:
                 assign(father, root)
 
-    for n in l:
+    for n in reversed(l):
         component: List["Node"] = []
         assign(n, component)
         if component:
@@ -74,9 +74,9 @@ def compute_cyclomatic_complexity(function: "Function") -> int:
     # where M is the complexity
     # E number of edges
     # N number of nodes
-    # P number of connected components
+    # P number of connected components (always 1 for a function)
 
     E = compute_number_edges(function)
     N = len(function.nodes)
-    P = len(compute_strongly_connected_components(function))
+    P = 1
     return E - N + 2 * P


### PR DESCRIPTION
File `code_complexity.py` had two bugs in it. This PR fixes both of them.

The first bug was related to strongly connected components algorithm: the final DFS (or `assign` in this case) should be performed on reversed postorder order instead on just postorder.

The second issue concerned calculating cyclomatic complexity: `P` in the formula should be a number of connected components (always `1` in case of solidity functions) instead of strongly connected components.