### PR TITLE
Fix bytes pop ir

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1363,11 +1363,12 @@ def convert_to_pop(ir: HighLevelCall, node: "Node") -> List[Operation]:
     # TODO the following is equivalent to length.points_to = arr
     # Should it be removed?
     ir_length.lvalue.points_to = arr
-    # Note bytes is an ElementaryType not ArrayType so in that case we use ir.destination.type
+    # Note bytes is an ElementaryType not ArrayType and bytes1 should be returned
+    # since bytes is bytes1[] without padding between the elements
     # while in other cases such as uint256[] (ArrayType) we use ir.destination.type.type
     # in this way we will have the type always set to the corresponding ElementaryType
     element_to_delete.set_type(
-        ir.destination.type
+        ElementaryType("bytes1")
         if isinstance(ir.destination.type, ElementaryType)
         else ir.destination.type.type
     )


### PR DESCRIPTION
Popping from `bytes` should give a `bytes1` type not `bytes` https://github.com/crytic/slither/issues/1904#issuecomment-1552251332