### PR TITLE
fold constant of hash expressions

### DIFF
--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -178,11 +178,10 @@ def _extract_constants_from_irs(  # pylint: disable=too-many-branches,too-many-n
                     all_cst_used_in_binary[str(ir.type)].append(
                         ConstantValue(str(r.value), str(r.type))
                     )
-            if isinstance(ir.variable_left, Constant) and isinstance(ir.variable_right, Constant):
-                if ir.lvalue:
-                    type_ = ir.lvalue.type
-                    cst = ConstantFolding(ir.expression, type_).result()
-                    all_cst_used.append(ConstantValue(str(cst.value), str(type_)))
+            if ir.lvalue:
+                type_ = ir.lvalue.type
+                cst = ConstantFolding(ir.expression, type_).result()
+                all_cst_used.append(ConstantValue(str(cst.value), str(type_)))
         if isinstance(ir, TypeConversion):
             if isinstance(ir.variable, Constant):
                 if isinstance(ir.type, TypeAlias):

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -32,7 +32,7 @@ from slither.slithir.operations import (
 from slither.slithir.operations.binary import Binary
 from slither.slithir.variables import Constant
 from slither.utils.output import Output
-from slither.visitors.expression.constants_folding import ConstantFolding
+from slither.visitors.expression.constants_folding import ConstantFolding, NotConstant
 
 
 def _get_name(f: Union[Function, Variable]) -> str:
@@ -178,10 +178,16 @@ def _extract_constants_from_irs(  # pylint: disable=too-many-branches,too-many-n
                     all_cst_used_in_binary[str(ir.type)].append(
                         ConstantValue(str(r.value), str(r.type))
                     )
-            if ir.lvalue:
-                type_ = ir.lvalue.type
-                cst = ConstantFolding(ir.expression, type_).result()
-                all_cst_used.append(ConstantValue(str(cst.value), str(type_)))
+                if isinstance(ir.variable_left, Constant) or isinstance(
+                    ir.variable_right, Constant
+                ):
+                    if ir.lvalue:
+                        try:
+                            type_ = ir.lvalue.type
+                            cst = ConstantFolding(ir.expression, type_).result()
+                            all_cst_used.append(ConstantValue(str(cst.value), str(type_)))
+                        except NotConstant:
+                            pass
         if isinstance(ir, TypeConversion):
             if isinstance(ir.variable, Constant):
                 if isinstance(ir.type, TypeAlias):

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -433,6 +433,8 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                 type_candidate = ElementaryType("uint256")
             else:
                 type_candidate = ElementaryType("string")
+        elif type_candidate.startswith("rational_const "):
+            type_candidate = ElementaryType("uint256")
         elif type_candidate.startswith("int_const "):
             type_candidate = ElementaryType("uint256")
         elif type_candidate.startswith("bool"):

--- a/slither/utils/integer_conversion.py
+++ b/slither/utils/integer_conversion.py
@@ -4,7 +4,9 @@ from typing import Union
 from slither.exceptions import SlitherError
 
 
-def convert_string_to_fraction(val: Union[str, int]) -> Fraction:
+def convert_string_to_fraction(val: Union[str, bytes, int]) -> Fraction:
+    if isinstance(val, bytes):
+        return int.from_bytes(val, byteorder="big")
     if isinstance(val, int):
         return Fraction(val)
     if val.startswith(("0x", "0X")):

--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -12,7 +12,7 @@ from slither.core.expressions import (
     UnaryOperation,
     TupleExpression,
     TypeConversion,
-    CallExpression
+    CallExpression,
 )
 from slither.core.variables import Variable
 from slither.utils.integer_conversion import convert_string_to_fraction, convert_string_to_int
@@ -72,18 +72,22 @@ class ConstantFolding(ExpressionVisitor):
 
     def _post_identifier(self, expression: Identifier) -> None:
         from slither.core.declarations.solidity_variables import SolidityFunction
+
         if isinstance(expression.value, Variable):
             if expression.value.is_constant:
                 expr = expression.value.expression
                 # assumption that we won't have infinite loop
                 # Everything outside of literal
                 if isinstance(
-                    expr, (BinaryOperation, UnaryOperation, Identifier, TupleExpression, TypeConversion)
+                    expr,
+                    (BinaryOperation, UnaryOperation, Identifier, TupleExpression, TypeConversion),
                 ):
                     cf = ConstantFolding(expr, self._type)
                     expr = cf.result()
                 assert isinstance(expr, Literal)
                 set_val(expression, convert_string_to_int(expr.converted_value))
+            else:
+                raise NotConstant
         elif isinstance(expression.value, SolidityFunction):
             set_val(expression, expression.value)
         else:
@@ -103,7 +107,8 @@ class ConstantFolding(ExpressionVisitor):
             (Literal, BinaryOperation, UnaryOperation, Identifier, TupleExpression, TypeConversion),
         ):
             raise NotConstant
-
+        print(expression_left)
+        print(expression_right)
         left = get_val(expression_left)
         right = get_val(expression_right)
 
@@ -264,7 +269,15 @@ class ConstantFolding(ExpressionVisitor):
         expr = expression.expression
         if not isinstance(
             expr,
-            (Literal, BinaryOperation, UnaryOperation, Identifier, TupleExpression, TypeConversion, CallExpression),
+            (
+                Literal,
+                BinaryOperation,
+                UnaryOperation,
+                Identifier,
+                TupleExpression,
+                TypeConversion,
+                CallExpression,
+            ),
         ):
             raise NotConstant
         cf = ConstantFolding(expr, self._type)

--- a/tests/constant_folding_binop.sol
+++ b/tests/constant_folding_binop.sol
@@ -11,4 +11,5 @@ contract BinOp {
     bool j = true && false;
     bool k = true || false;
     uint l = uint(1) - uint(2);
+    bytes32 IMPLEMENTATION_SLOT = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1);
 }       

--- a/tests/test_constant_folding.py
+++ b/tests/test_constant_folding.py
@@ -12,37 +12,37 @@ def test_constant_folding_rational():
 
     variable_a = contract.get_state_variable_from_name("a")
     assert str(variable_a.type) == "uint256"
-    assert str(ConstantFolding(variable_a.expression, "uint256").result()) == "10"
+    assert ConstantFolding(variable_a.expression, "uint256").result().value == 10
 
     variable_b = contract.get_state_variable_from_name("b")
     assert str(variable_b.type) == "int128"
-    assert str(ConstantFolding(variable_b.expression, "int128").result()) == "2"
+    assert ConstantFolding(variable_b.expression, "int128").result().value == 2
 
     variable_c = contract.get_state_variable_from_name("c")
     assert str(variable_c.type) == "int64"
-    assert str(ConstantFolding(variable_c.expression, "int64").result()) == "3"
+    assert ConstantFolding(variable_c.expression, "int64").result().value == 3
 
     variable_d = contract.get_state_variable_from_name("d")
     assert str(variable_d.type) == "int256"
-    assert str(ConstantFolding(variable_d.expression, "int256").result()) == "1500"
+    assert ConstantFolding(variable_d.expression, "int256").result().value == 1500
 
     variable_e = contract.get_state_variable_from_name("e")
     assert str(variable_e.type) == "uint256"
     assert (
-        str(ConstantFolding(variable_e.expression, "uint256").result())
-        == "57896044618658097711785492504343953926634992332820282019728792003956564819968"
+        ConstantFolding(variable_e.expression, "uint256").result().value
+        == 57896044618658097711785492504343953926634992332820282019728792003956564819968
     )
 
     variable_f = contract.get_state_variable_from_name("f")
     assert str(variable_f.type) == "uint256"
     assert (
-        str(ConstantFolding(variable_f.expression, "uint256").result())
-        == "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        ConstantFolding(variable_f.expression, "uint256").result().value
+        == 115792089237316195423570985008687907853269984665640564039457584007913129639935
     )
 
     variable_g = contract.get_state_variable_from_name("g")
     assert str(variable_g.type) == "int64"
-    assert str(ConstantFolding(variable_g.expression, "int64").result()) == "-7"
+    assert ConstantFolding(variable_g.expression, "int64").result().value == -7
 
 
 def test_constant_folding_binary_expressions():
@@ -51,51 +51,58 @@ def test_constant_folding_binary_expressions():
 
     variable_a = contract.get_state_variable_from_name("a")
     assert str(variable_a.type) == "uint256"
-    assert str(ConstantFolding(variable_a.expression, "uint256").result()) == "0"
+    assert ConstantFolding(variable_a.expression, "uint256").result().value == 0
 
     variable_b = contract.get_state_variable_from_name("b")
     assert str(variable_b.type) == "uint256"
-    assert str(ConstantFolding(variable_b.expression, "uint256").result()) == "3"
+    assert ConstantFolding(variable_b.expression, "uint256").result().value == 3
 
     variable_c = contract.get_state_variable_from_name("c")
     assert str(variable_c.type) == "uint256"
-    assert str(ConstantFolding(variable_c.expression, "uint256").result()) == "3"
+    assert ConstantFolding(variable_c.expression, "uint256").result().value == 3
 
     variable_d = contract.get_state_variable_from_name("d")
     assert str(variable_d.type) == "bool"
-    assert str(ConstantFolding(variable_d.expression, "bool").result()) == "False"
+    assert ConstantFolding(variable_d.expression, "bool").result().value == False
 
     variable_e = contract.get_state_variable_from_name("e")
     assert str(variable_e.type) == "bool"
-    assert str(ConstantFolding(variable_e.expression, "bool").result()) == "False"
+    assert ConstantFolding(variable_e.expression, "bool").result().value == False
 
     variable_f = contract.get_state_variable_from_name("f")
     assert str(variable_f.type) == "bool"
-    assert str(ConstantFolding(variable_f.expression, "bool").result()) == "True"
+    assert ConstantFolding(variable_f.expression, "bool").result().value == True
 
     variable_g = contract.get_state_variable_from_name("g")
     assert str(variable_g.type) == "bool"
-    assert str(ConstantFolding(variable_g.expression, "bool").result()) == "False"
+    assert ConstantFolding(variable_g.expression, "bool").result().value == False
 
     variable_h = contract.get_state_variable_from_name("h")
     assert str(variable_h.type) == "bool"
-    assert str(ConstantFolding(variable_h.expression, "bool").result()) == "False"
+    assert ConstantFolding(variable_h.expression, "bool").result().value == False
 
     variable_i = contract.get_state_variable_from_name("i")
     assert str(variable_i.type) == "bool"
-    assert str(ConstantFolding(variable_i.expression, "bool").result()) == "True"
+    assert ConstantFolding(variable_i.expression, "bool").result().value == True
 
     variable_j = contract.get_state_variable_from_name("j")
     assert str(variable_j.type) == "bool"
-    assert str(ConstantFolding(variable_j.expression, "bool").result()) == "False"
+    assert ConstantFolding(variable_j.expression, "bool").result().value == False
 
     variable_k = contract.get_state_variable_from_name("k")
     assert str(variable_k.type) == "bool"
-    assert str(ConstantFolding(variable_k.expression, "bool").result()) == "True"
+    assert ConstantFolding(variable_k.expression, "bool").result().value == True
 
     variable_l = contract.get_state_variable_from_name("l")
     assert str(variable_l.type) == "uint256"
     assert (
-        str(ConstantFolding(variable_l.expression, "uint256").result())
-        == "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        ConstantFolding(variable_l.expression, "uint256").result().value
+        == 115792089237316195423570985008687907853269984665640564039457584007913129639935
+    )
+
+    IMPLEMENTATION_SLOT = contract.get_state_variable_from_name("IMPLEMENTATION_SLOT")
+    assert str(IMPLEMENTATION_SLOT.type) == "bytes32"
+    assert (
+        int.from_bytes(ConstantFolding(IMPLEMENTATION_SLOT.expression, "bytes32").result().value, byteorder="big")
+        == 24440054405305269366569402256811496959409073762505157381672968839269610695612
     )


### PR DESCRIPTION
Evaluate keccak on constants to enable folding of expressions like `bytes32 constant IMPLEMENTATION_SLOT = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)`. Also updated the `Literal` type of rational constants to be `uint256`.