### PR TITLE
make transitive dependencies explicit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
         # "crytic-compile>=0.3.1,<0.4.0",
         "crytic-compile@git+https://github.com/crytic/crytic-compile.git@windows-rel-path#egg=crytic-compile",
         "web3>=6.0.0",
+        "eth-abi>=4.0.0",
+        "eth-typing>=3.0.0",
+        "eth-utils>=2.1.0",
     ],
     extras_require={
         "lint": [


### PR DESCRIPTION
Right now, these dependencies are include in web3py and we should explicit declare them in case something changes upstream