### PR TITLE
fix: preserve empty tuple components during declaration-to-assignment conversion

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -815,19 +815,26 @@ class FunctionSolc(CallerContextExpression):
                             new_node = self._parse_variable_definition_init_tuple(
                                 new_statement, i, new_node, scope
                             )
+                        else:
+                            variables.append(None)
                         i = i + 1
 
                     var_identifiers = []
                     # craft of the expression doing the assignement
                     for v in variables:
-                        identifier = {
-                            "nodeType": "Identifier",
-                            "src": v["src"],
-                            "name": v["name"],
-                            "referencedDeclaration": v["id"],
-                            "typeDescriptions": {"typeString": v["typeDescriptions"]["typeString"]},
-                        }
-                        var_identifiers.append(identifier)
+                        if v is not None:
+                            identifier = {
+                                "nodeType": "Identifier",
+                                "src": v["src"],
+                                "name": v["name"],
+                                "referencedDeclaration": v["id"],
+                                "typeDescriptions": {
+                                    "typeString": v["typeDescriptions"]["typeString"]
+                                },
+                            }
+                            var_identifiers.append(identifier)
+                        else:
+                            var_identifiers.append(None)
 
                     tuple_expression = {
                         "nodeType": "TupleExpression",

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -197,12 +197,6 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 for idx, _ in enumerate(left):
                     if not left[idx] is None:
                         index = idx
-                        # The following test is probably always true?
-                        if (
-                            isinstance(left[idx], LocalVariableInitFromTuple)
-                            and left[idx].tuple_index is not None
-                        ):
-                            index = left[idx].tuple_index
                         operation = Unpack(left[idx], right, index)
                         operation.set_expression(expression)
                         self._result.append(operation)

--- a/tests/unit/core/test_data/tuple_assign/test_tuple_assign.sol
+++ b/tests/unit/core/test_data/tuple_assign/test_tuple_assign.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.8.13;
+
+contract Other {
+    struct S {
+        uint z;
+        uint b;
+        uint c;
+        uint d;
+    }
+
+    mapping(uint => S) public M;
+}
+
+contract TestEmptyComponent {
+    Other other;
+
+    function test() external {
+        (uint z, , uint c, uint d) = other.M(3);
+    }
+}
+
+contract TestTupleReassign {
+    function threeRet(int z) internal returns(int, int, int) {
+        return (1,2,3);
+    }
+    function twoRet(int z) internal returns(int, int) {
+        return (3,4);
+    }
+
+    function test() external returns(int) {
+        (int a, int b, int c) = threeRet(3);
+        (a, c) = twoRet(b);
+        return b;
+    }
+}

--- a/tests/unit/core/test_tuple_assign.py
+++ b/tests/unit/core/test_tuple_assign.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from slither import Slither
+from slither.slithir.operations.unpack import Unpack
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data" / "tuple_assign"
+
+
+def test_tuple_order(solc_binary_path) -> None:
+    """Test that the correct tuple components are projected when some components are left empty."""
+    solc_path = solc_binary_path("0.8.15")
+    slither = Slither(Path(TEST_DATA_DIR, "test_tuple_assign.sol").as_posix(), solc=solc_path)
+    fn = slither.get_contract_from_name("TestEmptyComponent")[0].get_function_from_canonical_name(
+        "TestEmptyComponent.test()"
+    )
+    unpacks = [ir for ir in fn.slithir_operations if isinstance(ir, Unpack)]
+    assert unpacks[0].index == 0
+    assert unpacks[1].index == 2
+    assert unpacks[2].index == 3
+
+
+def test_tuple_reassign(solc_binary_path) -> None:
+    """Test that tuple component indexes are not reused across assignments"""
+    solc_path = solc_binary_path("0.8.15")
+    slither = Slither(Path(TEST_DATA_DIR, "test_tuple_assign.sol").as_posix(), solc=solc_path)
+    fn = slither.get_contract_from_name("TestTupleReassign")[0].get_function_from_canonical_name(
+        "TestTupleReassign.test()"
+    )
+    unpacks = [ir for ir in fn.slithir_operations if isinstance(ir, Unpack)]
+    assert len(unpacks) == 5
+    assert unpacks[3].index == 0
+    assert unpacks[4].index == 1


### PR DESCRIPTION
This fixes [issue 1913](https://github.com/crytic/slither/issues/1913).

Previously, when performing an assignment whose variables were originally declared in a tuple-based declaration, the projection components were reused:
```
    function test() external returns(int) {
        (int a, int b, int c) = threeRet(3);
        (a, c) = twoRet(b);
        return b;
    }
...
  Expression: (a,c) = twoRet(b)
  IRs:
    TUPLE_1(int256,int256) = INTERNAL_CALL, Test.twoRet(int256)(b)
    a(int256)= UNPACK TUPLE_1 index: 0 
    c(int256)= UNPACK TUPLE_1 index: 2 
```

This happened because of some code in the `_post_assignment_operation` function in `expression_to_slithir.py`:
```
                        # The following test is probably always true?
                        if (
                            isinstance(left[idx], LocalVariableInitFromTuple)
                            and left[idx].tuple_index is not None
                        ):
                            index = left[idx].tuple_index
```

We shouldn't be reusing the variable's original projection component, but there is a reason that code was written; namely, [this code](https://github.com/crytic/slither/blob/master/slither/solc_parsing/declarations/function.py#L755) translates a multi-variable declaration into a multi-variable assignment. 

It also removes padding `None` entries and records each component index in its corresponding variable instead. As we've seen, this approach doesn't work, because not all tuple assignments are generated from variable declarations. To solve this, this PR leaves the `None` components inside of the tuple in order to select the correct projection index for each variable.

