### PR TITLE
fix(convert): do not convert array type to elementary for `InitArray`

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1857,7 +1857,7 @@ def convert_constant_types(irs: List[Operation]) -> None:
                     if isinstance(ir.lvalue.type.type, ElementaryType):
                         if ir.lvalue.type.type.type in ElementaryTypeInt:
                             for r in ir.read:
-                                if r.type.type not in ElementaryTypeInt:
+                                if r.type.type.type not in ElementaryTypeInt:
                                     r.set_type(ElementaryType(ir.lvalue.type.type.type))
                                     was_changed = True
 

--- a/slither/slithir/operations/init_array.py
+++ b/slither/slithir/operations/init_array.py
@@ -44,4 +44,4 @@ class InitArray(OperationWithLValue):
             return f"{elem}({elem.type})"
 
         init_values = convert(self.init_values)
-        return f"{self.lvalue}({self.lvalue.type}) =  {init_values}"
+        return f"{self.lvalue}({self.lvalue.type}) = {init_values}"

--- a/slither/slithir/operations/new_array.py
+++ b/slither/slithir/operations/new_array.py
@@ -33,4 +33,4 @@ class NewArray(Call, OperationWithLValue):
     def __str__(self):
         args = [str(a) for a in self.arguments]
         lvalue = self.lvalue
-        return f"{lvalue}{lvalue.type})  = new {self.array_type}({','.join(args)})"
+        return f"{lvalue}({lvalue.type})  = new {self.array_type}({','.join(args)})"

--- a/tests/unit/slithir/test_ssa_generation.py
+++ b/tests/unit/slithir/test_ssa_generation.py
@@ -11,7 +11,7 @@ from solc_select.solc_select import valid_version as solc_valid_version
 from slither import Slither
 from slither.core.cfg.node import Node, NodeType
 from slither.core.declarations import Function, Contract
-from slither.core.solidity_types import ArrayType
+from slither.core.solidity_types import ArrayType, ElementaryType
 from slither.core.variables.local_variable import LocalVariable
 from slither.core.variables.state_variable import StateVariable
 from slither.slithir.operations import (
@@ -1116,3 +1116,23 @@ def test_issue_1846_ternary_in_ternary(slither_from_source):
         assert node.type == NodeType.IF
         assert node.son_true.type == NodeType.IF
         assert node.son_false.type == NodeType.EXPRESSION
+
+
+def test_issue_2016(slither_from_source):
+    source = """
+    contract Contract {
+        function test() external {
+            int[] memory a = new int[](5);
+        }
+    }
+    """
+    with slither_from_source(source) as slither:
+        c = slither.get_contract_from_name("Contract")[0]
+        f = c.functions[0]
+        operations = f.slithir_operations
+        new_op = operations[0]
+        lvalue = new_op.lvalue
+        lvalue_type = lvalue.type
+        assert isinstance(lvalue_type, ArrayType)
+        assert lvalue_type.type == ElementaryType("int256")
+        assert lvalue_type.is_dynamic


### PR DESCRIPTION
partially addresses #2016 