### PR TITLE
ensure that phis are correctly placed for local var

### DIFF
--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -128,7 +128,7 @@ def add_ssa_ir(
     for v in function.parameters:
         if v.name:
             init_definition[v.name] = (v, function.entry_point)
-            function.entry_point.add_ssa_ir(Phi(LocalIRVariable(v), set()))
+            # function.entry_point.add_ssa_ir(Phi(LocalIRVariable(v), set()))
 
     for v in function.returns:
         if v.name:
@@ -146,8 +146,10 @@ def add_ssa_ir(
 
     for node in function.nodes:
         for (variable, nodes) in node.phi_origins_local_variables.values():
+
             if len(nodes) < 2:
                 continue
+
             if not is_used_later(node, variable):
                 continue
             node.add_ssa_ir(Phi(LocalIRVariable(variable), nodes))
@@ -162,6 +164,7 @@ def add_ssa_ir(
     for v in function.parameters:
         if v.name:
             new_var = LocalIRVariable(v)
+
             function.add_parameter_ssa(new_var)
             if new_var.is_storage:
                 fake_variable = LocalIRVariable(v)
@@ -421,6 +424,7 @@ def update_lvalue(
     state_variables_instances: Dict[str, StateIRVariable],
     all_state_variables_instances: Dict[str, StateIRVariable],
 ) -> None:
+
     if isinstance(new_ir, OperationWithLValue):
         lvalue = new_ir.lvalue
         update_through_ref = False
@@ -435,6 +439,7 @@ def update_lvalue(
                 new_var.index = all_local_variables_instances[lvalue.name].index + 1
                 all_local_variables_instances[lvalue.name] = new_var
                 local_variables_instances[lvalue.name] = new_var
+
             else:
                 new_var = StateIRVariable(lvalue)
                 new_var.index = all_state_variables_instances[lvalue.canonical_name].index + 1
@@ -568,10 +573,10 @@ def add_phi_origins(
     if node.dominance_frontier and len(node.dominator_successors) != 1:
         for phi_node in node.dominance_frontier:
             for _, (variable, n) in local_variables_definition.items():
+
                 phi_node.add_phi_origin_local_variable(variable, n)
             for _, (variable, n) in state_variables_definition.items():
                 phi_node.add_phi_origin_state_variable(variable, n)
-
     if not node.dominator_successors:
         return
     for succ in node.dominator_successors:

--- a/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_4_25_arbitrary_send_erc20_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_4_25_arbitrary_send_erc20_sol__0.txt
@@ -2,5 +2,7 @@ C.bad4(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-er
 
 C.bad1(address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#35-37) uses arbitrary from in transferFrom: erc20.transferFrom(notsend,to,am) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#36)
 
+C.int_transferFrom(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#49-51) uses arbitrary from in transferFrom: erc20.transferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#50)
+
 C.bad3(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#57-59) uses arbitrary from in transferFrom: erc20.safeTransferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.4.25/arbitrary_send_erc20.sol#58)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_5_16_arbitrary_send_erc20_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_5_16_arbitrary_send_erc20_sol__0.txt
@@ -2,5 +2,7 @@ C.bad4(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-er
 
 C.bad3(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#57-59) uses arbitrary from in transferFrom: erc20.safeTransferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#58)
 
+C.int_transferFrom(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#49-51) uses arbitrary from in transferFrom: erc20.transferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#50)
+
 C.bad1(address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#35-37) uses arbitrary from in transferFrom: erc20.transferFrom(notsend,to,am) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.5.16/arbitrary_send_erc20.sol#36)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_6_11_arbitrary_send_erc20_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_6_11_arbitrary_send_erc20_sol__0.txt
@@ -1,5 +1,7 @@
 C.bad1(address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#35-37) uses arbitrary from in transferFrom: erc20.transferFrom(notsend,to,am) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#36)
 
+C.int_transferFrom(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#49-51) uses arbitrary from in transferFrom: erc20.transferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#50)
+
 C.bad3(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#57-59) uses arbitrary from in transferFrom: erc20.safeTransferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#58)
 
 C.bad4(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#65-67) uses arbitrary from in transferFrom: SafeERC20.safeTransferFrom(erc20,from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.6.11/arbitrary_send_erc20.sol#66)

--- a/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_7_6_arbitrary_send_erc20_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_7_6_arbitrary_send_erc20_sol__0.txt
@@ -2,5 +2,7 @@ C.bad4(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-er
 
 C.bad3(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#57-59) uses arbitrary from in transferFrom: erc20.safeTransferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#58)
 
+C.int_transferFrom(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#49-51) uses arbitrary from in transferFrom: erc20.transferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#50)
+
 C.bad1(address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#35-37) uses arbitrary from in transferFrom: erc20.transferFrom(notsend,to,am) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.7.6/arbitrary_send_erc20.sol#36)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_8_0_arbitrary_send_erc20_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ArbitrarySendErc20NoPermit_0_8_0_arbitrary_send_erc20_sol__0.txt
@@ -4,3 +4,5 @@ C.bad3(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-er
 
 C.bad4(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.8.0/arbitrary_send_erc20.sol#65-67) uses arbitrary from in transferFrom: SafeERC20.safeTransferFrom(erc20,from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.8.0/arbitrary_send_erc20.sol#66)
 
+C.int_transferFrom(address,address,uint256) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.8.0/arbitrary_send_erc20.sol#49-51) uses arbitrary from in transferFrom: erc20.transferFrom(from,to,amount) (tests/e2e/detectors/test_data/arbitrary-send-erc20/0.8.0/arbitrary_send_erc20.sol#50)
+

--- a/tests/unit/slithir/test_ssa_generation.py
+++ b/tests/unit/slithir/test_ssa_generation.py
@@ -733,7 +733,6 @@ def test_shadow_local(slither_from_source):
         assert all(map(lambda x: x.lvalue.index == 1, get_ssa_of_type(f, Assignment)))
 
 
-@pytest.mark.xfail(strict=True, reason="Fails in current slither version. Fix in #1102.")
 def test_multiple_named_args_returns(slither_from_source):
     """Verifies that named arguments and return values have correct versions
 


### PR DESCRIPTION
closes https://github.com/crytic/slither/issues/1683

An empty phi was created for the parameter which is only used once. Since there was a phi IR, `update_lvalue` was reindexing the the zero indexed variable at the entry point to one. ~I believe this fixes a false negative in the arbitrary-send-erc20 detector and a failing SSA test.~ Nvm, it causes other tests to fail...