### PR TITLE
fix: make _convert_to_structure_to_list return a type instead of an ElementaryType's `type` field

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1583,11 +1583,9 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     # }
     if isinstance(return_type, (MappingType, ArrayType)):
         return []
-    if isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
-        return [return_type]
 
-    assert False
-
+    assert isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
+    return [return_type]
 
 def convert_type_of_high_and_internal_level_call(
     ir: Operation, contract: Optional[Contract]

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1584,7 +1584,7 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     if isinstance(return_type, (MappingType, ArrayType)):
         return []
 
-    assert isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
+    assert isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias))
     return [return_type]
 
 def convert_type_of_high_and_internal_level_call(

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1587,6 +1587,7 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     assert isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias))
     return [return_type]
 
+
 def convert_type_of_high_and_internal_level_call(
     ir: Operation, contract: Optional[Contract]
 ) -> Optional[Operation]:

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1581,12 +1581,12 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     #         (uint a, uint b) = a.st(0);
     #     }
     # }
-    elif isinstance(return_type, (MappingType, ArrayType)):
+    if isinstance(return_type, (MappingType, ArrayType)):
         return []
-    elif isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
+    if isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
         return [return_type]
-    else:
-        assert False
+
+    assert False
 
 
 def convert_type_of_high_and_internal_level_call(

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1581,9 +1581,12 @@ def _convert_to_structure_to_list(return_type: Type) -> List[Type]:
     #         (uint a, uint b) = a.st(0);
     #     }
     # }
-    if isinstance(return_type, (MappingType, ArrayType)):
+    elif isinstance(return_type, (MappingType, ArrayType)):
         return []
-    return [return_type.type]
+    elif isinstance(return_type, (ElementaryType, UserDefinedType, TypeAlias)):
+        return [return_type]
+    else:
+        assert False
 
 
 def convert_type_of_high_and_internal_level_call(


### PR DESCRIPTION
Fix https://github.com/crytic/slither/issues/1918