### PR TITLE
changes web3.toChecksumAddress() to web3.to_checksum_address()

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -92,7 +92,7 @@ class SlitherReadStorage:
         if not self.storage_address:
             raise ValueError
         if not self._checksum_address:
-            self._checksum_address = self.web3.toChecksumAddress(self.storage_address)
+            self._checksum_address = self.web3.to_checksum_address(self.storage_address)
         return self._checksum_address
 
     @property


### PR DESCRIPTION
Running
```slither-read-storage <address> --value --rpc-url <url>```
returns
```AttributeError: 'Web3' object has no attribute 'toChecksumAddress'```

Reference:
https://web3py.readthedocs.io/en/stable/web3.main.html#web3.Web3.to_checksum_address
