### PR TITLE
ci: add problem matchers for yamllint and pylint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,8 +9,6 @@ defaults:
 on:
   pull_request:
     branches: [master, dev]
-    paths:
-      - "**/*.py"
     
   schedule:
     # run CI every day even if no PRs/merges occur
@@ -42,6 +40,10 @@ jobs:
           mkdir -p .github/linters
           cp pyproject.toml .github/linters
 
+      - name: Register yamllint problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/yamllint.json"
+
       - name: Lint everything else
         uses: super-linter/super-linter/slim@v4.9.2
         if: always()
@@ -55,7 +57,6 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_ISORT: false
-          # Always false
           VALIDATE_JSON: false
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_PYTHON_FLAKE8: false

--- a/.github/workflows/matchers/pylint.json
+++ b/.github/workflows/matchers/pylint.json
@@ -1,0 +1,32 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "pylint-error",
+        "severity": "error",
+        "pattern": [
+          {
+            "regexp": "^(.+):(\\d+):(\\d+):\\s(([EF]\\d{4}):\\s.+)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "message": 4,
+            "code": 5
+          }
+        ]
+      },
+      {
+        "owner": "pylint-warning",
+        "severity": "warning",
+        "pattern": [
+          {
+            "regexp": "^(.+):(\\d+):(\\d+):\\s(([CRW]\\d{4}):\\s.+)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "message": 4,
+            "code": 5
+          }
+        ]
+      }
+    ]
+}

--- a/.github/workflows/matchers/yamllint.json
+++ b/.github/workflows/matchers/yamllint.json
@@ -1,0 +1,22 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "yamllint",
+        "pattern": [
+          {
+            "regexp": "^(.*\\.ya?ml)$",
+            "file": 1
+          },
+          {
+            "regexp": "^\\s{2}(\\d+):(\\d+)\\s+(error|warning)\\s+(.*?)\\s+\\((.*)\\)$",
+            "line": 1,
+            "column": 2,
+            "severity": 3,
+            "message": 4,
+            "code": 5,
+            "loop": true
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,6 +9,8 @@ defaults:
 on:
   pull_request:
     branches: [master, dev]
+    paths:
+      - "**/*.py"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,6 +37,10 @@ jobs:
         run: |
           mkdir -p .github/linters
           cp pyproject.toml .github/linters
+
+      - name: Register pylint problem matcher
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/pylint.json"
 
       - name: Pylint
         uses: super-linter/super-linter/slim@v4.9.2


### PR DESCRIPTION
Add problem matchers for pylint and yamllint. This will show a diagnostic using github checks API like:
![image](https://github.com/crytic/slither/assets/87383155/88ab7ae6-f914-4e27-a323-dd3b35338ea3)

