### PR TITLE
UnaryOperation: -variable and +variable doesn't make variable an lvalue

### DIFF
--- a/slither/core/expressions/unary_operation.py
+++ b/slither/core/expressions/unary_operation.py
@@ -106,8 +106,6 @@ class UnaryOperation(Expression):
             UnaryOperationType.MINUSMINUS_PRE,
             UnaryOperationType.PLUSPLUS_POST,
             UnaryOperationType.MINUSMINUS_POST,
-            UnaryOperationType.PLUS_PRE,
-            UnaryOperationType.MINUS_PRE,
         ]:
             expression.set_lvalue()
 


### PR DESCRIPTION
Small bugfix for UnaryOperation. Until now in code like this:
```solidity
function some_view() view returns (int) {
    return -someParameter;
}
```
Slither believes that `someParameter` is an lvalue. One of the results is that `slither.visitors.expression.write_var` believes that `someParameter` is written to.

I'm happy to add some test if needed.