### PR TITLE
remove modulo binop from `can_be_checked_for_overflow`

### DIFF
--- a/slither/slithir/operations/binary.py
+++ b/slither/slithir/operations/binary.py
@@ -94,7 +94,6 @@ class BinaryType(Enum):
         return self in [
             BinaryType.POWER,
             BinaryType.MULTIPLICATION,
-            BinaryType.MODULO,
             BinaryType.ADDITION,
             BinaryType.SUBTRACTION,
             BinaryType.DIVISION,


### PR DESCRIPTION
Closes https://github.com/crytic/slither/issues/1687