### PR TITLE
Bug Fix: Contract obj is_fully_implemented

### DIFF
--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -173,7 +173,6 @@ class ContractSolc(CallerContextExpression):
 
         self._contract.is_fully_implemented = attributes["fullyImplemented"]
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
-        # self._contract.fullyImplemented = attributes["fullyImplemented"]
 
         # Parse base contract information
         self._parse_base_contract_info()

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -170,8 +170,8 @@ class ContractSolc(CallerContextExpression):
             elif attributes["contractKind"] == "library":
                 self._contract.is_library = True
             self._contract.contract_kind = attributes["contractKind"]
-            self._contract.is_fully_implemented = attributes["fullyImplemented"]
 
+        self._contract.is_fully_implemented = attributes["fullyImplemented"]
         self._linearized_base_contracts = attributes["linearizedBaseContracts"]
         # self._contract.fullyImplemented = attributes["fullyImplemented"]
 

--- a/tests/unit/core/test_contract_declaration.py
+++ b/tests/unit/core/test_contract_declaration.py
@@ -32,6 +32,7 @@ def test_concrete_contract(solc_binary_path) -> None:
     slither = Slither(Path(CONTRACT_DECL_TEST_ROOT, "concrete.sol").as_posix(), solc=solc_path)
     assert slither.contracts[0].is_fully_implemented
 
+    solc_path = solc_binary_path("0.5.0")
     slither = Slither(
         Path(CONTRACT_DECL_TEST_ROOT, "concrete.sol").as_posix(),
         solc_force_legacy_json=True,

--- a/tests/unit/core/test_contract_declaration.py
+++ b/tests/unit/core/test_contract_declaration.py
@@ -29,17 +29,11 @@ def test_abstract_contract(solc_binary_path) -> None:
 
 def test_concrete_contract(solc_binary_path) -> None:
     solc_path = solc_binary_path("0.8.0")
-    slither = Slither(Path(CONTRACT_DECL_TEST_ROOT, "abstract.sol").as_posix(), solc=solc_path)
-    assert slither.contracts[0].is_fully_implemented
-
-    solc_path = solc_binary_path("0.5.0")
-    slither = Slither(
-        Path(CONTRACT_DECL_TEST_ROOT, "implicit_abstract.sol").as_posix(), solc=solc_path
-    )
+    slither = Slither(Path(CONTRACT_DECL_TEST_ROOT, "concrete.sol").as_posix(), solc=solc_path)
     assert slither.contracts[0].is_fully_implemented
 
     slither = Slither(
-        Path(CONTRACT_DECL_TEST_ROOT, "implicit_abstract.sol").as_posix(),
+        Path(CONTRACT_DECL_TEST_ROOT, "concrete.sol").as_posix(),
         solc_force_legacy_json=True,
         solc=solc_path,
     )

--- a/tests/unit/core/test_contract_declaration.py
+++ b/tests/unit/core/test_contract_declaration.py
@@ -27,6 +27,25 @@ def test_abstract_contract(solc_binary_path) -> None:
     assert not slither.contracts[0].is_fully_implemented
 
 
+def test_concrete_contract(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.0")
+    slither = Slither(Path(CONTRACT_DECL_TEST_ROOT, "abstract.sol").as_posix(), solc=solc_path)
+    assert slither.contracts[0].is_fully_implemented
+
+    solc_path = solc_binary_path("0.5.0")
+    slither = Slither(
+        Path(CONTRACT_DECL_TEST_ROOT, "implicit_abstract.sol").as_posix(), solc=solc_path
+    )
+    assert slither.contracts[0].is_fully_implemented
+
+    slither = Slither(
+        Path(CONTRACT_DECL_TEST_ROOT, "implicit_abstract.sol").as_posix(),
+        solc_force_legacy_json=True,
+        solc=solc_path,
+    )
+    assert slither.contracts[0].is_fully_implemented
+
+
 def test_private_variable(solc_binary_path) -> None:
     solc_path = solc_binary_path("0.8.15")
     slither = Slither(

--- a/tests/unit/core/test_contract_declaration.py
+++ b/tests/unit/core/test_contract_declaration.py
@@ -34,7 +34,7 @@ def test_concrete_contract(solc_binary_path) -> None:
 
     solc_path = solc_binary_path("0.5.0")
     slither = Slither(
-        Path(CONTRACT_DECL_TEST_ROOT, "concrete.sol").as_posix(),
+        Path(CONTRACT_DECL_TEST_ROOT, "concrete_old.sol").as_posix(),
         solc_force_legacy_json=True,
         solc=solc_path,
     )

--- a/tests/unit/core/test_data/contract_declaration/concrete.sol
+++ b/tests/unit/core/test_data/contract_declaration/concrete.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.8.0;
+
+contract SimpleStorage {
+    uint256 public value;
+
+    function setValue(uint256 newValue) public {
+        value = newValue;
+    }
+}

--- a/tests/unit/core/test_data/contract_declaration/concrete.sol
+++ b/tests/unit/core/test_data/contract_declaration/concrete.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.0;
 
-contract SimpleStorage {
+contract Concrete {
     uint256 public value;
 
     function setValue(uint256 newValue) public {

--- a/tests/unit/core/test_data/contract_declaration/concrete_old.sol
+++ b/tests/unit/core/test_data/contract_declaration/concrete_old.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.0;
+
+contract ConcreteOld {
+    uint256 public myNumber;
+
+    constructor(uint256 initialNumber) public {
+        myNumber = initialNumber;
+    }
+
+    function setNumber(uint256 newNumber) public {
+        myNumber = newNumber;
+    }
+}


### PR DESCRIPTION
Previously was not updating the is_fully_implemented property due to being incorrectly included in the `if` statement.
Fixes #1847