### PR TITLE
deregister_detector

### DIFF
--- a/slither/slither.py
+++ b/slither/slither.py
@@ -194,7 +194,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         """
 
         for obj in self._detectors:
-            if type(obj) == detector_class :
+            if type(obj) == detector_class :   # pylint: disable=unidiomatic-typecheck
                 self._detectors.remove(obj)
                 return
 

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -187,14 +187,14 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         for compilation_unit in self.compilation_units:
             instance = detector_class(compilation_unit, self, logger_detector)
             self._detectors.append(instance)
-            
+
     def deregister_detector(self, detector_class: Type[AbstractDetector]) -> None:
         """
         :param detector_class: Class inheriting from `AbstractDetector`.
         """
 
         for obj in self._detectors:
-            if type(obj) == detector_class :   # pylint: disable=unidiomatic-typecheck
+            if type(obj) == detector_class:  # pylint: disable=unidiomatic-typecheck
                 self._detectors.remove(obj)
                 return
 

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -188,7 +188,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
             instance = detector_class(compilation_unit, self, logger_detector)
             self._detectors.append(instance)
 
-    def deregister_detector(self, detector_class: Type[AbstractDetector]) -> None:
+    def unregister_detector(self, detector_class: Type[AbstractDetector]) -> None:
         """
         :param detector_class: Class inheriting from `AbstractDetector`.
         """

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -194,7 +194,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         """
 
         for obj in self._detectors:
-            if type(obj) == detector_class:  # pylint: disable=unidiomatic-typecheck
+            if isinstance(obj, detector_class):
                 self._detectors.remove(obj)
                 return
 

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -187,6 +187,15 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         for compilation_unit in self.compilation_units:
             instance = detector_class(compilation_unit, self, logger_detector)
             self._detectors.append(instance)
+            
+    def deregister_detector(self, detector_class: Type[AbstractDetector]) -> None:
+        """
+        :param detector_class: Class inheriting from `AbstractDetector`.
+        """
+
+        for obj in self._detectors:
+            if type(obj) == detector_class :
+                self._detectors.remove(obj)
 
     def register_printer(self, printer_class: Type[AbstractPrinter]) -> None:
         """

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -196,6 +196,7 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         for obj in self._detectors:
             if type(obj) == detector_class :
                 self._detectors.remove(obj)
+                return
 
     def register_printer(self, printer_class: Type[AbstractPrinter]) -> None:
         """


### PR DESCRIPTION
This function would be helpful to **_de-register_** a detector class from the list of detectors already registered with the slither object.