### PR TITLE
fix: preserve None tuple components in the left and right liftings of ternary expressions

### DIFF
--- a/slither/utils/expression_manipulations.py
+++ b/slither/utils/expression_manipulations.py
@@ -147,7 +147,7 @@ class SplitTernaryExpression:
         for next_expr in expression.expressions:
             # TODO: can we get rid of `NoneType` expressions in `TupleExpression`?
             # montyly: this might happen with unnamed tuple (ex: (,,,) = f()), but it needs to be checked
-            if next_expr:
+            if next_expr is not None:
 
                 if self.conditional_not_ahead(
                     next_expr, true_expression, false_expression, f_expressions
@@ -158,6 +158,9 @@ class SplitTernaryExpression:
                         true_expression.expressions[-1],
                         false_expression.expressions[-1],
                     )
+            else:
+                true_expression.expressions.append(None)
+                false_expression.expressions.append(None)
 
     def convert_index_access(
         self, next_expr: IndexAccess, true_expression: Expression, false_expression: Expression

--- a/tests/unit/slithir/test_data/ternary_expressions.sol
+++ b/tests/unit/slithir/test_data/ternary_expressions.sol
@@ -61,6 +61,7 @@ contract D {
     }
 
     function a(uint n) external {
-        (uint a,) = values(n > 0 ? 1 : 0);
+        uint a;
+        (a,) = values(n > 0 ? 1 : 0);
     }
 }

--- a/tests/unit/slithir/test_data/ternary_expressions.sol
+++ b/tests/unit/slithir/test_data/ternary_expressions.sol
@@ -39,7 +39,7 @@ contract C {
     function g(address one) public {
         (, uint x) = Test(one).testTuple();
     }
-    
+
     uint[] myIntegers;
     function _h(uint c) internal returns(uint) {
         return c;
@@ -49,8 +49,18 @@ contract C {
             myIntegers[cond ? a : b]
         );
     }
-    
+
     function i(bool cond) public {
         bytes memory a = new bytes(cond ? 1 : 2);
+    }
+}
+
+contract D {
+    function values(uint n) internal returns (uint, uint) {
+        return (0, 1);
+    }
+
+    function a(uint n) external {
+        (uint a,) = values(n > 0 ? 1 : 0);
     }
 }

--- a/tests/unit/slithir/test_ternary_expressions.py
+++ b/tests/unit/slithir/test_ternary_expressions.py
@@ -39,6 +39,7 @@ def test_ternary_conversions(solc_binary_path) -> None:
 
             assert vars_declared == vars_assigned
 
+
 def test_ternary_tuple(solc_binary_path) -> None:
     """
     Test that in the ternary liftings of an assignment of the form `(z, ) = ...`,
@@ -54,5 +55,10 @@ def test_ternary_tuple(solc_binary_path) -> None:
 
     if_node = if_nodes[0]
     assert isinstance(if_node.son_true.expression, AssignmentOperation)
-    assert len([ir for ir in if_node.son_true.all_slithir_operations() if isinstance(ir, Unpack)]) == 1
-    assert len([ir for ir in if_node.son_false.all_slithir_operations() if isinstance(ir, Unpack)]) == 1
+    assert (
+        len([ir for ir in if_node.son_true.all_slithir_operations() if isinstance(ir, Unpack)]) == 1
+    )
+    assert (
+        len([ir for ir in if_node.son_false.all_slithir_operations() if isinstance(ir, Unpack)])
+        == 1
+    )

--- a/tests/unit/slithir/test_ternary_expressions.py
+++ b/tests/unit/slithir/test_ternary_expressions.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import pdb
 from slither import Slither
 from slither.core.cfg.node import NodeType
 from slither.slithir.operations.unpack import Unpack

--- a/tests/unit/slithir/test_ternary_expressions.py
+++ b/tests/unit/slithir/test_ternary_expressions.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+import pdb
 from slither import Slither
 from slither.core.cfg.node import NodeType
+from slither.slithir.operations.unpack import Unpack
 from slither.slithir.operations import Assignment
 from slither.core.expressions import AssignmentOperation, TupleExpression
 
@@ -11,28 +13,46 @@ def test_ternary_conversions(solc_binary_path) -> None:
     """This tests that true and false sons define the same number of variables that the father node declares"""
     solc_path = solc_binary_path("0.8.0")
     slither = Slither(Path(TEST_DATA_DIR, "ternary_expressions.sol").as_posix(), solc=solc_path)
-    for contract in slither.contracts:
-        for function in contract.functions:
-            vars_declared = 0
-            vars_assigned = 0
-            for node in function.nodes:
-                if node.type in [NodeType.IF, NodeType.IFLOOP]:
+    contract = next(c for c in slither.contracts if c.name == "C")
+    for function in contract.functions:
+        vars_declared = 0
+        vars_assigned = 0
+        for node in function.nodes:
+            if node.type in [NodeType.IF, NodeType.IFLOOP]:
 
-                    # Iterate over true and false son
-                    for inner_node in node.sons:
-                        # Count all variables declared
-                        expression = inner_node.expression
-                        if isinstance(expression, AssignmentOperation):
-                            var_expr = expression.expression_left
-                            # Only tuples declare more than one var
-                            if isinstance(var_expr, TupleExpression):
-                                vars_declared += len(var_expr.expressions)
-                            else:
-                                vars_declared += 1
+                # Iterate over true and false son
+                for inner_node in node.sons:
+                    # Count all variables declared
+                    expression = inner_node.expression
+                    if isinstance(expression, AssignmentOperation):
+                        var_expr = expression.expression_left
+                        # Only tuples declare more than one var
+                        if isinstance(var_expr, TupleExpression):
+                            vars_declared += len(var_expr.expressions)
+                        else:
+                            vars_declared += 1
 
-                        for ir in inner_node.irs:
-                            # Count all variables defined
-                            if isinstance(ir, Assignment):
-                                vars_assigned += 1
+                    for ir in inner_node.irs:
+                        # Count all variables defined
+                        if isinstance(ir, Assignment):
+                            vars_assigned += 1
 
             assert vars_declared == vars_assigned
+
+def test_ternary_tuple(solc_binary_path) -> None:
+    """
+    Test that in the ternary liftings of an assignment of the form `(z, ) = ...`,
+    we obtain `z` from an unpack operation in both lifitings
+    """
+    solc_path = solc_binary_path("0.8.0")
+    slither = Slither(Path(TEST_DATA_DIR, "ternary_expressions.sol").as_posix(), solc=solc_path)
+    contract = next(c for c in slither.contracts if c.name == "D")
+    fn = next(f for f in contract.functions if f.name == "a")
+
+    if_nodes = [n for n in fn.nodes if n.type == NodeType.IF]
+    assert len(if_nodes) == 1
+
+    if_node = if_nodes[0]
+    assert isinstance(if_node.son_true.expression, AssignmentOperation)
+    assert len([ir for ir in if_node.son_true.all_slithir_operations() if isinstance(ir, Unpack)]) == 1
+    assert len([ir for ir in if_node.son_false.all_slithir_operations() if isinstance(ir, Unpack)]) == 1


### PR DESCRIPTION
This PR fixes [Issue 2025](https://github.com/crytic/slither/issues/2025). 

The problem was that the code for lifting ternary expressions would avoid processing `None` as a subexpression. Instead, we need to include the subexpression `None` in both the true and false liftings.