### PR TITLE
Additional optimizations for similar_variables.py

### DIFF
--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -47,9 +47,7 @@ class SimilarVarsDetection(AbstractDetector):
         Returns:
             bool: true if names are similar
         """
-        if len(seq1) != len(seq2):
-            return False
-        val = difflib.SequenceMatcher(a=seq1.lower(), b=seq2.lower()).ratio()
+        val = difflib.SequenceMatcher(a=seq1, b=seq2).ratio()
         ret = val > 0.90
         return ret
 
@@ -67,19 +65,21 @@ class SimilarVarsDetection(AbstractDetector):
 
         all_var = list(set(all_var + contract_var))
 
-        ret = []
+        ret = set()
         # pylint: disable=consider-using-enumerate
         for i in range(len(all_var)):
             v1 = all_var[i]
             _v1_name_lower = v1.name.lower()
             for j in range(i, len(all_var)):
                 v2 = all_var[j]
-                if _v1_name_lower != v2.name.lower():
-                    if SimilarVarsDetection.similar(v1.name, v2.name):
-                        if (v2, v1) not in ret:
-                            ret.append((v1, v2))
+                if len(v1.name) != len(v2.name):
+                    continue
+                _v2_name_lower = v2.name.lower()
+                if _v1_name_lower != _v2_name_lower:
+                    if SimilarVarsDetection.similar(_v1_name_lower, _v2_name_lower):
+                            ret.add((v1, v2))
 
-        return set(ret)
+        return ret
 
     def _detect(self) -> List[Output]:
         """Detect similar variables name

--- a/slither/detectors/variables/similar_variables.py
+++ b/slither/detectors/variables/similar_variables.py
@@ -77,7 +77,7 @@ class SimilarVarsDetection(AbstractDetector):
                 _v2_name_lower = v2.name.lower()
                 if _v1_name_lower != _v2_name_lower:
                     if SimilarVarsDetection.similar(_v1_name_lower, _v2_name_lower):
-                            ret.add((v1, v2))
+                        ret.add((v1, v2))
 
         return ret
 


### PR DESCRIPTION
Issue #1630 

Adding in the additional optimizations for the similar variable name detector as described in https://github.com/crytic/slither/pull/1945#issuecomment-1575060352 

Changes:

- length check brought out of `similar` into `detect_sim`. If the lengths aren't the same, no need to run `v2.name.lower()`
- `v1.name.lower()` and `v2.name.lower()` are cached in `detect_sim` and given as inputs for `similar` so that .lower() doesn't have to be run an extra 2 times in the `SequenceMatcher` call.

Again running on the C4 contest Maia codebase:

Current slither/dev:
   
    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    
    40      0.004    0.000    17.769   0.444   .../slither/detectors/variables/similar_variables.py:83(_detect)

With new optimizations:

    ncalls  tottime  percall  cumtime  percall filename:lineno(function)

    40      0.004    0.000    14.867   0.372   .../slither/detectors/variables/similar_variables.py:84(_detect) 

Detected issues unchanged, ~16% reduction in runtime.
