### PR TITLE
fix typo in Contract.get_state_variable_from_canonical_name()

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -861,7 +861,7 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         Returns:
             StateVariable
         """
-        return next((v for v in self.state_variables if v.name == canonical_name), None)
+        return next((v for v in self.state_variables if v.canonical_name == canonical_name), None)
 
     def get_structure_from_name(self, structure_name: str) -> Optional["StructureContract"]:
         """


### PR DESCRIPTION
The function should compare v.canonical_name with the parameter. Currently, it works the same as get_state_variable_from_name()