### PR TITLE
docs(readme): add new docs link

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+# CITATION.cff: Citation File Format for reproducible research software
+
+cff-version: 1.2.0
+title: Slither
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Josselin Feist
+    family-names: Feist
+  - given-names: Gustavo
+    family-names: Grieco
+  - given-names: Alex
+    family-names: Grace
+identifiers:
+  - type: doi
+    value: 10.48550/arXiv.1908.09878
+    description: arXiv.1908.09878
+  - type: url
+    value: 'https://arxiv.org/abs/1908.09878'
+    description: arxiv
+repository-code: 'https://github.com/crytic/slither'
+repository-artifact: 'https://github.com/crytic/slither/releases'
+abstract: 'Slither: A Static Analysis Framework for Smart Contracts'
+keywords:
+  - 'ethereum '
+  - Static Analysis
+  - Smart contracts
+  - EVM
+license: AGPL-3.0-or-later
+commit: 3d4f934d3228f072b7df2c5e7252c64df4601bc8
+version: 0.9.5
+date-released: '2023-06-28'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,18 +1,16 @@
-# CITATION.cff: Citation File Format for reproducible research software
-
 cff-version: 1.2.0
-title: Slither
+title: Slither Analyzer
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
 type: software
 authors:
-  - given-names: Josselin Feist
+  - given-names: Josselin
     family-names: Feist
   - given-names: Gustavo
     family-names: Grieco
   - given-names: Alex
-    family-names: Grace
+    family-names: Groce
 identifiers:
   - type: doi
     value: 10.48550/arXiv.1908.09878
@@ -20,15 +18,47 @@ identifiers:
   - type: url
     value: 'https://arxiv.org/abs/1908.09878'
     description: arxiv
+  - type: doi
+    value: 10.1109/wetseb.2019.00008
 repository-code: 'https://github.com/crytic/slither'
+url: 'https://www.trailofbits.com/'
 repository-artifact: 'https://github.com/crytic/slither/releases'
-abstract: 'Slither: A Static Analysis Framework for Smart Contracts'
+abstract: >-
+  Slither is a static analysis framework designed to provide
+  rich information about Ethereum smart contracts.
+
+  It works by converting Solidity smart contracts into an
+  intermediate representation called SlithIR.
+
+  SlithIR uses Static Single Assignment (SSA) form and a
+  reduced instruction set to ease implementation of analyses
+  while preserving semantic information that would be lost
+  in transforming Solidity to bytecode. 
+
+  Slither allows for the application of commonly used
+  program analysis techniques like dataflow and taint
+  tracking.
+
+
+  Our framework has four main use cases: 
+
+  (1) automated detection of vulnerabilities,
+
+  (2) automated detection of code optimization
+  opportunities,
+
+  (3) improvement of the user's understanding of the
+  contracts, and
+
+  (4) assistance with code review.  
 keywords:
-  - 'ethereum '
+  - Ethereum
   - Static Analysis
   - Smart contracts
   - EVM
-license: AGPL-3.0-or-later
+  - bug detection
+  - Software Engineering
+license: AGPL-3.0-only
 commit: 3d4f934d3228f072b7df2c5e7252c64df4601bc8
 version: 0.9.5
 date-released: '2023-06-28'

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
-# Slither, the Solidity source analyzer
+# [Slither, the Solidity source analyzer](https://crytic.github.io/slither/slither.html)
 
 <img src="https://raw.githubusercontent.com/crytic/slither/master/logo.png" alt="Logo" width="500"/>
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/crytic/slither/ci.yml?branch=master)](https://github.com/crytic/slither/actions?query=workflow%3ACI)
-[![Slack Status](https://empireslacking.herokuapp.com/badge.svg)](https://empireslacking.herokuapp.com)
 [![PyPI version](https://badge.fury.io/py/slither-analyzer.svg)](https://badge.fury.io/py/slither-analyzer)
+[![Slither - Read the Docs](https://img.shields.io/badge/Slither-Read_the_Docs-2ea44f)](https://crytic.github.io/slither/slither.html)
+[![docs](https://github.com/crytic/slither/actions/workflows/docs.yml/badge.svg)](https://github.com/crytic/slither/actions/workflows/docs.yml)
+
 
 Slither is a Solidity static analysis framework written in Python3. It runs a suite of vulnerability detectors, prints visual information about contract details, and provides an API to easily write custom analyses. Slither enables developers to find vulnerabilities, enhance their code comprehension, and quickly prototype custom analyses.
 
-- [Features](#features)
-- [Usage](#usage)
-- [How to Install](#how-to-install)
-- [Detectors](#detectors)
-- [Printers](#printers)
-- [Tools](#tools)
-- [API Documentation](#api-documentation)
-- [Getting Help](#getting-help)
-- [FAQ](#faq)
-- [Publications](#publications)
+  * [Features](#features)
+  * [Usage](#usage)
+  * [How to install](#how-to-install)
+    + [Using Pip](#using-pip)
+    + [Using Git](#using-git)
+    + [Using Docker](#using-docker)
+    + [Integration](#integration)
+  * [Detectors](#detectors)
+  * [Printers](#printers)
+    + [Quick Review Printers](#quick-review-printers)
+    + [In-Depth Review Printers](#in-depth-review-printers)
+  * [Tools](#tools)
+  * [API Documentation](#api-documentation)
+  * [Getting Help](#getting-help)
+  * [FAQ](#faq)
+  * [License](#license)
+  * [Publications](#publications)
+    + [Trail of Bits publication](#trail-of-bits-publication)
+    + [External publications](#external-publications)
+
 
 ## Features
 
@@ -36,7 +48,7 @@ Slither is a Solidity static analysis framework written in Python3. It runs a su
 
 Run Slither on a Hardhat/Foundry/Dapp/Brownie application:
 
-```bash
+```console
 slither .
 ```
 
@@ -44,18 +56,19 @@ This is the preferred option if your project has dependencies as Slither relies 
 
 However, you can run Slither on a single file that does not import dependencies:
 
-```bash
+```console
 slither tests/uninitialized.sol
 ```
 
 ## How to install
 
-Slither requires Python 3.8+.
+> **Note** <br />
+> Slither requires Python 3.8+.
 If you're **not** going to use one of the [supported compilation frameworks](https://github.com/crytic/crytic-compile), you need [solc](https://github.com/ethereum/solidity/), the Solidity compiler; we recommend using [solc-select](https://github.com/crytic/solc-select) to conveniently switch between solc versions.
 
 ### Using Pip
 
-```bash
+```console
 pip3 install slither-analyzer
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
+<img src="https://raw.githubusercontent.com/crytic/slither/master/logo.png" alt="Slither Static Analysis Framework Logo" width="500" />
+
 # [Slither, the Solidity source analyzer](https://crytic.github.io/slither/slither.html)
 
-<img src="https://raw.githubusercontent.com/crytic/slither/master/logo.png" alt="Logo" width="500"/>
-
 [![Build Status](https://img.shields.io/github/actions/workflow/status/crytic/slither/ci.yml?branch=master)](https://github.com/crytic/slither/actions?query=workflow%3ACI)
-[![PyPI version](https://badge.fury.io/py/slither-analyzer.svg)](https://badge.fury.io/py/slither-analyzer)
+![PyPI](https://img.shields.io/pypi/v/slither-analyzer?logo=python&logoColor=white&label=slither-analyzer)
 [![Slither - Read the Docs](https://img.shields.io/badge/Slither-Read_the_Docs-2ea44f)](https://crytic.github.io/slither/slither.html)
-[![docs](https://github.com/crytic/slither/actions/workflows/docs.yml/badge.svg)](https://github.com/crytic/slither/actions/workflows/docs.yml)
+[![Slither - Wiki](https://img.shields.io/badge/Slither-Wiki-2ea44f)](https://github.com/crytic/slither/wiki/SlithIR)
+
+> Join the Empire Hacking Slack  
+> 
+> [![Slack Status](https://slack.empirehacking.nyc/badge.svg)](https://slack.empirehacking.nyc/)
+> > <sub><i>- Discussions and Support </i></sub>
 
 
-Slither is a Solidity static analysis framework written in Python3. It runs a suite of vulnerability detectors, prints visual information about contract details, and provides an API to easily write custom analyses. Slither enables developers to find vulnerabilities, enhance their code comprehension, and quickly prototype custom analyses.
+**Slither** is a Solidity static analysis framework written in Python3. It runs a suite of vulnerability detectors, prints visual information about contract details, and provides an API to easily write custom analyses. Slither enables developers to find vulnerabilities, enhance their code comprehension, and quickly prototype custom analyses.
 
   * [Features](#features)
   * [Usage](#usage)


### PR DESCRIPTION
Fix the status badges and include a link to the documentation page that is now generated

Edit:
Additional changes include a direct link to the wiki
updated slack badge to join
more information in the citation.cff file
slight style changes regarding the markup of the header


