### PR TITLE
refactor: introduce lowering context to simplify cfg construction

### DIFF
--- a/slither/solc_parsing/declarations/modifier.py
+++ b/slither/solc_parsing/declarations/modifier.py
@@ -1,7 +1,7 @@
 """
     Event module
 """
-from typing import Dict, TYPE_CHECKING, Union
+from typing import Dict, TYPE_CHECKING
 
 from slither.core.cfg.node import NodeType
 from slither.core.cfg.node import link_nodes

--- a/slither/solc_parsing/declarations/modifier.py
+++ b/slither/solc_parsing/declarations/modifier.py
@@ -5,15 +5,13 @@ from typing import Dict, TYPE_CHECKING, Union
 
 from slither.core.cfg.node import NodeType
 from slither.core.cfg.node import link_nodes
-from slither.core.cfg.scope import Scope
 from slither.core.declarations.modifier import Modifier
 from slither.solc_parsing.cfg.node import NodeSolc
-from slither.solc_parsing.declarations.function import FunctionSolc
+from slither.solc_parsing.declarations.function import FunctionSolc, LoweringContext
 
 if TYPE_CHECKING:
     from slither.solc_parsing.declarations.contract import ContractSolc
     from slither.solc_parsing.slither_compilation_unit_solc import SlitherCompilationUnitSolc
-    from slither.core.declarations import Function
 
 
 class ModifierSolc(FunctionSolc):
@@ -97,11 +95,13 @@ class ModifierSolc(FunctionSolc):
         # self._analyze_calls()
 
     def _parse_statement(
-        self, statement: Dict, node: NodeSolc, scope: Union[Scope, "Function"]
+        self, statement: Dict, node: NodeSolc, lowering_ctx: LoweringContext
     ) -> NodeSolc:
         name = statement[self.get_key()]
         if name == "PlaceholderStatement":
-            placeholder_node = self._new_node(NodeType.PLACEHOLDER, statement["src"], scope)
+            placeholder_node = self._new_node(
+                NodeType.PLACEHOLDER, statement["src"], lowering_ctx.scope
+            )
             link_nodes(node.underlying_node, placeholder_node.underlying_node)
             return placeholder_node
-        return super()._parse_statement(statement, node, scope)
+        return super()._parse_statement(statement, node, lowering_ctx)

--- a/tests/unit/core/test_data/arithmetic_usage/unchecked_scope.sol
+++ b/tests/unit/core/test_data/arithmetic_usage/unchecked_scope.sol
@@ -1,3 +1,6 @@
+contract X {
+
+}
 contract TestScope {
     function scope(uint256 x) public {
         uint checked1 = x - x; 
@@ -13,5 +16,22 @@ contract TestScope {
             }
         }
         uint checked2 = x - x; 
+        try new X() {
+            unchecked {
+                uint unchecked4 = x - x;
+            }
+            uint checked3 = x - x;
+        } catch {
+            unchecked {
+                uint unchecked5 = x - x;
+            }
+            uint checked4 = x - x;
+        }
+        while (true) {
+            unchecked {
+                uint unchecked6 = x - x;
+            }
+            uint checked5 = x - x;
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a `LoweringContext` which stores whether the current scope is checked and the loop destination for break/continue.
Depends on https://github.com/crytic/slither/pull/1951
Replaces https://github.com/crytic/slither/pull/629

This will unblock fixes like https://github.com/crytic/slither/pull/1651