### PR TITLE
allow toplevel var to be an lvalue

### DIFF
--- a/slither/slithir/utils/utils.py
+++ b/slither/slithir/utils/utils.py
@@ -52,6 +52,7 @@ def is_valid_lvalue(v: Optional[SourceMapping]) -> bool:
         (
             StateVariable,
             LocalVariable,
+            TopLevelVariable,
             TemporaryVariable,
             ReferenceVariable,
             TupleVariable,


### PR DESCRIPTION
replaces https://github.com/crytic/slither/pull/1968