### PR TITLE
feat: abstractness

### DIFF
--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -171,7 +171,6 @@ class SlitherCore(Context):
         else:
             with open(path, encoding="utf8", newline="") as f:
                 self.source_code[path] = f.read()
-
         self.parse_ignore_comments(path)
 
     @property

--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -1,6 +1,7 @@
 # pylint: disable=unused-import,relative-beyond-top-level
 from .summary.function import FunctionSummary
 from .summary.contract import ContractSummary
+from .summary.abstractness import Abstractness
 from .summary.loc import Loc
 from .inheritance.inheritance import PrinterInheritance
 from .inheritance.inheritance_graph import PrinterInheritanceGraph

--- a/slither/printers/summary/abstractness.py
+++ b/slither/printers/summary/abstractness.py
@@ -1,0 +1,43 @@
+"""
+    Module printing summary of the contract
+"""
+from slither.printers.abstract_printer import AbstractPrinter
+from slither.utils.colors import blue, green
+from typing import Tuple
+
+
+def count_abstracts(contracts) -> Tuple[int, int]:
+    total_contract_count = 0
+    abstract_contract_count = 0
+    for c in contracts:
+        total_contract_count += 1
+        if not c.is_fully_implemented:
+            abstract_contract_count += 1
+    return (abstract_contract_count, total_contract_count)
+
+
+class Abstractness(AbstractPrinter):
+    ARGUMENT = "abstractness"
+    HELP = "Number of abstract contracts / total number of contracts"
+
+    WIKI = (
+        "https://github.com/trailofbits/slither/wiki/Printer-documentation#contract-summary"  # TODO
+    )
+
+    def output(self, _filename):
+        """
+        _filename is not used
+        Args:
+            _filename(string)
+        """
+        (abstract_contract_count, total_contract_count) = count_abstracts(self.contracts)
+        abstractness = 1.0 * abstract_contract_count / total_contract_count
+        abstractness_formatted = "{:.2f}".format(abstractness)  # is there a more modern way to do this?
+
+        txt = f"\nAbstract contracts {blue(abstract_contract_count)}\n"
+        txt += f"Total contracts {green(total_contract_count)}\n"
+        txt += f"Abstractness: {abstractness_formatted}\n"
+        self.info(txt)
+        res = self.generate_output(txt)
+
+        return res


### PR DESCRIPTION
From [wikipedia](https://en.wikipedia.org/wiki/Software_package_metrics):
> Abstractness (A): The ratio of the number of abstract classes (and interfaces) in the analyzed package to the total number of classes in the analyzed package. The range for this metric is 0 to 1, with A=0 indicating a completely concrete package and A=1 indicating a completely abstract package.

This pr adds a new printer for "abstractness" which is based on the `.is_fully_implemented` property of contracts and includes abstract contracts and interfaces.  The logic to determine this will also be used in other complexity measurement printers as well as a future `complexity dashboard printer`.