### PR TITLE
Update solc version recommendations

### DIFF
--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -66,7 +66,7 @@ Consider using the latest version of Solidity for testing."""
     # Indicates the allowed versions. Must be formatted in increasing order.
     ALLOWED_VERSIONS = ["0.8.18"]
 
-    TOO_RECENT_VERSION_TXT = f"necessitates a version too recent to be trusted. Consider deploying with {'/'.join(ALLOWED_VERSIONS)} "
+    TOO_RECENT_VERSION_TXT = f"necessitates a version too recent to be trusted. Consider deploying with {'/'.join(ALLOWED_VERSIONS)}."
 
     # Indicates the versions that should not be used.
     BUGGY_VERSIONS = [

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -43,10 +43,7 @@ We also recommend avoiding complex `pragma` statement."""
     # region wiki_recommendation
     WIKI_RECOMMENDATION = """
 Deploy with any of the following Solidity versions:
-- 0.5.16 - 0.5.17
-- 0.6.11 - 0.6.12
-- 0.7.5 - 0.7.6
-- 0.8.16
+- 0.8.18
 
 The recommendations take into account:
 - Risks related to recent releases
@@ -68,7 +65,7 @@ Consider using the latest version of Solidity for testing."""
     )
 
     # Indicates the allowed versions. Must be formatted in increasing order.
-    ALLOWED_VERSIONS = ["0.5.16", "0.5.17", "0.6.11", "0.6.12", "0.7.5", "0.7.6", "0.8.16"]
+    ALLOWED_VERSIONS = ["0.8.18"]
 
     # Indicates the versions that should not be used.
     BUGGY_VERSIONS = [

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -59,13 +59,14 @@ Consider using the latest version of Solidity for testing."""
     OLD_VERSION_TXT = "allows old versions"
     LESS_THAN_TXT = "uses lesser than"
 
-    TOO_RECENT_VERSION_TXT = "necessitates a version too recent to be trusted. Consider deploying with 0.6.12/0.7.6/0.8.16"
     BUGGY_VERSION_TXT = (
         "is known to contain severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)"
     )
 
     # Indicates the allowed versions. Must be formatted in increasing order.
     ALLOWED_VERSIONS = ["0.8.18"]
+
+    TOO_RECENT_VERSION_TXT = f"necessitates a version too recent to be trusted. Consider deploying with {'/'.join(ALLOWED_VERSIONS)} "
 
     # Indicates the versions that should not be used.
     BUGGY_VERSIONS = [

--- a/tests/detectors/solc-version/0.5.16/dynamic_1.sol.0.5.16.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.5.16/dynamic_1.sol.0.5.16.IncorrectSolc.json
@@ -1,6 +1,16 @@
 [
     [
         {
+            "elements": [],
+            "description": "solc-0.5.16 is not recommended for deployment\n",
+            "markdown": "solc-0.5.16 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "94ddf430efb860e471a768a108c851848fa998e8a2c489c6fb23ed71d3ef4b09",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        },
+        {
             "elements": [
                 {
                     "type": "pragma",

--- a/tests/detectors/solc-version/0.5.16/dynamic_2.sol.0.5.16.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.5.16/dynamic_2.sol.0.5.16.IncorrectSolc.json
@@ -38,6 +38,16 @@
             "check": "solc-version",
             "impact": "Informational",
             "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.5.16 is not recommended for deployment\n",
+            "markdown": "solc-0.5.16 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "94ddf430efb860e471a768a108c851848fa998e8a2c489c6fb23ed71d3ef4b09",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
         }
     ]
 ]

--- a/tests/detectors/solc-version/0.5.16/static.sol.0.5.16.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.5.16/static.sol.0.5.16.IncorrectSolc.json
@@ -1,3 +1,49 @@
 [
-    []
+    [
+        {
+            "elements": [
+                {
+                    "type": "pragma",
+                    "name": "0.5.16",
+                    "source_mapping": {
+                        "start": 0,
+                        "length": 23,
+                        "filename_relative": "tests/detectors/solc-version/0.5.16/static.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/solc-version/0.5.16/static.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            1
+                        ],
+                        "starting_column": 1,
+                        "ending_column": 24
+                    },
+                    "type_specific_fields": {
+                        "directive": [
+                            "solidity",
+                            "0.5",
+                            ".16"
+                        ]
+                    }
+                }
+            ],
+            "description": "Pragma version0.5.16 (tests/detectors/solc-version/0.5.16/static.sol#1) allows old versions\n",
+            "markdown": "Pragma version[0.5.16](tests/detectors/solc-version/0.5.16/static.sol#L1) allows old versions\n",
+            "first_markdown_element": "tests/detectors/solc-version/0.5.16/static.sol#L1",
+            "id": "2407d991de90e57d2f6b6bdbc61bb939845a5c0bb2d82910ed4c49abff2ab6e3",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.5.16 is not recommended for deployment\n",
+            "markdown": "solc-0.5.16 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "94ddf430efb860e471a768a108c851848fa998e8a2c489c6fb23ed71d3ef4b09",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        }
+    ]
 ]

--- a/tests/detectors/solc-version/0.6.11/dynamic_1.sol.0.6.11.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.6.11/dynamic_1.sol.0.6.11.IncorrectSolc.json
@@ -35,6 +35,16 @@
             "check": "solc-version",
             "impact": "Informational",
             "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.6.11 is not recommended for deployment\n",
+            "markdown": "solc-0.6.11 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "bafd522d637977886f038e619ad47c1987efedc6c4c24515e6e27b23585535bd",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
         }
     ]
 ]

--- a/tests/detectors/solc-version/0.6.11/dynamic_2.sol.0.6.11.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.6.11/dynamic_2.sol.0.6.11.IncorrectSolc.json
@@ -38,6 +38,16 @@
             "check": "solc-version",
             "impact": "Informational",
             "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.6.11 is not recommended for deployment\n",
+            "markdown": "solc-0.6.11 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "bafd522d637977886f038e619ad47c1987efedc6c4c24515e6e27b23585535bd",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
         }
     ]
 ]

--- a/tests/detectors/solc-version/0.6.11/static.sol.0.6.11.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.6.11/static.sol.0.6.11.IncorrectSolc.json
@@ -1,3 +1,49 @@
 [
-    []
+    [
+        {
+            "elements": [
+                {
+                    "type": "pragma",
+                    "name": "0.6.11",
+                    "source_mapping": {
+                        "start": 0,
+                        "length": 23,
+                        "filename_relative": "tests/detectors/solc-version/0.6.11/static.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/solc-version/0.6.11/static.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            1
+                        ],
+                        "starting_column": 1,
+                        "ending_column": 24
+                    },
+                    "type_specific_fields": {
+                        "directive": [
+                            "solidity",
+                            "0.6",
+                            ".11"
+                        ]
+                    }
+                }
+            ],
+            "description": "Pragma version0.6.11 (tests/detectors/solc-version/0.6.11/static.sol#1) allows old versions\n",
+            "markdown": "Pragma version[0.6.11](tests/detectors/solc-version/0.6.11/static.sol#L1) allows old versions\n",
+            "first_markdown_element": "tests/detectors/solc-version/0.6.11/static.sol#L1",
+            "id": "ad7b24eed22ac098a57ae02ade0ccffb4cb094e851effe93cad1d0a65b489816",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.6.11 is not recommended for deployment\n",
+            "markdown": "solc-0.6.11 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "bafd522d637977886f038e619ad47c1987efedc6c4c24515e6e27b23585535bd",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        }
+    ]
 ]

--- a/tests/detectors/solc-version/0.7.6/dynamic_1.sol.0.7.6.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.7.6/dynamic_1.sol.0.7.6.IncorrectSolc.json
@@ -1,6 +1,16 @@
 [
     [
         {
+            "elements": [],
+            "description": "solc-0.7.6 is not recommended for deployment\n",
+            "markdown": "solc-0.7.6 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "ddb8ee36d9dd69b14eab702506268f8f9ef3283777d042e197277e29407b386e",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        },
+        {
             "elements": [
                 {
                     "type": "pragma",

--- a/tests/detectors/solc-version/0.7.6/dynamic_2.sol.0.7.6.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.7.6/dynamic_2.sol.0.7.6.IncorrectSolc.json
@@ -38,6 +38,16 @@
             "check": "solc-version",
             "impact": "Informational",
             "confidence": "High"
+        },
+        {
+            "elements": [],
+            "description": "solc-0.7.6 is not recommended for deployment\n",
+            "markdown": "solc-0.7.6 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "ddb8ee36d9dd69b14eab702506268f8f9ef3283777d042e197277e29407b386e",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
         }
     ]
 ]

--- a/tests/detectors/solc-version/0.7.6/static.sol.0.7.6.IncorrectSolc.json
+++ b/tests/detectors/solc-version/0.7.6/static.sol.0.7.6.IncorrectSolc.json
@@ -1,3 +1,49 @@
 [
-    []
+    [
+        {
+            "elements": [],
+            "description": "solc-0.7.6 is not recommended for deployment\n",
+            "markdown": "solc-0.7.6 is not recommended for deployment\n",
+            "first_markdown_element": "",
+            "id": "ddb8ee36d9dd69b14eab702506268f8f9ef3283777d042e197277e29407b386e",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        },
+        {
+            "elements": [
+                {
+                    "type": "pragma",
+                    "name": "0.7.6",
+                    "source_mapping": {
+                        "start": 0,
+                        "length": 22,
+                        "filename_relative": "tests/detectors/solc-version/0.7.6/static.sol",
+                        "filename_absolute": "/GENERIC_PATH",
+                        "filename_short": "tests/detectors/solc-version/0.7.6/static.sol",
+                        "is_dependency": false,
+                        "lines": [
+                            1
+                        ],
+                        "starting_column": 1,
+                        "ending_column": 23
+                    },
+                    "type_specific_fields": {
+                        "directive": [
+                            "solidity",
+                            "0.7",
+                            ".6"
+                        ]
+                    }
+                }
+            ],
+            "description": "Pragma version0.7.6 (tests/detectors/solc-version/0.7.6/static.sol#1) allows old versions\n",
+            "markdown": "Pragma version[0.7.6](tests/detectors/solc-version/0.7.6/static.sol#L1) allows old versions\n",
+            "first_markdown_element": "tests/detectors/solc-version/0.7.6/static.sol#L1",
+            "id": "e7a5c0ee3d0af7a59907908f88499f79435e302745284c6279167a1cc209b4ed",
+            "check": "solc-version",
+            "impact": "Informational",
+            "confidence": "High"
+        }
+    ]
 ]


### PR DESCRIPTION
- Recommend 0.8.18 (0.8.19 being less than 1 month old)
- Remove recommendations for 0.5/0.6/0.7 branches. 0.8 has been around for long enough that everyone should use it.