### PR TITLE
FIx return variables shadowing compact AST

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -774,6 +774,7 @@ class FunctionSolc(CallerContextExpression):
                             "nodeType": "Identifier",
                             "src": v["src"],
                             "name": v["name"],
+                            "referencedDeclaration": v["id"],
                             "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},
                         }
                         var_identifiers.append(identifier)


### PR DESCRIPTION
Fix #1867 for compact AST.
When applying the same fix to the legacy AST case strange things start happening and i'm not sure it's worth to try to fix it since it's discontinued.
```solidity
contract T {
 function a() public {
    if (2>1){
       (uint aa, uint bb) = b();
       uint tot = aa+bb;
    }
    if (2<1){
     (uint aa, uint bb) = b();
     uint tot2 = aa+bb;
    }
  }
  function b() internal returns(uint,uint) {return(2,3); }
}
```
Before
```
...
		Expression: 2 < 1
		IRs:
			TMP_2(bool) = 2 < 1
			CONDITION TMP_2
		Expression: (aa,bb) = b()
		IRs:
			TUPLE_1(uint256,uint256) = INTERNAL_CALL, T.b()()
			aa(uint256)= UNPACK TUPLE_1 index: 0 
			bb(uint256)= UNPACK TUPLE_1 index: 1 
		Expression: tot2 = aa_scope_0 + bb_scope_1
		IRs:
			TMP_3(uint256) = aa_scope_0 + bb_scope_1
			tot2(uint256) := TMP_3(uint256)

```
After
```
...
		Expression: 2 < 1
		IRs:
			TMP_2(bool) = 2 < 1
			CONDITION TMP_2
		Expression: (aa_scope_0,bb_scope_1) = b()
		IRs:
			TUPLE_1(uint256,uint256) = INTERNAL_CALL, T.b()()
			aa_scope_0(uint256)= UNPACK TUPLE_1 index: 0 
			bb_scope_1(uint256)= UNPACK TUPLE_1 index: 1 
		Expression: tot2 = aa_scope_0 + bb_scope_1
		IRs:
			TMP_3(uint256) = aa_scope_0 + bb_scope_1
			tot2(uint256) := TMP_3(uint256)

```
Slithir for the example in the referenced issue
```
INFO:Printers:Contract Foo
	Function Foo.foo4(uint256) (*)
Contract T
	Function T.a(Foo) (*)
		Expression: (bb_scope_0) = bb.foo4(342)
		IRs:
			TUPLE_0(uint256,uint256,uint256,uint256) = HIGH_LEVEL_CALL, dest:bb(Foo), function:foo4, arguments:['342']  
			bb_scope_0(uint256)= UNPACK TUPLE_0 index: 1 
	Function T.b(Foo) (*)
		Expression: (bb_scope_0,cc) = bb.foo4(342)
		IRs:
			TUPLE_1(uint256,uint256,uint256,uint256) = HIGH_LEVEL_CALL, dest:bb(Foo), function:foo4, arguments:['342']  
			bb_scope_0(uint256)= UNPACK TUPLE_1 index: 1 
			cc(uint256)= UNPACK TUPLE_1 index: 2 

```