### PR TITLE
fix abi decode

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -441,7 +441,7 @@ class SlitherReadStorage:
         if "int" in key_type:  # without this eth_utils encoding fails
             key = int(key)
         key = coerce_type(key_type, key)
-        slot = keccak(encode([key_type, "uint256"], [key, decode("uint256", slot)]))
+        slot = keccak(encode([key_type, "uint256"], [key, decode(["uint256"], slot)[0]]))
 
         if isinstance(target_variable_type.type_to, UserDefinedType) and isinstance(
             target_variable_type.type_to.type, Structure


### PR DESCRIPTION
In the decode function of ethabi 4.0, there is validate_list_like_param, and the type can only be, isinstance(param, (list, tuple)), so an error will be reported when reading the key of the map.

validate_list_like_param fuction
```
def validate_list_like_param(param: Any, param_name: str) -> None:
    if not isinstance(param, (list, tuple)):
        raise TypeError(
            f"The `{param_name}` value type must be one of list or tuple. "
            f"Got {type(param)}"
        )
```
```
slot = keccak(encode([key_type, "uint256"], [key, decode("uint256", slot)]))
# changed to
slot = keccak(encode([key_type, "uint256"], [key, decode(["uint256"], slot)[0]]))
```
