### PR TITLE
feat: loc printer

### DIFF
--- a/examples/scripts/possible_paths.py
+++ b/examples/scripts/possible_paths.py
@@ -98,7 +98,6 @@ def __find_target_paths(target_function, current_path=None):
     # Look through all functions
     for contract in slither.contracts:
         for function in contract.functions_and_modifiers_declared:
-
             # If the function is already in our path, skip it.
             if function in current_path:
                 continue

--- a/examples/scripts/slithIR.py
+++ b/examples/scripts/slithIR.py
@@ -10,22 +10,17 @@ slither = Slither(sys.argv[1])
 
 # Iterate over all the contracts
 for contract in slither.contracts:
-
     # Iterate over all the functions
     for function in contract.functions:
-
         # Dont explore inherited functions
         if function.contract_declarer == contract:
-
             print(f"Function: {function.name}")
 
             # Iterate over the nodes of the function
             for node in function.nodes:
-
                 # Print the Solidity expression of the nodes
                 # And the SlithIR operations
                 if node.expression:
-
                     print(f"\tSolidity expression: {node.expression}")
                     print("\tSlithIR:")
                     for ir in node.irs:

--- a/plugin_example/slither_my_plugin/detectors/example.py
+++ b/plugin_example/slither_my_plugin/detectors/example.py
@@ -19,7 +19,6 @@ class Example(AbstractDetector):  # pylint: disable=too-few-public-methods
     WIKI_RECOMMENDATION = ""
 
     def _detect(self):
-
         info = "This is an example!"
 
         json = self.generate_result(info)

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -150,9 +150,9 @@ def _process(
 ###################################################################################
 
 
-def get_detectors_and_printers() -> Tuple[
-    List[Type[AbstractDetector]], List[Type[AbstractPrinter]]
-]:
+def get_detectors_and_printers() -> (
+    Tuple[List[Type[AbstractDetector]], List[Type[AbstractPrinter]]]
+):
     detectors_ = [getattr(all_detectors, name) for name in dir(all_detectors)]
     detectors = [d for d in detectors_ if inspect.isclass(d) and issubclass(d, AbstractDetector)]
 
@@ -747,7 +747,7 @@ def main_impl(
 
     default_log = logging.INFO if not args.debug else logging.DEBUG
 
-    for (l_name, l_level) in [
+    for l_name, l_level in [
         ("Slither", default_log),
         ("Contract", default_log),
         ("Function", default_log),

--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -379,7 +379,7 @@ def propagate_function(
     transitive_close_dependencies(function, context_key, context_key_non_ssa)
     # Propage data dependency
     data_depencencies = function.context[context_key]
-    for (key, values) in data_depencencies.items():
+    for key, values in data_depencencies.items():
         if not key in contract.context[context_key]:
             contract.context[context_key][key] = set(values)
         else:
@@ -492,7 +492,7 @@ def convert_to_non_ssa(
 ) -> Dict[SUPPORTED_TYPES, Set[SUPPORTED_TYPES]]:
     # Need to create new set() as its changed during iteration
     ret: Dict[SUPPORTED_TYPES, Set[SUPPORTED_TYPES]] = {}
-    for (k, values) in data_depencies.items():
+    for k, values in data_depencies.items():
         var = convert_variable_to_non_ssa(k)
         if not var in ret:
             ret[var] = set()

--- a/slither/analyses/evm/convert.py
+++ b/slither/analyses/evm/convert.py
@@ -14,7 +14,6 @@ def get_evm_instructions(obj):
     assert isinstance(obj, (Function, Contract, Node))
 
     if KEY_EVM_INS not in obj.context:
-
         CFG = load_evm_cfg_builder()
 
         slither = obj.slither

--- a/slither/core/cfg/node.py
+++ b/slither/core/cfg/node.py
@@ -104,6 +104,7 @@ class NodeType(Enum):
 
 # endregion
 
+
 # I am not sure why, but pylint reports a lot of "no-member" issue that are not real (Josselin)
 # pylint: disable=no-member
 class Node(SourceMapping):  # pylint: disable=too-many-public-methods
@@ -847,9 +848,7 @@ class Node(SourceMapping):  # pylint: disable=too-many-public-methods
     ###################################################################################
 
     def _find_read_write_call(self) -> None:  # pylint: disable=too-many-statements
-
         for ir in self.irs:
-
             self._slithir_vars |= {v for v in ir.read if self._is_valid_slithir_var(v)}
 
             if isinstance(ir, OperationWithLValue):

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -1379,9 +1379,8 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         from slither.core.declarations.function_contract import FunctionContract
 
         if self.state_variables:
-            for (idx, variable_candidate) in enumerate(self.state_variables):
+            for idx, variable_candidate in enumerate(self.state_variables):
                 if variable_candidate.expression and not variable_candidate.is_constant:
-
                     constructor_variable = FunctionContract(self.compilation_unit)
                     constructor_variable.set_function_type(FunctionType.CONSTRUCTOR_VARIABLES)
                     constructor_variable.set_contract(self)  # type: ignore
@@ -1409,9 +1408,8 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                             counter += 1
                     break
 
-            for (idx, variable_candidate) in enumerate(self.state_variables):
+            for idx, variable_candidate in enumerate(self.state_variables):
                 if variable_candidate.expression and variable_candidate.is_constant:
-
                     constructor_variable = FunctionContract(self.compilation_unit)
                     constructor_variable.set_function_type(
                         FunctionType.CONSTRUCTOR_CONSTANT_VARIABLES

--- a/slither/core/expressions/new_array.py
+++ b/slither/core/expressions/new_array.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 
 class NewArray(Expression):
-
     # note: dont conserve the size of the array if provided
     def __init__(
         self, depth: int, array_type: Union["TypeAliasTopLevel", "ElementaryType"]

--- a/slither/core/scope/scope.py
+++ b/slither/core/scope/scope.py
@@ -114,7 +114,6 @@ class FileScope:
         name: str,
         getter: Callable[[SourceUnit], Dict[str, AbstractReturnType]],
     ) -> Optional[AbstractReturnType]:
-
         assert self.filename in crytic_compile_compilation_unit.source_units
 
         source_unit = crytic_compile_compilation_unit.source_unit(self.filename)

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -199,7 +199,6 @@ class SlitherCore(Context):
         implementation = get_implementation(thing)
 
         for offset in range(definition.start, definition.end + 1):
-
             if (
                 isinstance(thing, TopLevel)
                 or (
@@ -216,7 +215,6 @@ class SlitherCore(Context):
 
         for ref in references:
             for offset in range(ref.start, ref.end + 1):
-
                 if (
                     isinstance(thing, TopLevel)
                     or (
@@ -300,7 +298,6 @@ class SlitherCore(Context):
         # The first time we check a file, find all start/end ignore comments and memoize them.
         line_number = 1
         while True:
-
             line_text = self.crytic_compile.get_code_from_line(file, line_number)
             if line_text is None:
                 break
@@ -358,7 +355,6 @@ class SlitherCore(Context):
         )
 
         for file, lines in mapping_elements_with_lines:
-
             # Check if result is within an ignored range.
             ignore_ranges = self._ignore_ranges[file][r["check"]] + self._ignore_ranges[file]["all"]
             for start, end in ignore_ranges:

--- a/slither/core/solidity_types/user_defined_type.py
+++ b/slither/core/solidity_types/user_defined_type.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from slither.core.declarations.enum import Enum
     from slither.core.declarations.contract import Contract
 
+
 # pylint: disable=import-outside-toplevel
 class UserDefinedType(Type):
     def __init__(self, t: Union["Enum", "Contract", "Structure"]) -> None:

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 # All an object needs to do is to inherits from SourceMapping
 # And call set_offset at some point
 
+
 # pylint: disable=too-many-instance-attributes
 class Source:
     def __init__(self, compilation_unit: "SlitherCompilationUnit") -> None:
@@ -57,7 +58,6 @@ class Source:
         return f"{filename_short}{lines} ({self.starting_column} - {self.ending_column})"
 
     def _get_lines_str(self, line_descr: str = "") -> str:
-
         line_prefix = self.compilation_unit.core.line_prefix
 
         lines = self.lines

--- a/slither/core/variables/variable.py
+++ b/slither/core/variables/variable.py
@@ -10,6 +10,7 @@ from slither.core.solidity_types.elementary_type import ElementaryType
 if TYPE_CHECKING:
     from slither.core.expressions.expression import Expression
 
+
 # pylint: disable=too-many-instance-attributes
 class Variable(SourceMapping):
     def __init__(self) -> None:

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -144,7 +144,7 @@ Consider using the latest version of Solidity for testing."""
 
         # If we found any disallowed pragmas, we output our findings.
         if disallowed_pragmas:
-            for (reason, p) in disallowed_pragmas:
+            for reason, p in disallowed_pragmas:
                 info: DETECTOR_INFO = ["Pragma version", p, f" {reason}\n"]
 
                 json = self.generate_result(info)
@@ -152,7 +152,6 @@ Consider using the latest version of Solidity for testing."""
                 results.append(json)
 
         if self.compilation_unit.solc_version not in self.ALLOWED_VERSIONS:
-
             if self.compilation_unit.solc_version in self.BUGGY_VERSIONS:
                 info = [
                     "solc-",

--- a/slither/detectors/attributes/locked_ether.py
+++ b/slither/detectors/attributes/locked_ether.py
@@ -22,7 +22,6 @@ from slither.utils.output import Output
 
 
 class LockedEther(AbstractDetector):  # pylint: disable=too-many-nested-blocks
-
     ARGUMENT = "locked-ether"
     HELP = "Contracts that lock ether"
     IMPACT = DetectorClassification.MEDIUM

--- a/slither/detectors/compiler_bugs/array_by_reference.py
+++ b/slither/detectors/compiler_bugs/array_by_reference.py
@@ -78,7 +78,6 @@ As a result, Bob's usage of the contract is incorrect."""
         # Loop through all functions in all contracts.
         for contract in contracts:
             for function in contract.functions_declared:
-
                 # Skip any constructor functions.
                 if function.is_constructor:
                     continue
@@ -118,7 +117,6 @@ As a result, Bob's usage of the contract is incorrect."""
         for contract in contracts:
             for function in contract.functions_and_modifiers_declared:
                 for node in function.nodes:
-
                     # If this node has no expression, skip it.
                     if not node.expression:
                         continue

--- a/slither/detectors/compiler_bugs/reused_base_constructor.py
+++ b/slither/detectors/compiler_bugs/reused_base_constructor.py
@@ -100,7 +100,6 @@ The constructor of `A` is called multiple times in `D` and `E`:
 
         # Loop until there are no queued contracts left.
         while len(queued_contracts) > 0:
-
             # Pop a contract off the front of the queue, if it has already been processed, we stop.
             current_contract = queued_contracts.pop(0)
             if current_contract in processed_contracts:
@@ -143,7 +142,6 @@ The constructor of `A` is called multiple times in `D` and `E`:
 
         # Loop for each contract
         for contract in self.contracts:
-
             # Detect all locations which all underlying base constructors with arguments were called from.
             called_base_constructors = self._detect_explicitly_called_base_constructors(contract)
             for base_constructor, call_list in called_base_constructors.items():
@@ -159,7 +157,7 @@ The constructor of `A` is called multiple times in `D` and `E`:
                     " arguments more than once in inheritance hierarchy:\n",
                 ]
 
-                for (calling_contract, called_by_constructor) in call_list:
+                for calling_contract, called_by_constructor in call_list:
                     info += [
                         "\t- From ",
                         calling_contract,

--- a/slither/detectors/erc/unindexed_event_parameters.py
+++ b/slither/detectors/erc/unindexed_event_parameters.py
@@ -61,7 +61,6 @@ Failure to include these keywords will exclude the parameter data in the transac
 
         # Loop through all events to look for poor form.
         for event in contract.events_declared:
-
             # If this is transfer/approval events, expect the first two parameters to be indexed.
             if event.full_name in [
                 "Transfer(address,address,uint256)",
@@ -84,8 +83,7 @@ Failure to include these keywords will exclude the parameter data in the transac
             unindexed_params = self.detect_erc20_unindexed_event_params(c)
             if unindexed_params:
                 # Add each problematic event definition to our result list
-                for (event, parameter) in unindexed_params:
-
+                for event, parameter in unindexed_params:
                     info = [
                         "ERC20 event ",
                         event,

--- a/slither/detectors/functions/arbitrary_send_eth.py
+++ b/slither/detectors/functions/arbitrary_send_eth.py
@@ -135,8 +135,7 @@ Bob calls `setDestination` and `withdraw`. As a result he withdraws the contract
 
         for c in self.contracts:
             arbitrary_send_result = detect_arbitrary_send(c)
-            for (func, nodes) in arbitrary_send_result:
-
+            for func, nodes in arbitrary_send_result:
                 info = [func, " sends eth to arbitrary user\n"]
                 info += ["\tDangerous calls:\n"]
 

--- a/slither/detectors/functions/dead_code.py
+++ b/slither/detectors/functions/dead_code.py
@@ -40,7 +40,6 @@ contract Contract{
     WIKI_RECOMMENDATION = "Remove unused functions."
 
     def _detect(self) -> List[Output]:
-
         results = []
 
         functions_used = set()

--- a/slither/detectors/functions/external_function.py
+++ b/slither/detectors/functions/external_function.py
@@ -91,10 +91,8 @@ class ExternalFunction(AbstractDetector):
         # Loop through the list of inherited contracts and this contract, to find the first function instance which
         # matches this function's signature. Note here that `inheritance` is in order from most basic to most extended.
         for contract in function.contract.inheritance + [function.contract]:
-
             # Loop through the functions not inherited (explicitly defined in this contract).
             for f in contract.functions_declared:
-
                 # If it matches names, this is the base most function.
                 if f.full_name == function.full_name:
                     return f
@@ -159,14 +157,12 @@ class ExternalFunction(AbstractDetector):
 
         # Loop through all contracts
         for contract in self.contracts:
-
             # Filter false-positives: Immediately filter this contract if it's in blacklist
             if contract in dynamic_call_contracts:
                 continue
 
             # Next we'll want to loop through all functions defined directly in this contract.
             for function in contract.functions_declared:
-
                 # If all of the function arguments are non-reference type or calldata, we skip it.
                 reference_args = []
                 for arg in function.parameters:

--- a/slither/detectors/functions/protected_variable.py
+++ b/slither/detectors/functions/protected_variable.py
@@ -15,7 +15,6 @@ from slither.utils.output import Output
 
 
 class ProtectedVariables(AbstractDetector):
-
     ARGUMENT = "protected-vars"
     HELP = "Detected unprotected variables"
     IMPACT = DetectorClassification.HIGH

--- a/slither/detectors/functions/suicidal.py
+++ b/slither/detectors/functions/suicidal.py
@@ -81,7 +81,6 @@ Bob calls `kill` and destructs the contract."""
         for c in self.contracts:
             functions = self.detect_suicidal(c)
             for func in functions:
-
                 info: DETECTOR_INFO = [func, " allows anyone to destruct the contract\n"]
 
                 res = self.generate_result(info)

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -65,11 +65,9 @@ Solidity defines a [naming convention](https://solidity.readthedocs.io/en/v0.4.2
 
     # pylint: disable=too-many-branches,too-many-statements
     def _detect(self) -> List[Output]:
-
         results = []
         info: DETECTOR_INFO
         for contract in self.contracts:
-
             if not self.is_cap_words(contract.name):
                 info = ["Contract ", contract, " is not in CapWords\n"]
 

--- a/slither/detectors/operations/bad_prng.py
+++ b/slither/detectors/operations/bad_prng.py
@@ -125,7 +125,6 @@ As a result, Eve wins the game."""
         for c in self.compilation_unit.contracts_derived:
             values = detect_bad_PRNG(c)
             for func, nodes in values:
-
                 for node in nodes:
                     info: List[AllSupportedOutput] = [func, ' uses a weak PRNG: "', node, '" \n']
                     res = self.generate_result(info)

--- a/slither/detectors/operations/block_timestamp.py
+++ b/slither/detectors/operations/block_timestamp.py
@@ -60,7 +60,6 @@ def _detect_dangerous_timestamp(
 
 
 class Timestamp(AbstractDetector):
-
     ARGUMENT = "timestamp"
     HELP = "Dangerous usage of `block.timestamp`"
     IMPACT = DetectorClassification.LOW
@@ -81,8 +80,7 @@ class Timestamp(AbstractDetector):
 
         for c in self.contracts:
             dangerous_timestamp = _detect_dangerous_timestamp(c)
-            for (func, nodes) in dangerous_timestamp:
-
+            for func, nodes in dangerous_timestamp:
                 info: DETECTOR_INFO = [func, " uses timestamp for comparisons\n"]
 
                 info += ["\tDangerous comparisons:\n"]

--- a/slither/detectors/operations/missing_events_access_control.py
+++ b/slither/detectors/operations/missing_events_access_control.py
@@ -103,9 +103,9 @@ contract C {
         results = []
         for contract in self.compilation_unit.contracts_derived:
             missing_events = self._detect_missing_events(contract)
-            for (function, nodes) in missing_events:
+            for function, nodes in missing_events:
                 info: DETECTOR_INFO = [function, " should emit an event for: \n"]
-                for (node, _sv, _mod) in nodes:
+                for node, _sv, _mod in nodes:
                     info += ["\t- ", node, " \n"]
                 res = self.generate_result(info)
                 results.append(res)

--- a/slither/detectors/operations/missing_events_arithmetic.py
+++ b/slither/detectors/operations/missing_events_arithmetic.py
@@ -125,9 +125,9 @@ contract C {
         results = []
         for contract in self.compilation_unit.contracts_derived:
             missing_events = self._detect_missing_events(contract)
-            for (function, nodes) in missing_events:
+            for function, nodes in missing_events:
                 info: DETECTOR_INFO = [function, " should emit an event for: \n"]
-                for (node, _) in nodes:
+                for node, _ in nodes:
                     info += ["\t- ", node, " \n"]
                 res = self.generate_result(info)
                 results.append(res)

--- a/slither/detectors/operations/missing_zero_address_validation.py
+++ b/slither/detectors/operations/missing_zero_address_validation.py
@@ -157,7 +157,7 @@ Bob calls `updateOwner` without specifying the `newOwner`, so Bob loses ownershi
         results = []
         for contract in self.compilation_unit.contracts_derived:
             missing_zero_address_validation = self._detect_missing_zero_address_validation(contract)
-            for (_, var_nodes) in missing_zero_address_validation:
+            for _, var_nodes in missing_zero_address_validation:
                 for var, nodes in var_nodes.items():
                     info: DETECTOR_INFO = [var, " lacks a zero-check on ", ":\n"]
                     for node in nodes:

--- a/slither/detectors/operations/unused_return_values.py
+++ b/slither/detectors/operations/unused_return_values.py
@@ -93,7 +93,6 @@ contract MyConc{
                     continue
                 unused_return = self.detect_unused_return_values(f)
                 if unused_return:
-
                     for node in unused_return:
                         info: DETECTOR_INFO = [f, " ignores return value by ", node, "\n"]
 

--- a/slither/detectors/operations/void_constructor.py
+++ b/slither/detectors/operations/void_constructor.py
@@ -10,7 +10,6 @@ from slither.utils.output import Output
 
 
 class VoidConstructor(AbstractDetector):
-
     ARGUMENT = "void-cst"
     HELP = "Constructor called not implemented"
     IMPACT = DetectorClassification.LOW
@@ -39,7 +38,6 @@ When reading `B`'s constructor definition, we might assume that `A()` initiates 
         for c in self.contracts:
             cst = c.constructor
             if cst:
-
                 for constructor_call in cst.explicit_base_constructor_calls_statements:
                     for node in constructor_call.nodes:
                         if any(isinstance(ir, Nop) for ir in node.irs):

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -106,14 +106,14 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
             info = ["Reentrancy in ", func, ":\n"]
 
             info += ["\tExternal calls:\n"]
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 info += ["\t- ", call_info, "\n"]
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
                         info += ["\t\t- ", call_list_info, "\n"]
             if calls != send_eth and send_eth:
                 info += ["\tExternal calls sending eth:\n"]
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     info += ["\t- ", call_info, "\n"]
                     for call_list_info in calls_list:
                         if call_list_info != call_info:
@@ -132,7 +132,7 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 res.add(call_info, {"underlying_type": "external_calls"})
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
@@ -145,7 +145,7 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for (call_info, calls_list) in calls:
+                for call_info, calls_list in calls:
                     res.add(call_info, {"underlying_type": "external_calls_sending_eth"})
                     for call_list_info in calls_list:
                         if call_list_info != call_info:

--- a/slither/detectors/reentrancy/reentrancy_eth.py
+++ b/slither/detectors/reentrancy/reentrancy_eth.py
@@ -114,14 +114,14 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
 
             info = ["Reentrancy in ", func, ":\n"]
             info += ["\tExternal calls:\n"]
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 info += ["\t- ", call_info, "\n"]
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
                         info += ["\t\t- ", call_list_info, "\n"]
             if calls != send_eth and send_eth:
                 info += ["\tExternal calls sending eth:\n"]
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     info += ["\t- ", call_info, "\n"]
                     for call_list_info in calls_list:
                         if call_list_info != call_info:
@@ -148,7 +148,7 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 res.add(call_info, {"underlying_type": "external_calls"})
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
@@ -159,7 +159,7 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     res.add(call_info, {"underlying_type": "external_calls_sending_eth"})
                     for call_list_info in calls_list:
                         if call_list_info != call_info:

--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -98,14 +98,14 @@ If `d.()` re-enters, the `Counter` events will be shown in an incorrect order, w
 
             info = ["Reentrancy in ", func, ":\n"]
             info += ["\tExternal calls:\n"]
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 info += ["\t- ", call_info, "\n"]
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
                         info += ["\t\t- ", call_list_info, "\n"]
             if calls != send_eth and send_eth:
                 info += ["\tExternal calls sending eth:\n"]
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     info += ["\t- ", call_info, "\n"]
                     for call_list_info in calls_list:
                         if call_list_info != call_info:
@@ -124,7 +124,7 @@ If `d.()` re-enters, the `Counter` events will be shown in an incorrect order, w
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 res.add(call_info, {"underlying_type": "external_calls"})
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
@@ -137,7 +137,7 @@ If `d.()` re-enters, the `Counter` events will be shown in an incorrect order, w
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     res.add(call_info, {"underlying_type": "external_calls_sending_eth"})
                     for call_list_info in calls_list:
                         if call_list_info != call_info:

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -117,14 +117,14 @@ Only report reentrancy that is based on `transfer` or `send`."""
             info = ["Reentrancy in ", func, ":\n"]
 
             info += ["\tExternal calls:\n"]
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 info += ["\t- ", call_info, "\n"]
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
                         info += ["\t\t- ", call_list_info, "\n"]
             if calls != send_eth and send_eth:
                 info += ["\tExternal calls sending eth:\n"]
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     info += ["\t- ", call_info, "\n"]
                     for call_list_info in calls_list:
                         if call_list_info != call_info:
@@ -165,7 +165,7 @@ Only report reentrancy that is based on `transfer` or `send`."""
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 res.add(call_info, {"underlying_type": "external_calls"})
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
@@ -178,7 +178,7 @@ Only report reentrancy that is based on `transfer` or `send`."""
 
             # If the calls are not the same ones that send eth, add the eth sending nodes.
             if calls != send_eth:
-                for (call_info, calls_list) in send_eth:
+                for call_info, calls_list in send_eth:
                     res.add(call_info, {"underlying_type": "external_calls_sending_eth"})
                     for call_list_info in calls_list:
                         if call_list_info != call_info:

--- a/slither/detectors/reentrancy/reentrancy_read_before_write.py
+++ b/slither/detectors/reentrancy/reentrancy_read_before_write.py
@@ -110,7 +110,7 @@ Do not report reentrancies that involve Ether (see `reentrancy-eth`)."""
             info = ["Reentrancy in ", func, ":\n"]
 
             info += ["\tExternal calls:\n"]
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 info += ["\t- ", call_info, "\n"]
                 for call_list_info in calls_list:
                     if call_list_info != call_info:
@@ -137,7 +137,7 @@ Do not report reentrancies that involve Ether (see `reentrancy-eth`)."""
             res.add(func)
 
             # Add all underlying calls in the function which are potentially problematic.
-            for (call_info, calls_list) in calls:
+            for call_info, calls_list in calls:
                 res.add(call_info, {"underlying_type": "external_calls"})
                 for call_list_info in calls_list:
                     if call_list_info != call_info:

--- a/slither/detectors/statements/array_length_assignment.py
+++ b/slither/detectors/statements/array_length_assignment.py
@@ -40,7 +40,6 @@ def detect_array_length_assignment(contract: Contract) -> Set[Node]:
         for node in function.nodes:
             if node.type == NodeType.EXPRESSION:
                 for ir in node.irs:
-
                     # First we look for the member access for 'length', for which a reference is created.
                     # We add the reference to our list of array length references.
                     if isinstance(ir, Length):  # a

--- a/slither/detectors/statements/assert_state_change.py
+++ b/slither/detectors/statements/assert_state_change.py
@@ -90,7 +90,7 @@ The assert in `bad()` increments the state variable `s_a` while checking for the
         results = []
         for contract in self.contracts:
             assert_state_change = detect_assert_state_change(contract)
-            for (func, node) in assert_state_change:
+            for func, node in assert_state_change:
                 info: DETECTOR_INFO = [
                     func,
                     " has an assert() call which possibly changes state.\n",

--- a/slither/detectors/statements/boolean_constant_equality.py
+++ b/slither/detectors/statements/boolean_constant_equality.py
@@ -56,7 +56,6 @@ Boolean constants can be used directly and do not need to be compare to `true` o
     def _detect_boolean_equality(
         contract: Contract,
     ) -> List[Tuple[Function, Set[Node]]]:
-
         # Create our result set.
         results: List[Tuple[Function, Set[Node]]] = []
 
@@ -86,7 +85,7 @@ Boolean constants can be used directly and do not need to be compare to `true` o
         results = []
         for contract in self.contracts:
             boolean_constant_misuses = self._detect_boolean_equality(contract)
-            for (func, nodes) in boolean_constant_misuses:
+            for func, nodes in boolean_constant_misuses:
                 for node in nodes:
                     info: DETECTOR_INFO = [
                         func,

--- a/slither/detectors/statements/boolean_constant_misuse.py
+++ b/slither/detectors/statements/boolean_constant_misuse.py
@@ -86,7 +86,6 @@ Other uses (in complex expressions, as conditionals) indicate either an error or
 
             # Loop for every node in this function, looking for boolean constants
             for node in function.nodes:
-
                 # Do not report "while(true)"
                 if node.type == NodeType.IFLOOP and node.irs and len(node.irs) == 1:
                     ir = node.irs[0]
@@ -122,7 +121,7 @@ Other uses (in complex expressions, as conditionals) indicate either an error or
         results = []
         for contract in self.contracts:
             boolean_constant_misuses = self._detect_boolean_constant_misuses(contract)
-            for (func, nodes) in boolean_constant_misuses:
+            for func, nodes in boolean_constant_misuses:
                 for node in nodes:
                     info: DETECTOR_INFO = [
                         func,

--- a/slither/detectors/statements/calls_in_loop.py
+++ b/slither/detectors/statements/calls_in_loop.py
@@ -56,7 +56,6 @@ def call_in_loop(
 
 
 class MultipleCallsInLoop(AbstractDetector):
-
     ARGUMENT = "calls-loop"
     HELP = "Multiple calls in a loop"
     IMPACT = DetectorClassification.LOW

--- a/slither/detectors/statements/controlled_delegatecall.py
+++ b/slither/detectors/statements/controlled_delegatecall.py
@@ -26,7 +26,6 @@ def controlled_delegatecall(function: FunctionContract) -> List[Node]:
 
 
 class ControlledDelegateCall(AbstractDetector):
-
     ARGUMENT = "controlled-delegatecall"
     HELP = "Controlled delegatecall destination"
     IMPACT = DetectorClassification.HIGH

--- a/slither/detectors/statements/costly_operations_in_loop.py
+++ b/slither/detectors/statements/costly_operations_in_loop.py
@@ -23,7 +23,6 @@ def detect_costly_operations_in_loop(contract: Contract) -> List[Node]:
 def costly_operations_in_loop(
     node: Optional[Node], in_loop_counter: int, visited: List[Node], ret: List[Node]
 ) -> None:
-
     if node is None:
         return
 
@@ -51,7 +50,6 @@ def costly_operations_in_loop(
 
 
 class CostlyOperationsInLoop(AbstractDetector):
-
     ARGUMENT = "costly-loop"
     HELP = "Costly operations in a loop"
     IMPACT = DetectorClassification.INFORMATIONAL

--- a/slither/detectors/statements/delegatecall_in_loop.py
+++ b/slither/detectors/statements/delegatecall_in_loop.py
@@ -21,7 +21,6 @@ def detect_delegatecall_in_loop(contract: Contract) -> List[Node]:
 def delegatecall_in_loop(
     node: Optional[Node], in_loop_counter: int, visited: List[Node], results: List[Node]
 ) -> None:
-
     if node is None:
         return
 

--- a/slither/detectors/statements/deprecated_calls.py
+++ b/slither/detectors/statements/deprecated_calls.py
@@ -138,7 +138,8 @@ contract ContractWithDeprecatedReferences {
         """Detects the usage of any deprecated built-in symbols.
 
         Returns:
-            list of tuple: (state_variable | node, (detecting_signature, original_text, recommended_text))"""
+            list of tuple: (state_variable | node, (detecting_signature, original_text, recommended_text))
+        """
         results: List[
             Union[
                 Tuple[StateVariable, List[Tuple[str, str, str]]],
@@ -192,7 +193,7 @@ contract ContractWithDeprecatedReferences {
                     deprecated_entries = deprecated_reference[1]
                     info: DETECTOR_INFO = ["Deprecated standard detected ", source_object, ":\n"]
 
-                    for (_dep_id, original_desc, recommended_disc) in deprecated_entries:
+                    for _dep_id, original_desc, recommended_disc in deprecated_entries:
                         info += [
                             f'\t- Usage of "{original_desc}" should be replaced with "{recommended_disc}"\n'
                         ]

--- a/slither/detectors/statements/divide_before_multiply.py
+++ b/slither/detectors/statements/divide_before_multiply.py
@@ -193,8 +193,7 @@ In general, it's usually a good idea to re-arrange arithmetic to perform multipl
         for contract in self.contracts:
             divisions_before_multiplications = detect_divide_before_multiply(contract)
             if divisions_before_multiplications:
-                for (func, nodes) in divisions_before_multiplications:
-
+                for func, nodes in divisions_before_multiplications:
                     info: DETECTOR_INFO = [
                         func,
                         " performs a multiplication on the result of a division:\n",

--- a/slither/detectors/statements/incorrect_strict_equality.py
+++ b/slither/detectors/statements/incorrect_strict_equality.py
@@ -143,7 +143,6 @@ contract Crowdsale{
                 continue
             for node in func.nodes:
                 for ir in node.irs_ssa:
-
                     # Filter to only tainted equality (==) comparisons
                     if self.is_direct_comparison(ir) and self.is_any_tainted(ir.used, taints, func):
                         if func not in results:
@@ -172,7 +171,6 @@ contract Crowdsale{
             # sort ret to get deterministic results
             ret = sorted(list(ret.items()), key=lambda x: x[0].name)
             for f, nodes in ret:
-
                 func_info = [f, " uses a dangerous strict equality:\n"]
 
                 # sort the nodes to get deterministic results

--- a/slither/detectors/statements/mapping_deletion.py
+++ b/slither/detectors/statements/mapping_deletion.py
@@ -86,7 +86,7 @@ The mapping `balances` is never deleted, so `remove` does not work as intended."
         results = []
         for c in self.contracts:
             mapping = MappingDeletionDetection.detect_mapping_deletion(c)
-            for (func, struct, node) in mapping:
+            for func, struct, node in mapping:
                 info: DETECTOR_INFO = [func, " deletes ", struct, " which contains a mapping:\n"]
                 info += ["\t-", node, "\n"]
 

--- a/slither/detectors/statements/msg_value_in_loop.py
+++ b/slither/detectors/statements/msg_value_in_loop.py
@@ -21,7 +21,6 @@ def detect_msg_value_in_loop(contract: Contract) -> List[Node]:
 def msg_value_in_loop(
     node: Optional[Node], in_loop_counter: int, visited: List[Node], results: List[Node]
 ) -> None:
-
     if node is None:
         return
 

--- a/slither/detectors/statements/redundant_statements.py
+++ b/slither/detectors/statements/redundant_statements.py
@@ -66,7 +66,6 @@ Each commented line references types/identifiers, but performs no action with th
 
         # Loop through all functions + modifiers defined explicitly in this contract.
         for function in contract.functions_and_modifiers_declared:
-
             # Loop through each node in this function.
             for node in function.nodes:
                 if node.expression:
@@ -89,7 +88,6 @@ Each commented line references types/identifiers, but performs no action with th
         for contract in self.contracts:
             redundant_statements = self.detect_redundant_statements_contract(contract)
             if redundant_statements:
-
                 for redundant_statement in redundant_statements:
                     info: DETECTOR_INFO = [
                         'Redundant expression "',

--- a/slither/detectors/statements/tx_origin.py
+++ b/slither/detectors/statements/tx_origin.py
@@ -64,7 +64,6 @@ Bob is the owner of `TxOrigin`. Bob calls Eve's contract. Eve's contract calls `
     def detect_tx_origin(self, contract: Contract) -> List[Tuple[FunctionContract, List[Node]]]:
         ret = []
         for f in contract.functions:
-
             nodes = f.nodes
             condtional_nodes = [
                 n for n in nodes if n.contains_if() or n.contains_require_or_assert()
@@ -82,7 +81,6 @@ Bob is the owner of `TxOrigin`. Bob calls Eve's contract. Eve's contract calls `
         for c in self.contracts:
             values = self.detect_tx_origin(c)
             for func, nodes in values:
-
                 for node in nodes:
                     info: DETECTOR_INFO = [func, " uses tx.origin for authorization: ", node, "\n"]
                     res = self.generate_result(info)

--- a/slither/detectors/statements/type_based_tautology.py
+++ b/slither/detectors/statements/type_based_tautology.py
@@ -163,7 +163,7 @@ contract A {
         for contract in self.contracts:
             tautologies = self.detect_type_based_tautologies(contract)
             if tautologies:
-                for (func, nodes) in tautologies:
+                for func, nodes in tautologies:
                     for node in nodes:
                         info = [func, " contains a tautology or contradiction:\n"]
                         info += ["\t- ", node, "\n"]

--- a/slither/detectors/statements/unary.py
+++ b/slither/detectors/statements/unary.py
@@ -14,6 +14,7 @@ from slither.detectors.abstract_detector import (
 from slither.utils.output import Output
 from slither.visitors.expression.expression import ExpressionVisitor
 
+
 # pylint: disable=too-few-public-methods
 class InvalidUnaryExpressionDetector(ExpressionVisitor):
     def __init__(self, expression: Expression) -> None:

--- a/slither/detectors/statements/unprotected_upgradeable.py
+++ b/slither/detectors/statements/unprotected_upgradeable.py
@@ -57,7 +57,6 @@ def _initialize_functions(contract: Contract) -> List[Function]:
 
 
 class UnprotectedUpgradeable(AbstractDetector):
-
     ARGUMENT = "unprotected-upgrade"
     HELP = "Unprotected upgradeable contract"
     IMPACT = DetectorClassification.HIGH

--- a/slither/detectors/variables/function_init_state_variables.py
+++ b/slither/detectors/variables/function_init_state_variables.py
@@ -25,7 +25,6 @@ def detect_function_init_state_vars(contract: Contract) -> List[StateVariable]:
 
     # Loop for each state variable explicitly defined in this contract.
     for state_variable in contract.variables:
-
         # Skip this variable if it is inherited and not explicitly defined in this contract definition.
         if state_variable.contract != contract:
             continue

--- a/slither/detectors/variables/predeclaration_usage_local.py
+++ b/slither/detectors/variables/predeclaration_usage_local.py
@@ -150,7 +150,7 @@ Additionally, the for-loop uses the variable `max`, which is declared in a previ
         for contract in self.contracts:
             predeclared_usages = self.detect_predeclared_in_contract(contract)
             if predeclared_usages:
-                for (predeclared_usage_function, predeclared_usage_nodes) in predeclared_usages:
+                for predeclared_usage_function, predeclared_usage_nodes in predeclared_usages:
                     for (
                         predeclared_usage_node,
                         predeclared_usage_local_variable,

--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -87,7 +87,7 @@ class SimilarVarsDetection(AbstractDetector):
         for c in self.contracts:
             allVars = self.detect_sim(c)
             if allVars:
-                for (v1, v2) in sorted(allVars, key=lambda x: (x[0].name, x[1].name)):
+                for v1, v2 in sorted(allVars, key=lambda x: (x[0].name, x[1].name)):
                     v_left = v1 if v1.name < v2.name else v2
                     v_right = v2 if v_left == v1 else v1
                     info: DETECTOR_INFO = [

--- a/slither/detectors/variables/uninitialized_local_variables.py
+++ b/slither/detectors/variables/uninitialized_local_variables.py
@@ -13,7 +13,6 @@ from slither.utils.output import Output
 
 
 class UninitializedLocalVars(AbstractDetector):
-
     ARGUMENT = "uninitialized-local"
     HELP = "Uninitialized local variables"
     IMPACT = DetectorClassification.MEDIUM
@@ -108,8 +107,7 @@ Bob calls `transfer`. As a result, all Ether is sent to the address `0x0` and is
                     function.entry_point.context[self.key] = uninitialized_local_variables
                     self._detect_uninitialized(function, function.entry_point, [])
         all_results = list(set(self.results))
-        for (function, uninitialized_local_variable) in all_results:
-
+        for function, uninitialized_local_variable in all_results:
             info = [
                 uninitialized_local_variable,
                 " is a local variable never initialized\n",

--- a/slither/detectors/variables/uninitialized_state_variables.py
+++ b/slither/detectors/variables/uninitialized_state_variables.py
@@ -143,7 +143,6 @@ Initialize all the variables. If a variable is meant to be initialized to zero, 
         for c in self.compilation_unit.contracts_derived:
             ret = self._detect_uninitialized(c)
             for variable, functions in ret:
-
                 info: DETECTOR_INFO = [variable, " is never initialized. It is used in:\n"]
 
                 for f in functions:

--- a/slither/detectors/variables/uninitialized_storage_variables.py
+++ b/slither/detectors/variables/uninitialized_storage_variables.py
@@ -13,7 +13,6 @@ from slither.utils.output import Output
 
 
 class UninitializedStorageVars(AbstractDetector):
-
     ARGUMENT = "uninitialized-storage"
     HELP = "Uninitialized storage variables"
     IMPACT = DetectorClassification.HIGH
@@ -111,7 +110,7 @@ Bob calls `func`. As a result, `owner` is overridden to `0`.
                     function.entry_point.context[self.key] = uninitialized_storage_variables
                     self._detect_uninitialized(function, function.entry_point, [])
 
-        for (function, uninitialized_storage_variable) in self.results:
+        for function, uninitialized_storage_variable in self.results:
             info = [
                 uninitialized_storage_variable,
                 " is a storage variable never initialized\n",

--- a/slither/formatters/naming_convention/naming_convention.py
+++ b/slither/formatters/naming_convention/naming_convention.py
@@ -401,7 +401,6 @@ def _explore_type(  # pylint: disable=too-many-arguments,too-many-locals,too-man
             custom_type.type_from,
             custom_type.type_to,
         ]:
-
             full_txt_start = start
             full_txt_end = end
             full_txt = slither.core.source_code[filename_source_code].encode("utf8")[

--- a/slither/formatters/utils/patches.py
+++ b/slither/formatters/utils/patches.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from slither.core.compilation_unit import SlitherCompilationUnit
 
+
 # pylint: disable=too-many-arguments
 def create_patch(
     result: Dict,

--- a/slither/formatters/variables/unchanged_state_variables.py
+++ b/slither/formatters/variables/unchanged_state_variables.py
@@ -8,7 +8,6 @@ from slither.formatters.utils.patches import create_patch
 def custom_format(compilation_unit: SlitherCompilationUnit, result, attribute: str) -> None:
     elements = result["elements"]
     for element in elements:
-
         # TODO: decide if this should be changed in the constant detector
         contract_name = element["type_specific_fields"]["parent"]["name"]
         scope = compilation_unit.get_scope(element["source_mapping"]["filename_absolute"])

--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-import,relative-beyond-top-level
 from .summary.function import FunctionSummary
 from .summary.contract import ContractSummary
+from .summary.loc import Loc
 from .inheritance.inheritance import PrinterInheritance
 from .inheritance.inheritance_graph import PrinterInheritanceGraph
 from .call.call_graph import PrinterCallGraph

--- a/slither/printers/functions/authorization.py
+++ b/slither/printers/functions/authorization.py
@@ -10,7 +10,6 @@ from slither.utils.output import Output
 
 
 class PrinterWrittenVariablesAndAuthorization(AbstractPrinter):
-
     ARGUMENT = "vars-and-auth"
     HELP = "Print the state variables written and the authorization of the functions"
 
@@ -52,7 +51,6 @@ class PrinterWrittenVariablesAndAuthorization(AbstractPrinter):
                 ["Function", "State variables written", "Conditions on msg.sender"]
             )
             for function in contract.functions:
-
                 state_variables_written = [
                     v.name for v in function.all_state_variables_written() if v.name
                 ]

--- a/slither/printers/functions/cfg.py
+++ b/slither/printers/functions/cfg.py
@@ -3,7 +3,6 @@ from slither.utils.output import Output
 
 
 class CFG(AbstractPrinter):
-
     ARGUMENT = "cfg"
     HELP = "Export the CFG of each functions"
 

--- a/slither/printers/functions/dominator.py
+++ b/slither/printers/functions/dominator.py
@@ -3,7 +3,6 @@ from slither.utils.output import Output
 
 
 class Dominator(AbstractPrinter):
-
     ARGUMENT = "dominator"
     HELP = "Export the dominator tree of each functions"
 

--- a/slither/printers/inheritance/inheritance.py
+++ b/slither/printers/inheritance/inheritance.py
@@ -39,7 +39,6 @@ class PrinterInheritance(AbstractPrinter):
             info += blue(f"\n+ {child.name}\n")
             result["child_to_base"][child.name] = {"immediate": [], "not_immediate": []}
             if child.inheritance:
-
                 immediate = child.immediate_inheritance
                 not_immediate = [i for i in child.inheritance if i not in immediate]
 

--- a/slither/printers/summary/constructor_calls.py
+++ b/slither/printers/summary/constructor_calls.py
@@ -34,7 +34,6 @@ class ConstructorPrinter(AbstractPrinter):
                     stack_definition.append(_get_source_code(cst))
 
             if len(stack_name) > 0:
-
                 info += "\n########" + "#" * len(contract.name) + "########\n"
                 info += "####### " + contract.name + " #######\n"
                 info += "########" + "#" * len(contract.name) + "########\n\n"

--- a/slither/printers/summary/data_depenency.py
+++ b/slither/printers/summary/data_depenency.py
@@ -22,7 +22,6 @@ def _get(v: SUPPORTED_TYPES, c: Contract) -> List[str]:
 
 
 class DataDependency(AbstractPrinter):
-
     ARGUMENT = "data-dependency"
     HELP = "Print the data dependencies of the variables"
 

--- a/slither/printers/summary/function.py
+++ b/slither/printers/summary/function.py
@@ -7,7 +7,6 @@ from slither.utils.myprettytable import MyPrettyTable
 
 
 class FunctionSummary(AbstractPrinter):
-
     ARGUMENT = "function-summary"
     HELP = "Print a summary of the functions"
 

--- a/slither/printers/summary/function_ids.py
+++ b/slither/printers/summary/function_ids.py
@@ -7,7 +7,6 @@ from slither.utils.myprettytable import MyPrettyTable
 
 
 class FunctionIds(AbstractPrinter):
-
     ARGUMENT = "function-id"
     HELP = "Print the keccak256 signature of the functions"
 

--- a/slither/printers/summary/human_summary.py
+++ b/slither/printers/summary/human_summary.py
@@ -2,12 +2,12 @@
 Module printing summary of the contract
 """
 import logging
-from pathlib import Path
 from typing import Tuple, List, Dict
 
 from slither.core.declarations import SolidityFunction, Function
 from slither.core.variables.state_variable import StateVariable
 from slither.printers.abstract_printer import AbstractPrinter
+from slither.printers.summary.loc import compute_loc_metrics
 from slither.slithir.operations import (
     LowLevelCall,
     HighLevelCall,
@@ -21,7 +21,6 @@ from slither.utils.colors import green, red, yellow
 from slither.utils.myprettytable import MyPrettyTable
 from slither.utils.standard_libraries import is_standard_library
 from slither.core.cfg.node import NodeType
-from slither.utils.tests_pattern import is_test_file
 
 
 class PrinterHumanSummary(AbstractPrinter):
@@ -32,7 +31,6 @@ class PrinterHumanSummary(AbstractPrinter):
 
     @staticmethod
     def _get_summary_erc20(contract):
-
         functions_name = [f.name for f in contract.functions]
         state_variables = [v.name for v in contract.state_variables]
 
@@ -165,27 +163,6 @@ class PrinterHumanSummary(AbstractPrinter):
     def _number_functions(contract):
         return len(contract.functions)
 
-    def _lines_number(self):
-        if not self.slither.source_code:
-            return None
-        total_dep_lines = 0
-        total_lines = 0
-        total_tests_lines = 0
-
-        for filename, source_code in self.slither.source_code.items():
-            lines = len(source_code.splitlines())
-            is_dep = False
-            if self.slither.crytic_compile:
-                is_dep = self.slither.crytic_compile.is_dependency(filename)
-            if is_dep:
-                total_dep_lines += lines
-            else:
-                if is_test_file(Path(filename)):
-                    total_tests_lines += lines
-                else:
-                    total_lines += lines
-        return total_lines, total_dep_lines, total_tests_lines
-
     def _get_number_of_assembly_lines(self):
         total_asm_lines = 0
         for contract in self.contracts:
@@ -226,7 +203,6 @@ class PrinterHumanSummary(AbstractPrinter):
         return list(set(ercs))
 
     def _get_features(self, contract):  # pylint: disable=too-many-branches
-
         has_payable = False
         can_send_eth = False
         can_selfdestruct = False
@@ -291,6 +267,36 @@ class PrinterHumanSummary(AbstractPrinter):
             "Proxy": contract.is_upgradeable_proxy,
         }
 
+    def _get_contracts(self, txt):
+        (
+            number_contracts,
+            number_contracts_deps,
+            number_contracts_tests,
+        ) = self._number_contracts()
+        txt += f"Total number of contracts in source files: {number_contracts}\n"
+        if number_contracts_deps > 0:
+            txt += f"Number of contracts in dependencies: {number_contracts_deps}\n"
+        if number_contracts_tests > 0:
+            txt += f"Number of contracts in tests       : {number_contracts_tests}\n"
+        return txt
+
+    def _get_number_lines(self, txt, results):
+        lines_dict = compute_loc_metrics(self.slither)
+        txt += "Source lines of code (SLOC) in source files: "
+        txt += f"{lines_dict['src']['sloc']}\n"
+        if lines_dict["dep"]["sloc"] > 0:
+            txt += "Source lines of code (SLOC) in dependencies: "
+            txt += f"{lines_dict['dep']['sloc']}\n"
+        if lines_dict["test"]["sloc"] > 0:
+            txt += "Source lines of code (SLOC) in tests       : "
+            txt += f"{lines_dict['test']['sloc']}\n"
+        results["number_lines"] = lines_dict["src"]["sloc"]
+        results["number_lines__dependencies"] = lines_dict["dep"]["sloc"]
+        total_asm_lines = self._get_number_of_assembly_lines()
+        txt += f"Number of  assembly lines: {total_asm_lines}\n"
+        results["number_lines_assembly"] = total_asm_lines
+        return txt, results
+
     def output(self, _filename):  # pylint: disable=too-many-locals,too-many-statements
         """
         _filename is not used
@@ -311,24 +317,8 @@ class PrinterHumanSummary(AbstractPrinter):
             "number_findings": {},
             "detectors": [],
         }
-
-        lines_number = self._lines_number()
-        if lines_number:
-            total_lines, total_dep_lines, total_tests_lines = lines_number
-            txt += f"Number of lines: {total_lines} (+ {total_dep_lines} in dependencies, + {total_tests_lines} in tests)\n"
-            results["number_lines"] = total_lines
-            results["number_lines__dependencies"] = total_dep_lines
-            total_asm_lines = self._get_number_of_assembly_lines()
-            txt += f"Number of assembly lines: {total_asm_lines}\n"
-            results["number_lines_assembly"] = total_asm_lines
-
-        (
-            number_contracts,
-            number_contracts_deps,
-            number_contracts_tests,
-        ) = self._number_contracts()
-        txt += f"Number of contracts: {number_contracts} (+ {number_contracts_deps} in dependencies, + {number_contracts_tests} tests) \n\n"
-
+        txt = self._get_contracts(txt)
+        txt, results = self._get_number_lines(txt, results)
         (
             txt_detectors,
             detectors_results,
@@ -352,7 +342,7 @@ class PrinterHumanSummary(AbstractPrinter):
         libs = self._standard_libraries()
         if libs:
             txt += f'\nUse: {", ".join(libs)}\n'
-            results["standard_libraries"] = [str(l) for l in libs]
+            results["standard_libraries"] = [str(lib) for lib in libs]
 
         ercs = self._ercs()
         if ercs:
@@ -363,7 +353,6 @@ class PrinterHumanSummary(AbstractPrinter):
             ["Name", "# functions", "ERCS", "ERC20 info", "Complex code", "Features"]
         )
         for contract in self.slither.contracts_derived:
-
             if contract.is_from_dependency() or contract.is_test:
                 continue
 

--- a/slither/printers/summary/loc.py
+++ b/slither/printers/summary/loc.py
@@ -6,9 +6,25 @@ from slither.printers.abstract_printer import AbstractPrinter
 from slither.utils.myprettytable import transpose, make_pretty_table
 from slither.utils.tests_pattern import is_test_file
 
+"""
+Definitions:
+    "cloc": comment lines of code containing only comments
+    "sloc": source lines of code with no whitespace or comments
+    "loc": all lines of code including whitespace and comments
+    "src": source files (excluding tests and dependencies)
+    "dep": dependency files
+    "test": test files
 
-# @param takes a list of lines and returns a tuple of (cloc, sloc, loc)
+"""
+
+
 def count_lines(contract_lines: list) -> tuple:
+    """Function to count and classify the lines of code in a contract.
+    Args:
+        contract_lines: list(str) representing the lines of a contract.
+    Returns:
+        tuple(int, int, int) representing (cloc, sloc, loc)
+    """
     multiline_comment = False
     cloc = 0
     sloc = 0
@@ -39,6 +55,19 @@ def count_lines(contract_lines: list) -> tuple:
 
 
 def _update_lines_dict(file_type: str, lines: list, lines_dict: dict) -> dict:
+    """ An internal function used to update (mutate in place) the lines_dict.
+    Args:
+        file_type: str indicating  "src" (source files), "dep" (dependency files), or "test" tests.
+        lines: list(str) representing the lines of a contract.
+        lines_dict: dict to be updated with this shape:
+        {
+            "src" : {"loc": 30, "sloc": 20, "cloc":  5},   # code in source files
+            "dep" : {"loc": 50, "sloc": 30, "cloc": 10},   # code in dependencies
+            "test": {"loc": 80, "sloc": 60, "cloc": 10},   # code in tests
+        }
+    Returns:
+        an updated lines_dict
+    """
     cloc, sloc, loc = count_lines(lines)
     lines_dict[file_type]["loc"] += loc
     lines_dict[file_type]["cloc"] += cloc
@@ -46,14 +75,19 @@ def _update_lines_dict(file_type: str, lines: list, lines_dict: dict) -> dict:
     return lines_dict
 
 
-# takes a Slither object and returns a dict of loc metrics:
-# {
-#     "src" : {"loc": 30, "sloc": 20, "cloc":  5},   # code in source files
-#     "dep" : {"loc": 50, "sloc": 30, "cloc": 10},   # code in dependencies
-#     "test": {"loc": 80, "sloc": 60, "cloc": 10},   # code in tests
-# }
-# * sloc = source lines of code, cloc = comment lines of code, loc = all lines of code
 def compute_loc_metrics(slither) -> dict:
+    """Used to compute the lines of code metrics for a Slither object.
+    Args:
+        slither: A Slither object
+    Returns:
+        A new dict with the following shape:
+        {
+            "src" : {"loc": 30, "sloc": 20, "cloc":  5},   # code in source files
+            "dep" : {"loc": 50, "sloc": 30, "cloc": 10},   # code in dependencies
+            "test": {"loc": 80, "sloc": 60, "cloc": 10},   # code in tests
+        }
+    """
+
     lines_dict = {
         "src": {"loc": 0, "sloc": 0, "cloc": 0},
         "dep": {"loc": 0, "sloc": 0, "cloc": 0},

--- a/slither/printers/summary/loc.py
+++ b/slither/printers/summary/loc.py
@@ -1,0 +1,96 @@
+"""
+    Module printing summary of the contract
+"""
+from pathlib import Path
+from slither.printers.abstract_printer import AbstractPrinter
+from slither.utils.myprettytable import transpose, make_pretty_table
+from slither.utils.tests_pattern import is_test_file
+
+
+# @param takes a list of lines and returns a tuple of (cloc, sloc, loc)
+def count_lines(contract_lines: list) -> tuple:
+    multiline_comment = False
+    cloc = 0
+    sloc = 0
+    loc = 0
+
+    for line in contract_lines:
+        loc += 1
+        stripped_line = line.strip()
+        if not multiline_comment:
+            if stripped_line.startswith("//"):
+                cloc += 1
+            elif "/*" in stripped_line:
+                # Account for case where /* is followed by */ on the same line.
+                # If it is, then multiline_comment does not need to be set to True
+                start_idx = stripped_line.find("/*")
+                end_idx = stripped_line.find("*/", start_idx + 2)
+                if end_idx == -1:
+                    multiline_comment = True
+                cloc += 1
+            elif stripped_line:
+                sloc += 1
+        else:
+            cloc += 1
+            if "*/" in stripped_line:
+                multiline_comment = False
+
+    return cloc, sloc, loc
+
+
+def _update_lines_dict(file_type: str, lines: list, lines_dict: dict) -> dict:
+    cloc, sloc, loc = count_lines(lines)
+    lines_dict[file_type]["loc"] += loc
+    lines_dict[file_type]["cloc"] += cloc
+    lines_dict[file_type]["sloc"] += sloc
+    return lines_dict
+
+
+# takes a Slither object and returns a dict of loc metrics:
+# {
+#     "src" : {"loc": 30, "sloc": 20, "cloc":  5},   # code in source files
+#     "dep" : {"loc": 50, "sloc": 30, "cloc": 10},   # code in dependencies
+#     "test": {"loc": 80, "sloc": 60, "cloc": 10},   # code in tests
+# }
+# * sloc = source lines of code, cloc = comment lines of code, loc = all lines of code
+def compute_loc_metrics(slither) -> dict:
+    lines_dict = {
+        "src": {"loc": 0, "sloc": 0, "cloc": 0},
+        "dep": {"loc": 0, "sloc": 0, "cloc": 0},
+        "test": {"loc": 0, "sloc": 0, "cloc": 0},
+    }
+
+    if not slither.source_code:
+        return lines_dict
+
+    for filename, source_code in slither.source_code.items():
+        current_lines = source_code.splitlines()
+        is_dep = False
+        if slither.crytic_compile:
+            is_dep = slither.crytic_compile.is_dependency(filename)
+        file_type = "dep" if is_dep else "test" if is_test_file(Path(filename)) else "src"
+        lines_dict = _update_lines_dict(file_type, current_lines, lines_dict)
+    return lines_dict
+
+
+class Loc(AbstractPrinter):
+    ARGUMENT = "loc"
+    HELP = """Count the total number lines of code (LOC), source lines of code (SLOC), \
+            and comment lines of code (CLOC) found in source files (SRC), dependencies (DEP), \
+            and test files (TEST)."""
+
+    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#loc"
+
+    def output(self, _filename):
+        # compute loc metrics
+        lines_dict = compute_loc_metrics(self.slither)
+
+        # prepare the table
+        headers = [""] + list(lines_dict.keys())
+        report_dict = transpose(lines_dict)
+        table = make_pretty_table(headers, report_dict)
+        txt = "Lines of Code \n" + str(table)
+        self.info(txt)
+        res = self.generate_output(txt)
+        res.add_pretty_table(table, "Code Lines")
+        return res

--- a/slither/printers/summary/loc.py
+++ b/slither/printers/summary/loc.py
@@ -1,21 +1,18 @@
 """
-    Module printing summary of the contract
+    Lines of Code (LOC) printer
+
+    Definitions:
+    cloc: comment lines of code containing only comments
+    sloc: source lines of code with no whitespace or comments
+    loc: all lines of code including whitespace and comments
+    src: source files (excluding tests and dependencies)
+    dep: dependency files
+    test: test files
 """
 from pathlib import Path
 from slither.printers.abstract_printer import AbstractPrinter
 from slither.utils.myprettytable import transpose, make_pretty_table
 from slither.utils.tests_pattern import is_test_file
-
-"""
-Definitions:
-    "cloc": comment lines of code containing only comments
-    "sloc": source lines of code with no whitespace or comments
-    "loc": all lines of code including whitespace and comments
-    "src": source files (excluding tests and dependencies)
-    "dep": dependency files
-    "test": test files
-
-"""
 
 
 def count_lines(contract_lines: list) -> tuple:

--- a/slither/printers/summary/modifier_calls.py
+++ b/slither/printers/summary/modifier_calls.py
@@ -8,7 +8,6 @@ from slither.utils.myprettytable import MyPrettyTable
 
 
 class Modifiers(AbstractPrinter):
-
     ARGUMENT = "modifiers"
     HELP = "Print the modifiers called by each function"
 
@@ -32,7 +31,7 @@ class Modifiers(AbstractPrinter):
                 for call in function.all_internal_calls():
                     if isinstance(call, Function):
                         modifiers += call.modifiers
-                for (_, call) in function.all_library_calls():
+                for _, call in function.all_library_calls():
                     if isinstance(call, Function):
                         modifiers += call.modifiers
                 table.add_row([function.name, sorted([m.name for m in set(modifiers)])])

--- a/slither/printers/summary/require_calls.py
+++ b/slither/printers/summary/require_calls.py
@@ -15,7 +15,6 @@ require_or_assert = [
 
 
 class RequireOrAssert(AbstractPrinter):
-
     ARGUMENT = "require"
     HELP = "Print the require and assert calls of each function"
 

--- a/slither/printers/summary/slithir_ssa.py
+++ b/slither/printers/summary/slithir_ssa.py
@@ -6,7 +6,6 @@ from slither.printers.abstract_printer import AbstractPrinter
 
 
 class PrinterSlithIRSSA(AbstractPrinter):
-
     ARGUMENT = "slithir-ssa"
     HELP = "Print the slithIR representation of the functions"
 

--- a/slither/printers/summary/variable_order.py
+++ b/slither/printers/summary/variable_order.py
@@ -8,7 +8,6 @@ from slither.utils.output import Output
 
 
 class VariableOrder(AbstractPrinter):
-
     ARGUMENT = "variable-order"
     HELP = "Print the storage order of the state variables"
 

--- a/slither/printers/summary/when_not_paused.py
+++ b/slither/printers/summary/when_not_paused.py
@@ -10,7 +10,6 @@ from slither.utils.myprettytable import MyPrettyTable
 
 
 def _use_modifier(function: Function, modifier_name: str = "whenNotPaused") -> bool:
-
     for internal_call in function.all_internal_calls():
         if isinstance(internal_call, SolidityFunction):
             continue
@@ -20,7 +19,6 @@ def _use_modifier(function: Function, modifier_name: str = "whenNotPaused") -> b
 
 
 class PrinterWhenNotPaused(AbstractPrinter):
-
     ARGUMENT = "not-pausable"
     HELP = "Print functions that do not use whenNotPaused"
 
@@ -39,7 +37,6 @@ class PrinterWhenNotPaused(AbstractPrinter):
         txt += "Constructor and pure/view functions are not displayed\n"
         all_tables = []
         for contract in self.slither.contracts:
-
             txt += f"\n{contract.name}:\n"
             table = MyPrettyTable(["Name", "Use whenNotPaused"])
 

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -23,7 +23,6 @@ logger_printer = logging.getLogger("Printers")
 def _check_common_things(
     thing_name: str, cls: Type, base_cls: Type, instances_list: List[Type[AbstractDetector]]
 ) -> None:
-
     if not issubclass(cls, base_cls) or cls is base_cls:
         raise Exception(
             f"You can't register {cls!r} as a {thing_name}. You need to pass a class that inherits from {base_cls.__name__}"
@@ -135,7 +134,6 @@ class Slither(SlitherCore):  # pylint: disable=too-many-instance-attributes
         self._init_parsing_and_analyses(kwargs.get("skip_analyze", False))
 
     def _init_parsing_and_analyses(self, skip_analyze: bool) -> None:
-
         for parser in self._parsers:
             try:
                 parser.parse_contracts()

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1674,7 +1674,6 @@ def convert_type_of_high_and_internal_level_call(
         else:
             return_type = func.type
     if return_type:
-
         # If the return type is a structure, but the lvalue is a tuple
         # We convert the type of the structure to a list of element
         # TODO: explore to replace all tuple variables by structures
@@ -1883,7 +1882,6 @@ def convert_delete(irs: List[Operation]) -> None:
 
 def _find_source_mapping_references(irs: List[Operation]) -> None:
     for ir in irs:
-
         if isinstance(ir, NewContract):
             ir.contract_created.references.append(ir.expression.source_mapping)
 

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -137,7 +137,7 @@ def add_ssa_ir(
     # We only add phi function for state variable at entry node if
     # The state variable is used
     # And if the state variables is written in another function (otherwise its stay at index 0)
-    for (_, variable_instance) in all_state_variables_instances.items():
+    for _, variable_instance in all_state_variables_instances.items():
         if is_used_later(function.entry_point, variable_instance):
             # rvalues are fixed in solc_parsing.declaration.function
             function.entry_point.add_ssa_ir(Phi(StateIRVariable(variable_instance), set()))
@@ -145,13 +145,13 @@ def add_ssa_ir(
     add_phi_origins(function.entry_point, init_definition, {})
 
     for node in function.nodes:
-        for (variable, nodes) in node.phi_origins_local_variables.values():
+        for variable, nodes in node.phi_origins_local_variables.values():
             if len(nodes) < 2:
                 continue
             if not is_used_later(node, variable):
                 continue
             node.add_ssa_ir(Phi(LocalIRVariable(variable), nodes))
-        for (variable, nodes) in node.phi_origins_state_variables.values():
+        for variable, nodes in node.phi_origins_state_variables.values():
             if len(nodes) < 2:
                 continue
             # if not is_used_later(node, variable.name, []):
@@ -222,7 +222,6 @@ def generate_ssa_irs(
     init_local_variables_instances: Dict[str, LocalIRVariable],
     visited: List[Node],
 ) -> None:
-
     if node in visited:
         return
 
@@ -275,7 +274,6 @@ def generate_ssa_irs(
         )
 
         if new_ir:
-
             node.add_ssa_ir(new_ir)
 
             if isinstance(ir, (InternalCall, HighLevelCall, InternalDynamicCall, LowLevelCall)):
@@ -538,7 +536,6 @@ def add_phi_origins(
     local_variables_definition: Dict[str, Tuple[LocalVariable, Node]],
     state_variables_definition: Dict[str, Tuple[StateVariable, Node]],
 ) -> None:
-
     # Add new key to local_variables_definition
     # The key is the variable_name
     # The value is (variable_instance, the node where its written)

--- a/slither/solc_parsing/cfg/node.py
+++ b/slither/solc_parsing/cfg/node.py
@@ -39,7 +39,6 @@ class NodeSolc:
             # self._unparsed_expression = None
 
         if self._node.expression:
-
             if self._node.type == NodeType.VARIABLE:
                 # Update the expression to be an assignement to the variable
                 _expression = AssignmentOperation(

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -297,7 +297,6 @@ class ContractSolc(CallerContextExpression):
         self._contract.file_scope.user_defined_types[alias_canonical] = user_defined_type
 
     def _parse_struct(self, struct: Dict) -> None:
-
         st = StructureContract(self._contract.compilation_unit)
         st.set_contract(self._contract)
         st.set_offset(struct["src"], self._contract.compilation_unit)
@@ -392,7 +391,6 @@ class ContractSolc(CallerContextExpression):
         self._slither_parser.add_function_or_modifier_parser(func_parser)
 
     def parse_functions(self) -> None:
-
         for function in self._functionsNotParsed:
             self._parse_function(function)
 

--- a/slither/solc_parsing/declarations/custom_error.py
+++ b/slither/solc_parsing/declarations/custom_error.py
@@ -83,7 +83,6 @@ class CustomErrorSolc(CallerContextExpression):
         self._custom_error.set_solidity_sig()
 
     def _add_param(self, param: Dict) -> LocalVariableSolc:
-
         local_var = LocalVariable()
         local_var.set_offset(param["src"], self._slither_parser.compilation_unit)
 

--- a/slither/solc_parsing/declarations/event.py
+++ b/slither/solc_parsing/declarations/event.py
@@ -17,7 +17,6 @@ class EventSolc:
     """
 
     def __init__(self, event: Event, event_data: Dict, contract_parser: "ContractSolc") -> None:
-
         self._event = event
         event.set_contract(contract_parser.underlying_contract)
         self._parser_contract = contract_parser

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -46,7 +46,6 @@ def link_underlying_nodes(node1: NodeSolc, node2: NodeSolc):
 
 
 class FunctionSolc(CallerContextExpression):
-
     # elems = [(type, name)]
 
     def __init__(
@@ -620,7 +619,6 @@ class FunctionSolc(CallerContextExpression):
         return node_endLoop
 
     def _parse_dowhile(self, do_while_statement: Dict, node: NodeSolc) -> NodeSolc:
-
         node_startDoWhile = self._new_node(
             NodeType.STARTLOOP, do_while_statement["src"], node.underlying_node.scope
         )
@@ -1054,7 +1052,6 @@ class FunctionSolc(CallerContextExpression):
         return node
 
     def _parse_cfg(self, cfg: Dict) -> None:
-
         assert cfg[self.get_key()] == "Block"
 
         node = self._new_node(NodeType.ENTRYPOINT, cfg["src"], self.underlying_function)
@@ -1162,7 +1159,6 @@ class FunctionSolc(CallerContextExpression):
                     self._fix_catch(son, end_node, visited)
 
     def _add_param(self, param: Dict) -> LocalVariableSolc:
-
         local_var = LocalVariable()
         local_var.set_function(self._function)
         local_var.set_offset(param["src"], self._function.compilation_unit)
@@ -1194,7 +1190,6 @@ class FunctionSolc(CallerContextExpression):
             self._function.add_parameters(local_var.underlying_variable)
 
     def _parse_returns(self, returns: Dict):
-
         assert returns[self.get_key()] == "ParameterList"
 
         self._function.returns_src().set_offset(returns["src"], self._function.compilation_unit)

--- a/slither/solc_parsing/declarations/structure_contract.py
+++ b/slither/solc_parsing/declarations/structure_contract.py
@@ -24,7 +24,6 @@ class StructureContractSolc:  # pylint: disable=too-few-public-methods
         struct: Dict,
         contract_parser: "ContractSolc",
     ) -> None:
-
         if contract_parser.is_compact_ast:
             name = struct["name"]
             attributes = struct

--- a/slither/solc_parsing/declarations/structure_top_level.py
+++ b/slither/solc_parsing/declarations/structure_top_level.py
@@ -26,7 +26,6 @@ class StructureTopLevelSolc(CallerContextExpression):  # pylint: disable=too-few
         struct: Dict,
         slither_parser: "SlitherCompilationUnitSolc",
     ) -> None:
-
         if slither_parser.is_compact_ast:
             name = struct["name"]
             attributes = struct

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -103,6 +103,7 @@ def filter_name(value: str) -> str:
 ###################################################################################
 ###################################################################################
 
+
 # pylint: disable=too-many-statements
 def parse_call(
     expression: Dict, caller_context: Union["FunctionSolc", "ContractSolc", "TopLevelVariableSolc"]
@@ -395,7 +396,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
         return assignement
 
     if name == "Literal":
-
         subdenomination = None
 
         assert "children" not in expression
@@ -550,7 +550,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
 
     # NewExpression is not a root expression, it's always the child of another expression
     if name == "NewExpression":
-
         if is_compact_ast:
             type_name = expression["typeName"]
         else:
@@ -605,7 +604,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
         assert type_name[caller_context.get_key()] == "UserDefinedTypeName"
 
         if is_compact_ast:
-
             # Changed introduced in Solidity 0.8
             # see https://github.com/crytic/slither/issues/794
 
@@ -622,7 +620,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
         return new
 
     if name == "ModifierInvocation":
-
         if is_compact_ast:
             called = parse_expression(expression["modifierName"], caller_context)
             arguments = []
@@ -648,7 +645,6 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
 
     # Introduced with solc 0.8
     if name == "IdentifierPath":
-
         if caller_context.is_compact_ast:
             value = expression["name"]
 

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -50,7 +50,6 @@ def _handle_import_aliases(
     for symbol_alias in symbol_aliases:
         if "foreign" in symbol_alias and "local" in symbol_alias:
             if isinstance(symbol_alias["foreign"], dict) and "name" in symbol_alias["foreign"]:
-
                 original_name = symbol_alias["foreign"]["name"]
                 local_name = symbol_alias["local"]
                 import_directive.renaming[local_name] = original_name
@@ -151,7 +150,6 @@ class SlitherCompilationUnitSolc(CallerContextExpression):
             self.parse_top_level_from_loaded_json(data_loaded, filename)
             return True
         except ValueError:
-
             first = json_data.find("{")
             if first != -1:
                 last = json_data.rfind("}") + 1
@@ -555,7 +553,6 @@ Please rename it, this name is reserved for Slither's internals"""
         # Analyze a contract only if all its fathers
         # Were analyzed
         while contracts_to_be_analyzed:
-
             contract = contracts_to_be_analyzed[0]
 
             contracts_to_be_analyzed = contracts_to_be_analyzed[1:]
@@ -585,7 +582,6 @@ Please rename it, this name is reserved for Slither's internals"""
         # Analyze a contract only if all its fathers
         # Were analyzed
         while contracts_to_be_analyzed:
-
             contract = contracts_to_be_analyzed[0]
 
             contracts_to_be_analyzed = contracts_to_be_analyzed[1:]
@@ -612,7 +608,6 @@ Please rename it, this name is reserved for Slither's internals"""
         # Analyze a contract only if all its fathers
         # Were analyzed
         while contracts_to_be_analyzed:
-
             contract = contracts_to_be_analyzed[0]
 
             contracts_to_be_analyzed = contracts_to_be_analyzed[1:]
@@ -664,7 +659,6 @@ Please rename it, this name is reserved for Slither's internals"""
         contract.set_is_analyzed(True)
 
     def _analyze_struct_events(self, contract: ContractSolc) -> None:
-
         contract.analyze_constant_state_variables()
 
         # Struct can refer to enum, or state variables
@@ -727,7 +721,6 @@ Please rename it, this name is reserved for Slither's internals"""
         contract.set_is_analyzed(True)
 
     def _convert_to_slithir(self) -> None:
-
         for contract in self._compilation_unit.contracts:
             contract.add_constructor_variables()
 

--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -196,7 +196,6 @@ def _find_from_type_name(  # pylint: disable=too-many-locals,too-many-branches,t
 
 
 def _add_type_references(type_found: Type, src: str, sl: "SlitherCompilationUnit") -> None:
-
     if isinstance(type_found, UserDefinedType):
         type_found.type.add_reference_from_raw_source(src, sl)
     elif isinstance(type_found, (TypeAliasTopLevel, TypeAliasContract)):
@@ -438,7 +437,6 @@ def parse_type(
         return ArrayType(array_type, length)
 
     if t[key] == "Mapping":
-
         if is_compact_ast:
             mappingFrom = parse_type(t["keyType"], next_context)
             mappingTo = parse_type(t["valueType"], next_context)
@@ -451,7 +449,6 @@ def parse_type(
         return MappingType(mappingFrom, mappingTo)
 
     if t[key] == "FunctionTypeName":
-
         if is_compact_ast:
             params = t["parameterTypes"]
             return_values = t["returnParameterTypes"]

--- a/slither/solc_parsing/variables/variable_declaration.py
+++ b/slither/solc_parsing/variables/variable_declaration.py
@@ -106,7 +106,6 @@ class VariableDeclarationSolc:
 
     def _handle_comment(self, attributes: Dict) -> None:
         if "documentation" in attributes and "text" in attributes["documentation"]:
-
             candidates = attributes["documentation"]["text"].split(",")
 
             for candidate in candidates:

--- a/slither/tools/doctor/checks/paths.py
+++ b/slither/tools/doctor/checks/paths.py
@@ -22,7 +22,7 @@ def path_is_relative_to(path: Path, relative_to: Path) -> bool:
     if len(path_parts) < len(relative_to_parts):
         return False
 
-    for (a, b) in zip(path_parts, relative_to_parts):
+    for a, b in zip(path_parts, relative_to_parts):
         if a != b:
             return False
 

--- a/slither/tools/erc_conformance/__main__.py
+++ b/slither/tools/erc_conformance/__main__.py
@@ -85,7 +85,6 @@ def main() -> None:
     ret: Dict[str, List] = defaultdict(list)
 
     if args.erc.upper() in ERCS:
-
         contracts = slither.get_contract_from_name(args.contract_name)
 
         if len(contracts) != 1:

--- a/slither/tools/erc_conformance/erc/ercs.py
+++ b/slither/tools/erc_conformance/erc/ercs.py
@@ -190,7 +190,6 @@ def generic_erc_checks(
     ret: Dict[str, List],
     explored: Optional[Set[Contract]] = None,
 ) -> None:
-
     if explored is None:
         explored = set()
 

--- a/slither/tools/flattening/__main__.py
+++ b/slither/tools/flattening/__main__.py
@@ -112,7 +112,6 @@ def main() -> None:
     slither = Slither(args.filename, **vars(args))
 
     for compilation_unit in slither.compilation_units:
-
         flat = Flattening(
             compilation_unit,
             external_to_public=args.convert_external,

--- a/slither/tools/flattening/flattening.py
+++ b/slither/tools/flattening/flattening.py
@@ -433,7 +433,6 @@ class Flattening:
         zip: Optional[str] = None,  # pylint: disable=redefined-builtin
         zip_type: Optional[str] = None,
     ):
-
         if not self._export_path.exists():
             self._export_path.mkdir(parents=True)
 

--- a/slither/tools/kspec_coverage/kspec_coverage.py
+++ b/slither/tools/kspec_coverage/kspec_coverage.py
@@ -5,7 +5,6 @@ from slither import Slither
 
 
 def kspec_coverage(args: argparse.Namespace) -> None:
-
     contract = args.contract
     kspec = args.kspec
 

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -73,7 +73,6 @@ class ListMutators(argparse.Action):  # pylint: disable=too-few-public-methods
 
 
 def main() -> None:
-
     args = parse_args()
 
     print(args.codebase)

--- a/slither/tools/mutator/mutators/MIA.py
+++ b/slither/tools/mutator/mutators/MIA.py
@@ -12,13 +12,10 @@ class MIA(AbstractMutator):  # pylint: disable=too-few-public-methods
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self) -> Dict:
-
         result: Dict = {}
 
         for contract in self.slither.contracts:
-
             for function in contract.functions_declared + list(contract.modifiers_declared):
-
                 for node in function.nodes:
                     if node.type == NodeType.IF:
                         # Retrieve the file

--- a/slither/tools/mutator/mutators/MVIE.py
+++ b/slither/tools/mutator/mutators/MVIE.py
@@ -13,11 +13,9 @@ class MVIE(AbstractMutator):  # pylint: disable=too-few-public-methods
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self) -> Dict:
-
         result: Dict = {}
         variable: Variable
         for contract in self.slither.contracts:
-
             # Create fault for state variables declaration
             for variable in contract.state_variables_declared:
                 if variable.initialized:

--- a/slither/tools/mutator/mutators/MVIV.py
+++ b/slither/tools/mutator/mutators/MVIV.py
@@ -13,12 +13,10 @@ class MVIV(AbstractMutator):  # pylint: disable=too-few-public-methods
     FAULTNATURE = FaultNature.Missing
 
     def _mutate(self) -> Dict:
-
         result: Dict = {}
         variable: Variable
 
         for contract in self.slither.contracts:
-
             # Create fault for state variables declaration
             for variable in contract.state_variables_declared:
                 if variable.initialized:

--- a/slither/tools/mutator/utils/command_line.py
+++ b/slither/tools/mutator/utils/command_line.py
@@ -17,7 +17,7 @@ def output_mutators(mutators_classes: List[Type[AbstractMutator]]) -> None:
     # Sort by class, nature, name
     mutators_list = sorted(mutators_list, key=lambda element: (element[2], element[3], element[0]))
     idx = 1
-    for (argument, help_info, fault_class, fault_nature) in mutators_list:
+    for argument, help_info, fault_class, fault_nature in mutators_list:
         table.add_row([str(idx), argument, help_info, fault_class, fault_nature])
         idx = idx + 1
     print(table)

--- a/slither/tools/possible_paths/possible_paths.py
+++ b/slither/tools/possible_paths/possible_paths.py
@@ -116,7 +116,6 @@ def __find_target_paths(
     # Look through all functions
     for contract in slither.contracts:
         for function in contract.functions_and_modifiers_declared:
-
             # If the function is already in our path, skip it.
             if function in current_path:
                 continue

--- a/slither/tools/properties/solidity/generate_properties.py
+++ b/slither/tools/properties/solidity/generate_properties.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("Slither")
 def generate_solidity_properties(
     contract: Contract, type_property: str, solidity_properties: str, output_dir: Path
 ) -> Path:
-
     solidity_import = 'import "./interfaces.sol";\n'
     solidity_import += f'import "../{contract.source_mapping.filename.short}";'
 

--- a/slither/tools/similarity/encode.py
+++ b/slither/tools/similarity/encode.py
@@ -233,10 +233,8 @@ def encode_contract(cfilename, **kwargs):
 
     # Iterate over all the contracts
     for contract in slither.contracts:
-
         # Iterate over all the functions
         for function in contract.functions_declared:
-
             if function.nodes == [] or function.is_constructor_variables:
                 continue
 

--- a/slither/tools/similarity/info.py
+++ b/slither/tools/similarity/info.py
@@ -12,9 +12,7 @@ logger = logging.getLogger("Slither-simil")
 
 
 def info(args: argparse.Namespace) -> None:
-
     try:
-
         model = args.model
         if os.path.isfile(model):
             model = load_model(model)

--- a/slither/tools/similarity/plot.py
+++ b/slither/tools/similarity/plot.py
@@ -25,7 +25,6 @@ logger = logging.getLogger("Slither-simil")
 
 
 def plot(args: argparse.Namespace) -> None:  # pylint: disable=too-many-locals
-
     if decomposition is None or plt is None:
         logger.error(
             "ERROR: In order to use plot mode in slither-simil, you need to install sklearn and matplotlib:"
@@ -34,7 +33,6 @@ def plot(args: argparse.Namespace) -> None:  # pylint: disable=too-many-locals
         sys.exit(-1)
 
     try:
-
         model = args.model
         model = load_model(model)
         # contract = args.contract
@@ -71,7 +69,7 @@ def plot(args: argparse.Namespace) -> None:  # pylint: disable=too-many-locals
         logger.info("Plotting data..")
         plt.figure(figsize=(20, 10))
         assert len(tdata) == len(fs)
-        for ([x, y], l) in zip(tdata, fs):
+        for [x, y], l in zip(tdata, fs):
             x = random.gauss(0, 0.01) + x
             y = random.gauss(0, 0.01) + y
             plt.scatter(x, y, c="blue")

--- a/slither/tools/similarity/test.py
+++ b/slither/tools/similarity/test.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("Slither-simil")
 
 
 def test(args: Namespace) -> None:
-
     try:
         model = args.model
         model = load_model(model)

--- a/slither/tools/similarity/train.py
+++ b/slither/tools/similarity/train.py
@@ -12,7 +12,6 @@ logger = logging.getLogger("Slither-simil")
 
 
 def train(args: argparse.Namespace) -> None:  # pylint: disable=too-many-locals
-
     try:
         last_data_train_filename = "last_data_train.txt"
         model_filename = args.model

--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -279,6 +279,7 @@ def _checks_on_contract_and_proxy(
 ###################################################################################
 ###################################################################################
 
+
 # pylint: disable=too-many-statements,too-many-branches,too-many-locals
 def main() -> None:
     json_results: Dict = {

--- a/slither/tools/upgradeability/checks/constant.py
+++ b/slither/tools/upgradeability/checks/constant.py
@@ -70,7 +70,6 @@ Do not remove `constant` from a state variables during an update.
 
         results = []
         while idx_v1 < len(state_variables_v1):
-
             state_v1 = contract_v1.state_variables[idx_v1]
             if len(state_variables_v2) <= idx_v2:
                 break
@@ -160,7 +159,6 @@ Do not make an existing state variable `constant`.
 
         results = []
         while idx_v1 < len(state_variables_v1):
-
             state_v1 = contract_v1.state_variables[idx_v1]
             if len(state_variables_v2) <= idx_v2:
                 break

--- a/slither/tools/upgradeability/checks/functions_ids.py
+++ b/slither/tools/upgradeability/checks/functions_ids.py
@@ -88,7 +88,7 @@ Rename the function. Avoid public functions in the proxy.
 
         results = []
 
-        for (k, _) in signatures_ids_implem.items():
+        for k, _ in signatures_ids_implem.items():
             if k in signatures_ids_proxy:
                 if signatures_ids_implem[k] != signatures_ids_proxy[k]:
                     implem_function = _get_function_or_variable(
@@ -160,7 +160,7 @@ Rename the function. Avoid public functions in the proxy.
 
         results = []
 
-        for (k, _) in signatures_ids_implem.items():
+        for k, _ in signatures_ids_implem.items():
             if k in signatures_ids_proxy:
                 if signatures_ids_implem[k] == signatures_ids_proxy[k]:
                     implem_function = _get_function_or_variable(

--- a/slither/tools/upgradeability/checks/initialization.py
+++ b/slither/tools/upgradeability/checks/initialization.py
@@ -376,7 +376,6 @@ Ensure that the function is called at deployment.
     REQUIRE_CONTRACT = True
 
     def _check(self):
-
         # TODO: handle MultipleInitTarget
         try:
             most_derived_init = _get_most_derived_init(self.contract)

--- a/slither/tools/upgradeability/utils/command_line.py
+++ b/slither/tools/upgradeability/utils/command_line.py
@@ -47,7 +47,7 @@ def output_detectors(detector_classes: List[Type[AbstractCheck]]) -> None:
     # Sort by impact, confidence, and name
     detectors_list = sorted(detectors_list, key=lambda element: (element[2], element[0]))
     idx = 1
-    for (argument, help_info, impact, proxy, v2) in detectors_list:
+    for argument, help_info, impact, proxy, v2 in detectors_list:
         table.add_row(
             [
                 str(idx),
@@ -80,7 +80,7 @@ def output_to_markdown(detector_classes: List[Type[AbstractCheck]], _filter_wiki
     # Sort by impact, confidence, and name
     detectors_list = sorted(detectors_list, key=lambda element: (element[2], element[0]))
     idx = 1
-    for (argument, help_info, impact, proxy, v2) in detectors_list:
+    for argument, help_info, impact, proxy, v2 in detectors_list:
         print(
             f"{idx} | `{argument}` | {help_info} | {classification_txt[impact]} | {'X' if proxy else ''} | {'X' if v2 else ''}"
         )

--- a/slither/utils/arithmetic.py
+++ b/slither/utils/arithmetic.py
@@ -7,11 +7,11 @@ from slither.utils.integer_conversion import convert_string_to_fraction
 if TYPE_CHECKING:
     from slither.core.declarations import Contract, Function
 
+
 # pylint: disable=too-many-branches
 def convert_subdenomination(
     value: str, sub: str
 ) -> int:  # pylint: disable=too-many-return-statements
-
     decimal_value = convert_string_to_fraction(value)
     if sub == "wei":
         return int(decimal_value)

--- a/slither/utils/colors.py
+++ b/slither/utils/colors.py
@@ -41,7 +41,6 @@ def enable_windows_virtual_terminal_sequences() -> bool:
 
         # Loop for each stdout/stderr handle.
         for current_handle in [handle_stdout, handle_stderr]:
-
             # If we get a null handle, or fail any subsequent calls in this scope, we do not colorize any output.
             if current_handle is None or current_handle == HANDLE(-1):
                 return False

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -123,7 +123,7 @@ def output_to_markdown(
         detectors_list, key=lambda element: (element[2], element[3], element[0])
     )
     idx = 1
-    for (argument, help_info, impact, confidence) in detectors_list:
+    for argument, help_info, impact, confidence in detectors_list:
         print(f"{idx} | `{argument}` | {help_info} | {classification_txt[impact]} | {confidence}")
         idx = idx + 1
 
@@ -137,7 +137,7 @@ def output_to_markdown(
     # Sort by impact, confidence, and name
     printers_list = sorted(printers_list, key=lambda element: (element[0]))
     idx = 1
-    for (argument, help_info) in printers_list:
+    for argument, help_info in printers_list:
         print(f"{idx} | `{argument}` | {help_info}")
         idx = idx + 1
 
@@ -193,7 +193,7 @@ def output_results_to_markdown(
         )
 
     counter = 0
-    for (check, results) in checks.items():
+    for check, results in checks.items():
         print(f"## {check}")
         print(f'Impact: {info[check]["impact"]}')
         print(f'Confidence: {info[check]["confidence"]}')
@@ -213,7 +213,6 @@ def output_results_to_markdown(
 
 
 def output_wiki(detector_classes: List[Type[AbstractDetector]], filter_wiki: str) -> None:
-
     # Sort by impact, confidence, and name
     detectors_list = sorted(
         detector_classes,
@@ -267,7 +266,7 @@ def output_detectors(detector_classes: List[Type[AbstractDetector]]) -> None:
         detectors_list, key=lambda element: (element[2], element[3], element[0])
     )
     idx = 1
-    for (argument, help_info, impact, confidence) in detectors_list:
+    for argument, help_info, impact, confidence in detectors_list:
         table.add_row([str(idx), argument, help_info, classification_txt[impact], confidence])
         idx = idx + 1
     print(table)
@@ -347,7 +346,7 @@ def output_printers(printer_classes: List[Type[AbstractPrinter]]) -> None:
     # Sort by impact, confidence, and name
     printers_list = sorted(printers_list, key=lambda element: (element[0]))
     idx = 1
-    for (argument, help_info) in printers_list:
+    for argument, help_info in printers_list:
         table.add_row([str(idx), argument, help_info])
         idx = idx + 1
     print(table)
@@ -365,7 +364,7 @@ def output_printers_json(printer_classes: List[Type[AbstractPrinter]]) -> List[D
     printers_list = sorted(printers_list, key=lambda element: (element[0]))
     idx = 1
     table = []
-    for (argument, help_info) in printers_list:
+    for argument, help_info in printers_list:
         table.append({"index": idx, "check": argument, "title": help_info})
         idx = idx + 1
     return table

--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -23,6 +23,7 @@ from slither.core.expressions.tuple_expression import TupleExpression
 from slither.core.expressions.type_conversion import TypeConversion
 from slither.core.expressions.new_elementary_type import NewElementaryType
 
+
 # pylint: disable=protected-access
 def f_expressions(
     e: Union[AssignmentOperation, BinaryOperation, TupleExpression],
@@ -53,7 +54,6 @@ def f_called(e: CallExpression, x: Identifier) -> None:
 
 class SplitTernaryExpression:
     def __init__(self, expression: Union[AssignmentOperation, ConditionalExpression]) -> None:
-
         if isinstance(expression, ConditionalExpression):
             self.true_expression = copy.copy(expression.then_expression)
             self.false_expression = copy.copy(expression.else_expression)
@@ -148,7 +148,6 @@ class SplitTernaryExpression:
             # TODO: can we get rid of `NoneType` expressions in `TupleExpression`?
             # montyly: this might happen with unnamed tuple (ex: (,,,) = f()), but it needs to be checked
             if next_expr:
-
                 if self.conditional_not_ahead(
                     next_expr, true_expression, false_expression, f_expressions
                 ):

--- a/slither/utils/myprettytable.py
+++ b/slither/utils/myprettytable.py
@@ -22,3 +22,42 @@ class MyPrettyTable:
 
     def __str__(self) -> str:
         return str(self.to_pretty_table())
+
+
+# **Dict to MyPrettyTable utility functions**
+
+
+# Converts a dict to a MyPrettyTable.  Dict keys are the row headers.
+# @param headers str[] of column names
+# @param body dict of row headers with a dict of the values
+# @param totals bool optional add Totals row
+def make_pretty_table(headers: list, body: dict, totals: bool = False) -> MyPrettyTable:
+    table = MyPrettyTable(headers)
+    for row in body:
+        table_row = [row] + [body[row][key] for key in headers[1:]]
+        table.add_row(table_row)
+    if totals:
+        table.add_row(["Total"] + [sum([body[row][key] for row in body]) for key in headers[1:]])
+    return table
+
+
+# takes a dict of dicts and returns a dict of dicts with the keys transposed
+# example:
+# in:
+# {
+#     "dep": {"loc": 0, "sloc": 0, "cloc": 0},
+#     "test": {"loc": 0, "sloc": 0, "cloc": 0},
+#     "src": {"loc": 0, "sloc": 0, "cloc": 0},
+# }
+# out:
+# {
+#     'loc': {'dep': 0, 'test': 0, 'src': 0},
+#     'sloc': {'dep': 0, 'test': 0, 'src': 0},
+#     'cloc': {'dep': 0, 'test': 0, 'src': 0},
+# }
+def transpose(table):
+    any_key = list(table.keys())[0]
+    return {
+        inner_key: {outer_key: table[outer_key][inner_key] for outer_key in table}
+        for inner_key in table[any_key]
+    }

--- a/slither/utils/upgradeability.py
+++ b/slither/utils/upgradeability.py
@@ -327,7 +327,6 @@ def encode_ir_for_compare(ir: Operation) -> str:
 
 # pylint: disable=too-many-branches
 def encode_var_for_compare(var: Variable) -> str:
-
     # variables
     if isinstance(var, Constant):
         return f"constant({ntype(var.type)})"

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -151,7 +151,6 @@ def convert_assignment(
 
 
 class ExpressionToSlithIR(ExpressionVisitor):
-
     # pylint: disable=super-init-not-called
     def __init__(self, expression: Expression, node: "Node") -> None:
         from slither.core.cfg.node import NodeType  # pylint: disable=import-outside-toplevel
@@ -282,7 +281,6 @@ class ExpressionToSlithIR(ExpressionVisitor):
 
     # pylint: disable=too-many-branches,too-many-statements,too-many-locals
     def _post_call_expression(self, expression: CallExpression) -> None:
-
         assert isinstance(expression, CallExpression)
 
         expression_called = expression.called

--- a/tests/e2e/detectors/test_detectors.py
+++ b/tests/e2e/detectors/test_detectors.py
@@ -1645,6 +1645,7 @@ GENERIC_PATH = "/GENERIC_PATH"
 
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 
+
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize("test_item", ALL_TEST_OBJECTS, ids=id_test)
 def test_detector(test_item: Test, snapshot):

--- a/tests/e2e/solc_parsing/test_ast_parsing.py
+++ b/tests/e2e/solc_parsing/test_ast_parsing.py
@@ -596,7 +596,6 @@ def _generate_compile(test_item: Test, skip_existing=False):
 
 
 if __name__ == "__main__":
-
     required_solcs = set()
     for test in ALL_TESTS:
         required_solcs |= set(test.solc_versions)

--- a/tests/tools/read-storage/test_read_storage.py
+++ b/tests/tools/read-storage/test_read_storage.py
@@ -16,6 +16,7 @@ from slither.tools.read_storage import SlitherReadStorage
 
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 
+
 # pylint: disable=too-few-public-methods
 class GanacheInstance:
     def __init__(self, provider: str, eth_address: str, eth_privkey: str):
@@ -54,7 +55,6 @@ def fixture_ganache() -> Generator[GanacheInstance, None, None]:
         ),
         shell=True,
     ) as p:
-
         sleep(3)
         yield GanacheInstance(f"http://127.0.0.1:{port}", eth_address, eth_privkey)
         p.kill()

--- a/tests/unit/slithir/test_ssa_generation.py
+++ b/tests/unit/slithir/test_ssa_generation.py
@@ -117,7 +117,7 @@ def ssa_basic_properties(function: Function) -> None:
         if v and v.name:
             ssa_defs[v.name] += 1
 
-    for (k, count) in lvalue_assignments.items():
+    for k, count in lvalue_assignments.items():
         assert ssa_defs[k] >= count
 
     # Helper 5/6

--- a/tests/unit/slithir/test_ternary_expressions.py
+++ b/tests/unit/slithir/test_ternary_expressions.py
@@ -6,6 +6,8 @@ from slither.core.expressions import AssignmentOperation, TupleExpression
 
 
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+
 # pylint: disable=too-many-nested-blocks
 def test_ternary_conversions(solc_binary_path) -> None:
     """This tests that true and false sons define the same number of variables that the father node declares"""
@@ -17,7 +19,6 @@ def test_ternary_conversions(solc_binary_path) -> None:
             vars_assigned = 0
             for node in function.nodes:
                 if node.type in [NodeType.IF, NodeType.IFLOOP]:
-
                     # Iterate over true and false son
                     for inner_node in node.sons:
                         # Count all variables declared


### PR DESCRIPTION
- This pr adds a new printer: `loc`: 
```bash

INFO:Printers:Lines of Code
+------+-----+-----+------+
|      | src | dep | test |
+------+-----+-----+------+
| loc  |  21 |  0  |  0   |
| sloc |  11 |  0  |  0   |
| cloc |  5  |  0  |  0   |
+------+-----+-----+------+
```

- The Human summary printer was also updated.  Previously, the Human summary only reported total lines of code (LOC) but now it only reports SLOC. Also, it only displays information about Test and Dependency files if those type of files were found.

Before:
```bash
INFO:Printers:
Compiled with solc
Number of lines: 21 (+ 0 in dependencies, + 0 in tests)
```

After
```bash
INFO:Printers:
Compiled with solc
Source lines of code (SLOC) in source files: 11
```

- A couple of utility files were added to easily convert `dict`s to `MyPrettyTable`
