### PR TITLE
Catch AssertionError and log context and raise again while parsing

### DIFF
--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -743,12 +743,12 @@ Please rename it, this name is reserved for Slither's internals"""
                         f"Impossible to generate IR for {contract.name}.{func.name} ({func.source_mapping}):\n {e}"
                     )
                 except AssertionError as e:
-                    func_expressions = "\n".join([f'\t{ex}' for ex in func.expressions])
+                    func_expressions = "\n".join([f"\t{ex}" for ex in func.expressions])
                     logger.error(
                         f"\nFailed to parse {contract.name}.{func.name} ({func.source_mapping}):\n "
-                        f"{func_expressions}")
+                        f"{func_expressions}"
+                    )
                     raise e
-
 
             contract.convert_expression_to_slithir_ssa()
 

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -742,19 +742,46 @@ Please rename it, this name is reserved for Slither's internals"""
                     self._underlying_contract_to_parser[contract].log_incorrect_parsing(
                         f"Impossible to generate IR for {contract.name}.{func.name} ({func.source_mapping}):\n {e}"
                     )
-                except AssertionError as e:
+                except Exception as e:
                     func_expressions = "\n".join([f"\t{ex}" for ex in func.expressions])
                     logger.error(
-                        f"\nFailed to parse {contract.name}.{func.name} ({func.source_mapping}):\n "
+                        f"\nFailed to generate IR for {contract.name}.{func.name}. Please open an issue https://github.com/crytic/slither/issues.\n{contract.name}.{func.name} ({func.source_mapping}):\n "
                         f"{func_expressions}"
                     )
                     raise e
-
-            contract.convert_expression_to_slithir_ssa()
+            try:
+                contract.convert_expression_to_slithir_ssa()
+            except Exception as e:
+                logger.error(
+                    f"\nFailed to convert IR to SSA for {contract.name} contract. Please open an issue https://github.com/crytic/slither/issues.\n "
+                )
+                raise e
 
         for func in self._compilation_unit.functions_top_level:
-            func.generate_slithir_and_analyze()
-            func.generate_slithir_ssa({})
+            try:
+                func.generate_slithir_and_analyze()
+            except AttributeError as e:
+                logger.error(
+                    f"Impossible to generate IR for top level function {func.name} ({func.source_mapping}):\n {e}"
+                )
+            except Exception as e:
+                func_expressions = "\n".join([f"\t{ex}" for ex in func.expressions])
+                logger.error(
+                    f"\nFailed to generate IR for top level function {func.name}. Please open an issue https://github.com/crytic/slither/issues.\n{func.name} ({func.source_mapping}):\n "
+                    f"{func_expressions}"
+                )
+                raise e
+
+            try:
+                func.generate_slithir_ssa({})
+            except Exception as e:
+                func_expressions = "\n".join([f"\t{ex}" for ex in func.expressions])
+                logger.error(
+                    f"\nFailed to convert IR to SSA for top level function {func.name}. Please open an issue https://github.com/crytic/slither/issues.\n{func.name} ({func.source_mapping}):\n "
+                    f"{func_expressions}"
+                )
+                raise e
+
         self._compilation_unit.propagate_function_calls()
         for contract in self._compilation_unit.contracts:
             contract.fix_phi()

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -742,6 +742,13 @@ Please rename it, this name is reserved for Slither's internals"""
                     self._underlying_contract_to_parser[contract].log_incorrect_parsing(
                         f"Impossible to generate IR for {contract.name}.{func.name} ({func.source_mapping}):\n {e}"
                     )
+                except AssertionError as e:
+                    func_expressions = "\n".join([f'\t{ex}' for ex in func.expressions])
+                    logger.error(
+                        f"\nFailed to parse {contract.name}.{func.name} ({func.source_mapping}):\n "
+                        f"{func_expressions}")
+                    raise e
+
 
             contract.convert_expression_to_slithir_ssa()
 


### PR DESCRIPTION
partial fix of #1853
Opened PR per request in #1854

AssertionError with stack trace can occur while parsing contracts that provides no context to what was parsed that threw the error as described in #1853. This change catches this error, logs additional context, and then throws the error again.

An example of the logging from code I am working on:

```
$ slither .
...
Compiler run successful

ERROR:SlitherSolcParsing:
Failed to parse MyERC20Controller.constructor (contracts/MyERC20Controller.sol#19-25):
 	(tokenX,tokenY) = IMyFactoryCallback(msg.sender).tokens()
	(success,data) = msg.sender.delegatecall(abi.encodeWithSelector(IMyFactoryCallback.newTokens.selector,tokenX,tokenY))
	require(bool,string)(success,Factory new tokens failed)
	_tokens = abi.decode(data,(IMyERC20[6]))
Traceback (most recent call last):
  File "~/slither/slither/__main__.py", line 810, in main_impl
    ) = process_all(filename, args, detector_classes, printer_classes)
  File "~/slither/slither/__main__.py", line 101, in process_all
...
```
Logging should make it easier for further issues from users to be easily understood and if necessary included in a bug report.