### PR TITLE
Fix incorrect temporary variable type in NewArray operation

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -789,7 +789,13 @@ def propagate_types(ir: Operation, node: "Node"):  # pylint: disable=too-many-lo
                                 if v:
                                     ir.lvalue.set_type(v.type)
             elif isinstance(ir, NewArray):
-                ir.lvalue.set_type(ir.array_type)
+                # Reconstruct the array type from base type and depth
+                # Note that the length of the array type is lost since NewArray expression does not store it.
+                # So, here we over-approximately set the length to None (dynamic array).
+                typ = ir.array_type
+                for _ in range(ir.depth):
+                    typ = ArrayType(typ, None)
+                ir.lvalue.set_type(typ)
             elif isinstance(ir, NewContract):
                 contract = node.file_scope.get_contract_from_name(ir.contract_name)
                 ir.lvalue.set_type(UserDefinedType(contract))

--- a/tests/test_ssa_generation.py
+++ b/tests/test_ssa_generation.py
@@ -9,6 +9,7 @@ from tempfile import NamedTemporaryFile
 from typing import Union, List, Optional
 
 import pytest
+from slither.core.solidity_types import ArrayType
 from solc_select import solc_select
 from solc_select.solc_select import valid_version as solc_valid_version
 
@@ -1077,3 +1078,20 @@ def test_issue_1748():
         operations = f.slithir_operations
         assign_op = operations[0]
         assert isinstance(assign_op, InitArray)
+
+
+def test_issue_1776():
+    source = """
+    contract Contract {
+        function foo() public returns (uint) {
+            uint[] memory arr = new uint[](2);
+            return 0;
+        }
+    }
+    """
+    with slither_from_source(source) as slither:
+        c = slither.get_contract_from_name("Contract")[0]
+        f = c.functions[0]
+        operations = f.slithir_operations
+        assign_op = operations[0]
+        assert isinstance(assign_op.lvalue.type, ArrayType)


### PR DESCRIPTION
Fix #1776 

When setting the type of the temporary variable from `NewArray` expression, the original code directly use the array base type instead of the array type. 
This PR re-construct the `ArrayType` using the base type and the depth at L792-797 of file slither/slithir/convert.py. 

One imperfect point is that length of nested array is lost since it is not stored in the `NewArray` expression, in other words, `new uint[10][](2);` expression will become `new uint[][](2)`. 
Fixing this will result in a great modification in the `NewArray` class, which may induce breaking change. So, I just leave it for future work. 