### PR TITLE
Abstract contract property

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -85,7 +85,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         self._kind: Optional[str] = None
         self._is_interface: bool = False
         self._is_library: bool = False
-        self._is_abstract: bool = False
+        self._is_fully_implemented: bool = False
 
         self._signatures: Optional[List[str]] = None
         self._signatures_declared: Optional[List[str]] = None
@@ -192,6 +192,12 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     @comments.setter
     def comments(self, comments: str):
         self._comments = comments
+    def is_fully_implemented(self) -> bool:
+        return self._is_fully_implemented
+
+    @is_fully_implemented.setter
+    def is_fully_implemented(self, is_fully_implemented: bool):
+        self._is_fully_implemented = is_fully_implemented
 
     # endregion
     ###################################################################################

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -85,6 +85,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         self._kind: Optional[str] = None
         self._is_interface: bool = False
         self._is_library: bool = False
+        self._is_abstract: bool = False
 
         self._signatures: Optional[List[str]] = None
         self._signatures_declared: Optional[List[str]] = None

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -193,6 +193,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     def comments(self, comments: str):
         self._comments = comments
 
+    @property
     def is_fully_implemented(self) -> bool:
         return self._is_fully_implemented
 

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -192,6 +192,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     @comments.setter
     def comments(self, comments: str):
         self._comments = comments
+
     def is_fully_implemented(self) -> bool:
         return self._is_fully_implemented
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -165,6 +165,9 @@ class ContractSolc(CallerContextExpression):
                 self._contract.is_library = True
             self._contract.contract_kind = attributes["contractKind"]
 
+            if not self._contract.is_interface:
+                self._contract.is_abstract = not attributes["fullyImplemented"]
+
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
         # self._contract.fullyImplemented = attributes["fullyImplemented"]
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -164,9 +164,7 @@ class ContractSolc(CallerContextExpression):
             elif attributes["contractKind"] == "library":
                 self._contract.is_library = True
             self._contract.contract_kind = attributes["contractKind"]
-
-            if not self._contract.is_interface:
-                self._contract.is_abstract = not attributes["fullyImplemented"]
+            self._contract.is_fully_implemented = attributes["fullyImplemented"]
 
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
         # self._contract.fullyImplemented = attributes["fullyImplemented"]

--- a/tests/function_features/abstract.sol
+++ b/tests/function_features/abstract.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.8.0;
+
+abstract contract ExplicitAbstract{
+    function f() virtual public;
+}

--- a/tests/function_features/implicit_abstract.sol
+++ b/tests/function_features/implicit_abstract.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.5.0;
+
+contract ImplicitAbstract{
+    function f() public;
+}

--- a/tests/slithir/test_ternary_expressions.py
+++ b/tests/slithir/test_ternary_expressions.py
@@ -6,6 +6,7 @@ from slither.core.expressions import AssignmentOperation, TupleExpression
 # pylint: disable=too-many-nested-blocks
 def test_ternary_conversions() -> None:
     """This tests that true and false sons define the same number of variables that the father node declares"""
+    solc_select.switch_global_version("0.8.0", always_install=True)
     slither = Slither("./tests/slithir/ternary_expressions.sol")
     for contract in slither.contracts:
         for function in contract.functions:

--- a/tests/slithir/test_ternary_expressions.py
+++ b/tests/slithir/test_ternary_expressions.py
@@ -1,3 +1,4 @@
+from solc_select import solc_select
 from slither import Slither
 from slither.core.cfg.node import NodeType
 from slither.slithir.operations import Assignment

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -210,7 +210,7 @@ def test_abstract_contract() -> None:
     assert not slither.contracts[0].is_fully_implemented
 
     solc_select.switch_global_version("0.5.0", always_install=True)
-    slither = Slither("./tests/function_features/abstract.sol")
+    slither = Slither("./tests/function_features/implicit_abstract.sol")
     assert not slither.contracts[0].is_fully_implemented
 
     slither = Slither(

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -202,3 +202,18 @@ def test_using_for_global_collision() -> None:
     compilation = CryticCompile(standard_json)
     sl = Slither(compilation)
     _run_all_detectors(sl)
+
+
+def test_abstract_contract() -> None:
+    solc_select.switch_global_version("0.8.0", always_install=True)
+    slither = Slither("./tests/function_features/abstract.sol")
+    assert not slither.contracts[0].is_fully_implemented
+
+    solc_select.switch_global_version("0.5.0", always_install=True)
+    slither = Slither("./tests/function_features/implicit_abstract.sol")
+    assert not slither.contracts[0].is_fully_implemented
+
+    slither = Slither(
+        "./tests/function_features/implicit_abstract.sol", solc_force_legacy_json=True
+    )
+    assert not slither.contracts[0].is_fully_implemented

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -210,7 +210,7 @@ def test_abstract_contract() -> None:
     assert not slither.contracts[0].is_fully_implemented
 
     solc_select.switch_global_version("0.5.0", always_install=True)
-    slither = Slither("./tests/function_features/implicit_abstract.sol")
+    slither = Slither("./tests/function_features/abstract.sol")
     assert not slither.contracts[0].is_fully_implemented
 
     slither = Slither(


### PR DESCRIPTION
This PR adds an "is_abstract" property to the contract class. Without this class property, detectors can only check for abstractness by verifying all of the functions have implementations. 