### PR TITLE
fixed: changed name of the printer pausable -> not-pausable

### DIFF
--- a/slither/printers/summary/when_not_paused.py
+++ b/slither/printers/summary/when_not_paused.py
@@ -23,7 +23,7 @@ def _use_modifier(function: Function, modifier_name: str = "whenNotPaused") -> b
 
 class PrinterWhenNotPaused(AbstractPrinter):
 
-    ARGUMENT = "pausable"
+    ARGUMENT = "not-pausable"
     HELP = "Print functions that do not use whenNotPaused"
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#when-not-paused"


### PR DESCRIPTION
This PR is related to the issue #1670 where it says to change the name of the printer from `pausable` to `not-pausable`