### PR TITLE
Write `slither.db.json` file on each save_results_to_hide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ crytic-export/
 
 # Auto-generated Github pages docs
 docs/
+
+# slither.db.json 
+slither.db.json

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -466,6 +466,7 @@ class SlitherCore(Context):
 
     def save_results_to_hide(self, results: List[Dict]) -> None:
         self._results_to_hide += results
+        self.write_results_to_hide()
 
     def add_path_to_filter(self, path: str):
         """


### PR DESCRIPTION

Currently in the process of doing a very large code audit using the `triage-mode` and due to being such a large codebase we really need the db file saved on each step to help in the process of cancelling and restarting the slither test tool after code edits and not losing all pasted saved `save_results_to_hide` that are just kept in memory. 

Anyway was a very simple fix and now the db is saved each time `save_results_to_hide` is called. 

Pretty sure this will be helpful for others doing large audits too. 

Thanks