### PR TITLE
feat: coupling printer

### DIFF
--- a/slither/printers/all_printers.py
+++ b/slither/printers/all_printers.py
@@ -20,3 +20,4 @@ from .summary.evm import PrinterEVM
 from .summary.when_not_paused import PrinterWhenNotPaused
 from .summary.declaration import Declaration
 from .functions.dominator import Dominator
+from .summary.coupling import Coupling

--- a/slither/printers/summary/coupling.py
+++ b/slither/printers/summary/coupling.py
@@ -1,0 +1,57 @@
+"""
+    Coupling metrics printer
+
+    Efferent Coupling (Ce) - Number of contracts that the contract depends on
+    Afferent Coupling (Ca) - Number of contracts that depend on a contract
+
+"""
+from slither.printers.abstract_printer import AbstractPrinter
+from slither.utils.myprettytable import make_pretty_table
+
+
+def compute_coupling(contracts: list) -> dict:
+    """Used to compute the coupling between contracts based on inheritance
+    Args:
+        contracts: list of contracts
+    Returns:
+        dict of contract names with dicts of the coupling metrics:
+        {
+        "contract_name1": {"dependents_Ca": 0, "dependencies_Ce": 3},
+        "contract_name2": {"dependents_Ca": 2, "dependencies_Ce": 1},
+        }
+    """
+
+    ca_table = {
+        inherited.name: {
+            contract.name for contract in contracts if inherited.name in contract.inheritance
+        }
+        for inherited in contracts
+    }
+
+    coupling_dict = {}
+    for contract in contracts:
+        ce = len(contract.inheritance)
+        ca = len(ca_table.get(contract.name, []))
+        coupling_dict[contract.name] = {"dependents_Ca": ca, "dependencies_Ce": ce}
+    return coupling_dict
+
+
+class Coupling(AbstractPrinter):
+    ARGUMENT = "coupling"
+    HELP = "Measures the coupling between contracts based on inheritance"
+
+    WIKI = "https://github.com/trailofbits/slither/wiki/Printer-documentation#coupling"
+
+    def output(self, _filename):
+        coupling_dict = compute_coupling(self.contracts)
+
+        table = make_pretty_table(
+            ["Contract", *list(coupling_dict[self.contracts[0].name].keys())], coupling_dict
+        )
+        txt = "Coupling\nEfferent Coupling (Ce) - Number of contracts that "
+        txt += "a contract depends on\nAfferent Coupling (Ca) - Number of "
+        txt += "contracts that depend on the contract\n" + str(table)
+        self.info(txt)
+        res = self.generate_output(txt)
+        res.add_pretty_table(table, "Code Lines")
+        return res

--- a/slither/utils/myprettytable.py
+++ b/slither/utils/myprettytable.py
@@ -22,3 +22,42 @@ class MyPrettyTable:
 
     def __str__(self) -> str:
         return str(self.to_pretty_table())
+
+
+# **Dict to MyPrettyTable utility functions**
+
+
+# Converts a dict to a MyPrettyTable.  Dict keys are the row headers.
+# @param headers str[] of column names
+# @param body dict of row headers with a dict of the values
+# @param totals bool optional add Totals row
+def make_pretty_table(headers: list, body: dict, totals: bool = False) -> MyPrettyTable:
+    table = MyPrettyTable(headers)
+    for row in body:
+        table_row = [row] + [body[row][key] for key in headers[1:]]
+        table.add_row(table_row)
+    if totals:
+        table.add_row(["Total"] + [sum([body[row][key] for row in body]) for key in headers[1:]])
+    return table
+
+
+# takes a dict of dicts and returns a dict of dicts with the keys transposed
+# example:
+# in:
+# {
+#     "dep": {"loc": 0, "sloc": 0, "cloc": 0},
+#     "test": {"loc": 0, "sloc": 0, "cloc": 0},
+#     "src": {"loc": 0, "sloc": 0, "cloc": 0},
+# }
+# out:
+# {
+#     'loc': {'dep': 0, 'test': 0, 'src': 0},
+#     'sloc': {'dep': 0, 'test': 0, 'src': 0},
+#     'cloc': {'dep': 0, 'test': 0, 'src': 0},
+# }
+def transpose(table):
+    any_key = list(table.keys())[0]
+    return {
+        inner_key: {outer_key: table[outer_key][inner_key] for outer_key in table}
+        for inner_key in table[any_key]
+    }


### PR DESCRIPTION
This pr adds a printer which measures [coupling](https://en.wikipedia.org/wiki/Software_package_metrics) between contracts by summing the number of contracts inherited (Ce) or that are inherited (Ca).

```bash
INFO:Printers:Coupling
Efferent Coupling (Ce) - Number of contracts that a contract depends on
Afferent Coupling (Ca) - Number of contracts that depend on the contract
+---------------------+---------------+-----------------+
|       Contract      | dependents_Ca | dependencies_Ce |
+---------------------+---------------+-----------------+
|    BaseContract1    |       3       |        0        |
|    BaseContract2    |       1       |        0        |
|    ChildContract1   |       1       |        1        |
|    ChildContract2   |       0       |        2        |
| GrandchildContract1 |       0       |        2        |
+---------------------+---------------+-----------------+
INFO:Slither:./examples/printers/inheritances.sol analyzed (5 contracts)
```
The logic to determine this will also be used in several other complexity measurement printers as well as a future complexity dashboard printer.
