### PR TITLE
fixed: pausable printer includes checks on constructor()

### DIFF
--- a/slither/printers/summary/when_not_paused.py
+++ b/slither/printers/summary/when_not_paused.py
@@ -23,7 +23,7 @@ def _use_modifier(function: Function, modifier_name: str = "whenNotPaused") -> b
 
 class PrinterWhenNotPaused(AbstractPrinter):
 
-    ARGUMENT = "pausable"
+    ARGUMENT = "not-pausable"
     HELP = "Print functions that do not use whenNotPaused"
 
     WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#when-not-paused"

--- a/slither/printers/summary/when_not_paused.py
+++ b/slither/printers/summary/when_not_paused.py
@@ -10,8 +10,6 @@ from slither.utils.myprettytable import MyPrettyTable
 
 
 def _use_modifier(function: Function, modifier_name: str = "whenNotPaused") -> bool:
-    if function.is_constructor or function.view or function.pure:
-        return False
 
     for internal_call in function.all_internal_calls():
         if isinstance(internal_call, SolidityFunction):
@@ -46,6 +44,8 @@ class PrinterWhenNotPaused(AbstractPrinter):
             table = MyPrettyTable(["Name", "Use whenNotPaused"])
 
             for function in contract.functions_entry_points:
+                if function.is_constructor or function.view or function.pure:
+                    continue
                 status = "X" if _use_modifier(function, modifier_name) else ""
                 table.add_row([function.solidity_signature, status])
 


### PR DESCRIPTION
This PR is related to the issue #1671 where when pausable is run then it also shows the constructor/view/pure function. This PR fixes that.