### PR TITLE
Add setter for `self._web3` in SlitherReadStorage

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -79,6 +79,10 @@ class SlitherReadStorage:
             self._web3 = Web3(Web3.HTTPProvider(self.rpc))
         return self._web3
 
+    @web3.setter
+    def web3(self, web3: Web3):
+        self._web3 = web3
+
     @property
     def checksum_address(self) -> ChecksumAddress:
         if not self.storage_address:

--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -80,7 +80,7 @@ class SlitherReadStorage:
         return self._web3
 
     @web3.setter
-    def web3(self, web3: Web3):
+    def web3(self, web3: Web3) -> None:
         self._web3 = web3
 
     @property


### PR DESCRIPTION
Adds setter for `self._web3` in SlitherReadStorage for more flexibility using SRS in other tools.

`SlitherReadStorage._web3` depends on `SlitherReadStorage.rpc`, which is not protected, so it would seem simple enough to just set the RPC if we want to set up our own Web3 provider. 

However, in my project I already have a Web3 provider created, and I need to do the following to handle PoA networks:
```python
        # Workaround for PoA networks
        if is_poa:
            self._w3.middleware_onion.inject(geth_poa_middleware, layer=0)
```
I would then like to set `srs.web3 = self._w3` so that subsequent calls to `srs.get_slot_values` will work with PoA networks.

I suppose the alternative is for my program to store `is_poa` for later, and then do the following, though this is only necessary because there is no `srs.web3` setter:
```python
        srs.rpc = self._rpc_provider
        if self._is_poa:
            srs.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
```