### PR TITLE
Perform cross-contract taint analysis from diff of two upgrade versions

### DIFF
--- a/slither/utils/upgradeability.py
+++ b/slither/utils/upgradeability.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List, Union
+from typing import Optional, Tuple, List, Union, TypedDict
 from slither.core.declarations import (
     Contract,
     Structure,
@@ -19,10 +19,12 @@ from slither.core.variables.local_variable_init_from_tuple import LocalVariableI
 from slither.core.variables.state_variable import StateVariable
 from slither.analyses.data_dependency.data_dependency import get_dependencies
 from slither.core.variables.variable import Variable
-from slither.core.expressions.literal import Literal
-from slither.core.expressions.identifier import Identifier
-from slither.core.expressions.call_expression import CallExpression
-from slither.core.expressions.assignment_operation import AssignmentOperation
+from slither.core.expressions import (
+    Literal,
+    Identifier,
+    CallExpression,
+    AssignmentOperation,
+)
 from slither.core.cfg.node import Node, NodeType
 from slither.slithir.operations import (
     Operation,
@@ -61,11 +63,23 @@ from slither.slithir.variables import (
 from slither.tools.read_storage.read_storage import SlotInfo, SlitherReadStorage
 
 
+class TaintedExternalContract(TypedDict):
+    contract: Contract
+    functions: List[Function]
+    variables: List[Variable]
+
+
 # pylint: disable=too-many-locals
 def compare(
     v1: Contract, v2: Contract
 ) -> Tuple[
-    List[Variable], List[Variable], List[Variable], List[Function], List[Function], List[Function]
+    List[Variable],
+    List[Variable],
+    List[Variable],
+    List[Function],
+    List[Function],
+    List[Function],
+    List[TaintedExternalContract],
 ]:
     """
     Compares two versions of a contract. Most useful for upgradeable (logic) contracts,
@@ -159,6 +173,11 @@ def compare(
         ):
             tainted_variables.append(var)
 
+    # Find all external contracts and functions called by new/modified/tainted functions
+    tainted_contracts = tainted_external_contracts(
+        new_functions + modified_functions + tainted_functions
+    )
+
     return (
         missing_vars_in_v2,
         new_variables,
@@ -166,7 +185,67 @@ def compare(
         new_functions,
         modified_functions,
         tainted_functions,
+        tainted_contracts,
     )
+
+
+def tainted_external_contracts(funcs: List[Function]) -> List[TaintedExternalContract]:
+    """
+    Takes a list of functions from one contract, finds any calls in these to functions in external contracts,
+    and determines which variables and functions in the external contracts are tainted by these external calls.
+    Args:
+        funcs: a list of Function objects to search for external calls.
+
+    Returns:
+        TaintedExternalContract(TypedDict) (
+            contract: Contract,
+            functions: List[Function],
+            variables: List[Variable]
+        )
+    """
+    tainted_contracts = {}
+
+    for func in funcs:
+        for contract, target in func.all_high_level_calls():
+            if contract.name not in tainted_contracts:
+                tainted_contracts[contract.name] = TaintedExternalContract(
+                    contract=contract, functions=[], variables=[]
+                )
+            if (
+                isinstance(target, Function)
+                and target not in funcs
+                and target not in tainted_contracts[contract.name]["functions"]
+                and not (target.is_constructor or target.is_fallback or target.is_receive)
+            ):
+                tainted_contracts[contract.name]["functions"].append(target)
+                for var in target.all_state_variables_written():
+                    if var not in tainted_contracts[contract.name]["variables"]:
+                        tainted_contracts[contract.name]["variables"].append(var)
+            elif (
+                isinstance(target, Variable)
+                and target not in tainted_contracts[contract.name]["variables"]
+                and not (target.is_constant or target.is_immutable)
+            ):
+                tainted_contracts[contract.name]["variables"].append(target)
+    tainted_contracts = {
+        item
+        for item in tainted_contracts.items()
+        if len(item[1]["variables"]) > 0 and len(item[1]["functions"]) > 0
+    }
+    for c in tainted_contracts.items():
+        contract = c[1]["contract"]
+        variables = c[1]["variables"]
+        for var in variables:
+            read_write = set(
+                contract.get_functions_reading_from_variable(var)
+                + contract.get_functions_writing_to_variable(var)
+            )
+            for f in read_write:
+                if f not in tainted_contracts[contract.name]["functions"] and not (
+                    f.is_constructor or f.is_fallback or f.is_receive
+                ):
+                    tainted_contracts[contract.name]["functions"].append(f)
+    return list(tainted_contracts.values())
 
 
 def get_missing_vars(v1: Contract, v2: Contract) -> List[StateVariable]:

--- a/slither/utils/upgradeability.py
+++ b/slither/utils/upgradeability.py
@@ -251,6 +251,18 @@ def tainted_inheriting_contracts(
     tainted_contracts: List[TaintedExternalContract],
     contracts: List[Contract] = None
 ) -> List[TaintedExternalContract]:
+    """
+    Takes a list of TaintedExternalContract obtained from tainted_external_contracts, and finds any contracts which
+    inherit a tainted contract, as well as any functions that call tainted functions or read tainted variables in
+    the inherited contract.
+    Args:
+        tainted_contracts: the list obtained from `tainted_external_contracts` or `compare`.
+        contracts: (optional) the list of contracts to check for inheritance. If not provided, defaults to
+                    `contract.compilation_unit.contracts` for each contract in tainted_contracts.
+
+    Returns:
+        An updated list of TaintedExternalContract, including all from the input list.
+    """
     for tainted in tainted_contracts:
         contract = tainted['contract']
         if contracts is None:

--- a/slither/utils/upgradeability.py
+++ b/slither/utils/upgradeability.py
@@ -248,8 +248,7 @@ def tainted_external_contracts(funcs: List[Function]) -> List[TaintedExternalCon
 
 
 def tainted_inheriting_contracts(
-    tainted_contracts: List[TaintedExternalContract],
-    contracts: List[Contract] = None
+    tainted_contracts: List[TaintedExternalContract], contracts: List[Contract] = None
 ) -> List[TaintedExternalContract]:
     """
     Takes a list of TaintedExternalContract obtained from tainted_external_contracts, and finds any contracts which
@@ -264,24 +263,24 @@ def tainted_inheriting_contracts(
         An updated list of TaintedExternalContract, including all from the input list.
     """
     for tainted in tainted_contracts:
-        contract = tainted['contract']
+        contract = tainted["contract"]
         if contracts is None:
             contracts = contract.compilation_unit.contracts
         for c in contracts:
             inheritance = [i.name for i in c.inheritance]
             if contract.name in inheritance and c.name not in tainted_contracts:
-                new_taint = TaintedExternalContract(
-                    contract=c, functions=[], variables=[]
-                )
+                new_taint = TaintedExternalContract(contract=c, functions=[], variables=[])
                 for f in c.functions_declared:
                     internal_calls = f.all_internal_calls()
-                    if (
-                        any(str(call) == str(t) for t in tainted['functions'] for call in internal_calls)
-                        or any(str(var) == str(t) for t in tainted['variables']
-                               for var in f.all_state_variables_read() + f.all_state_variables_written())
+                    if any(
+                        str(call) == str(t) for t in tainted["functions"] for call in internal_calls
+                    ) or any(
+                        str(var) == str(t)
+                        for t in tainted["variables"]
+                        for var in f.all_state_variables_read() + f.all_state_variables_written()
                     ):
-                        new_taint['functions'].append(f)
-                if len(new_taint['functions']) > 0:
+                        new_taint["functions"].append(f)
+                if len(new_taint["functions"]) > 0:
                     tainted_contracts.append(new_taint)
     return tainted_contracts
 


### PR DESCRIPTION
In `slither.utils.upgradeability`, the `compare` function found functions and variables in the contracts being compared that were tainted due to new or modified functions. But functions and variables in other contracts may also be tainted by these changes due to external calls.

This PR currently adds two functions to `slither.utils.upgradeability`, one of which is used by `compare` to perform cross-contract taint analysis and return more information in the diff results:

- `tainted_external_contracts` takes a list of functions, i.e., the new, modified and tainted functions found in `compare`, and searches them for high-level calls to other contracts. It marks the corresponding functions (and public variables) as tainted, as well as any variables they write to. Then, it searches for any other functions in the external contract which read or write to tainted variables. It returns a list of `TaintedExternalContract` objects, which are typed dicts containing the contract object plus two lists of tainted functions and variables. `compare` calls this function, after finding all new, modified and tainted functions in the diffed contracts, and returns the list along with all original outputs. 
- `tainted_inheriting_contracts` addresses a shortcoming of `tainted_external_contracts`, which is that high-level calls may take advantage of polymorphism and call functions from a base contract, causing the method to miss tainted functions and variables defined in contracts that inherit the base class. `tainted_inheriting_contracts` takes a list of `TaintedExternalContract` objects as input, as well as an optional list of contracts to search for inheritance, and outputs a potentially augmented list of tainted contracts with their tainted functions and variables. It searches the list of contracts (or the contracts in the compilation unit) for contracts that inherit from tainted contracts, and searches their declared functions for internal calls to previously tainted functions or reads/writes to tainted variables. It then appends the new `TaintedExternalContract` to the original list.

These functions are not strictly related to upgradeability, so I'm not sure if they belong here or somewhere else. I am open to any suggestions/feedback!