### PR TITLE
allow dead code to not have an immediate dominator

### DIFF
--- a/slither/core/dominators/utils.py
+++ b/slither/core/dominators/utils.py
@@ -95,5 +95,4 @@ def compute_dominance_frontier(nodes: List["Node"]) -> None:
                     runner.dominance_frontier = runner.dominance_frontier.union({node})
                 while runner != node.immediate_dominator:
                     runner.dominance_frontier = runner.dominance_frontier.union({node})
-                    assert runner.immediate_dominator
                     runner = runner.immediate_dominator


### PR DESCRIPTION
The example in the issue highlights that the expression `i++` will cause issues since it is dead code and thus does not have any dominating nodes 

closes https://github.com/crytic/slither/issues/1973