### PR TITLE
Rename discussion template so it renders

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/installation.yml
+++ b/.github/DISCUSSION_TEMPLATE/installation.yml
@@ -2,12 +2,6 @@
 body: 
   - 
     attributes: 
-      value: |
-          Please check the issues tab to avoid duplicates.
-          Thanks for taking the time to fill out this bug report!
-    type: markdown
-  - 
-    attributes: 
       label: "What operating system are you using?"
     id: os
     type: textarea
@@ -31,14 +25,6 @@ body:
         - "Yes"
         - "No"
         - "Not sure"
-  - type: dropdown
-    id: solc
-    attributes:
-      label: Do you have solc-select installed?
-      multiple: true
-      options:
-        - "Yes"
-        - "No"
   - 
     attributes: 
       description: |
@@ -47,7 +33,6 @@ body:
       render: shell
       label: "Output of running `slither-doctor .`:"
     id: logs
-    type: textarea
 labels: 
   - installation-help
 title: "[Installation-Help]: "

--- a/.github/DISCUSSION_TEMPLATE/trouble_with_installation.yml
+++ b/.github/DISCUSSION_TEMPLATE/trouble_with_installation.yml
@@ -48,8 +48,6 @@ body:
       label: "Output of running `slither-doctor .`:"
     id: logs
     type: textarea
-description: "Get help troubleshooting slither installation"
 labels: 
   - installation-help
-name: "Trouble with Installing Slither"
 title: "[Installation-Help]: "

--- a/.github/ISSUE_TEMPLATE/false_negative.yml
+++ b/.github/ISSUE_TEMPLATE/false_negative.yml
@@ -57,5 +57,5 @@ body:
 description: "Slither missed a bug it should find."
 labels: 
   - false-negative
-name: False Negative"
+name: False Negative
 title: "[False Negative]: "

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,15 @@ setup(
     description="Slither is a Solidity static analysis framework written in Python 3.",
     url="https://github.com/crytic/slither",
     author="Trail of Bits",
-    version="0.9.2",
+    version="0.9.3",
     packages=find_packages(),
     python_requires=">=3.8",
     install_requires=[
         "packaging",
         "prettytable>=0.7.2",
         "pycryptodome>=3.4.6",
-        # "crytic-compile>=0.3.0",
-        "crytic-compile@git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile",
+        "crytic-compile>=0.3.1,<0.4.0",
+        # "crytic-compile@git+https://github.com/crytic/crytic-compile.git@master#egg=crytic-compile",
         "web3>=6.0.0",
     ],
     extras_require={


### PR DESCRIPTION
The name must match the category https://github.com/crytic/slither/discussions/categories/installation. Since we made solc-select a dependency via crytic-compile, I also removed that question.