### PR TITLE
Optimizations for similar_variables.py

### DIFF
--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -47,9 +47,7 @@ class SimilarVarsDetection(AbstractDetector):
         Returns:
             bool: true if names are similar
         """
-        if len(seq1) != len(seq2):
-            return False
-        val = difflib.SequenceMatcher(a=seq1.lower(), b=seq2.lower()).ratio()
+        val = difflib.SequenceMatcher(a=seq1, b=seq2).ratio()
         ret = val > 0.90
         return ret
 
@@ -69,11 +67,15 @@ class SimilarVarsDetection(AbstractDetector):
 
         ret = []
         for v1 in all_var:
+            _len_v1 = len(v1.name) 
             for v2 in all_var:
-                if v1.name.lower() != v2.name.lower():
-                    if SimilarVarsDetection.similar(v1.name, v2.name):
-                        if (v2, v1) not in ret:
-                            ret.append((v1, v2))
+                if _len_v1 != len(v2.name):
+                    continue
+                _v1_name_lower = v1.name.lower()
+                _v2_name_lower = v2.name.lower()
+                if _v1_name_lower != _v2_name_lower:
+                    if SimilarVarsDetection.similar(_v1_name_lower, _v2_name_lower):
+                        ret.append((v1, v2))
 
         return set(ret)
 

--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -47,7 +47,9 @@ class SimilarVarsDetection(AbstractDetector):
         Returns:
             bool: true if names are similar
         """
-        val = difflib.SequenceMatcher(a=seq1, b=seq2).ratio()
+        if len(seq1) != len(seq2):
+            return False
+        val = difflib.SequenceMatcher(a=seq1.lower(), b=seq2.lower()).ratio()
         ret = val > 0.90
         return ret
 
@@ -68,16 +70,13 @@ class SimilarVarsDetection(AbstractDetector):
         ret = []
         for i in range(len(all_var)):
             v1 = all_var[i]
-            _len_v1 = len(v1.name) 
-            for j in range(i,len(all_var)):
+            _v1_name_lower = v1.name.lower()
+            for j in range(i,len(all_var)): 
                 v2 = all_var[j]
-                if _len_v1 != len(v2.name):
-                    continue
-                _v1_name_lower = v1.name.lower()
-                _v2_name_lower = v2.name.lower()
-                if _v1_name_lower != _v2_name_lower:
-                    if SimilarVarsDetection.similar(_v1_name_lower, _v2_name_lower):
-                        ret.append((v1, v2))
+                if _v1_name_lower != v2.name.lower():
+                    if SimilarVarsDetection.similar(v1.name, v2.name):
+                        if (v2, v1) not in ret:
+                            ret.append((v1, v2))
 
         return set(ret)
 

--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -63,12 +63,14 @@ class SimilarVarsDetection(AbstractDetector):
 
         contract_var = contract.variables
 
-        all_var = set(all_var + contract_var)
+        all_var = list(set(all_var + contract_var))
 
         ret = []
-        for v1 in all_var:
+        for i in range(len(all_var)):
+            v1 = all_var[i]
             _len_v1 = len(v1.name) 
-            for v2 in all_var:
+            for j in range(i,len(all_var)):
+                v2 = all_var[j]
                 if _len_v1 != len(v2.name):
                     continue
                 _v1_name_lower = v1.name.lower()

--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -68,10 +68,11 @@ class SimilarVarsDetection(AbstractDetector):
         all_var = list(set(all_var + contract_var))
 
         ret = []
+        # pylint: disable=consider-using-enumerate
         for i in range(len(all_var)):
             v1 = all_var[i]
             _v1_name_lower = v1.name.lower()
-            for j in range(i,len(all_var)): 
+            for j in range(i, len(all_var)):
                 v2 = all_var[j]
                 if _v1_name_lower != v2.name.lower():
                     if SimilarVarsDetection.similar(v1.name, v2.name):


### PR DESCRIPTION
Fixes #1630

Optimizations to the algorithm for detecting similar variable names in similar_variables.py. 

Runtime for slither/dev on current C4 competiton MAIA codebase:

    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    
    40      0.005    0.000    39.760   0.994   .../slither/detectors/variables/similar_variables.py:76(_detect)

Runtime for optimized version on same codebase:

    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    
    40      0.004    0.000    17.769   0.444   .../slither/detectors/variables/similar_variables.py:83(_detect)

Runtime is reduced by >50% here, and the issues detected are identical.

Changes (in `detect_sim`):

- Inner loop reworked so that it doesn't repeat comparisons. No need to compare the current outer loop's variable to anything with a lower index, as it's already been compared.
- caching v1.name.lower() in the outer loop so it is only repeated once per outer loop rather than once per inner loop