### PR TITLE
Add detailed assert info for echidna

### DIFF
--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -126,15 +126,24 @@ def _extract_constant_functions(slither: SlitherCore) -> Dict[str, List[str]]:
     return ret
 
 
-def _extract_assert(slither: SlitherCore) -> Dict[str, List[str]]:
-    ret: Dict[str, List[str]] = {}
+def _extract_assert(slither: SlitherCore) -> Dict[str, Dict[str, List[Dict]]]:
+    """
+    Return the list of contract -> function name -> List(source mapping of the assert))
+
+    Args:
+        slither:
+
+    Returns:
+
+    """
+    ret: Dict[str, Dict[str, List[Dict]]] = {}
     for contract in slither.contracts:
-        functions_using_assert = []
+        functions_using_assert: Dict[str, List[Dict]] = defaultdict(list)
         for f in contract.functions_entry_points:
-            for v in f.all_solidity_calls():
-                if v == SolidityFunction("assert(bool)"):
-                    functions_using_assert.append(_get_name(f))
-                    break
+            for node in f.all_nodes():
+                if SolidityFunction("assert(bool)") in node.solidity_calls and node.source_mapping:
+                    func_name = _get_name(f)
+                    functions_using_assert[func_name].append(node.source_mapping.to_json())
         if functions_using_assert:
             ret[contract.name] = functions_using_assert
     return ret


### PR DESCRIPTION
Fix https://github.com/crytic/slither/issues/2104

On
```solidity
contract A{

        function f() public{
                revert();
                assert(false);
        }

        function g() public{
                assert(true);
                revert();
                assert(false);
        }

        function h() public{
                if(true) assert(false); else assert(true);
        }
}
```

The printer will now output 
```
            "f()": [
                {
                    "start": 49,
                    "length": 13,
                    "filename_relative": "assert.sol",
                    "filename_absolute": "/private/tmp/assert.sol",
                    "filename_short": "assert.sol",
                    "is_dependency": false,
                    "lines": [
                        5
                    ],
                    "starting_column": 3,
                    "ending_column": 16
                }
            ],
            "g()": [
                {
                    "start": 92,
                    "length": 12,
                    "filename_relative": "assert.sol",
                    "filename_absolute": "/private/tmp/assert.sol",
                    "filename_short": "assert.sol",
                    "is_dependency": false,
                    "lines": [
                        9
                    ],
                    "starting_column": 3,
                    "ending_column": 15
                },
                {
                    "start": 120,
                    "length": 13,
                    "filename_relative": "assert.sol",
                    "filename_absolute": "/private/tmp/assert.sol",
                    "filename_short": "assert.sol",
                    "is_dependency": false,
                    "lines": [
                        11
                    ],
                    "starting_column": 3,
                    "ending_column": 16
                }
            ],
            "h()": [
                {
                    "start": 172,
                    "length": 13,
                    "filename_relative": "assert.sol",
                    "filename_absolute": "/private/tmp/assert.sol",
                    "filename_short": "assert.sol",
                    "is_dependency": false,
                    "lines": [
                        15
                    ],
                    "starting_column": 12,
                    "ending_column": 25
                },
                {
                    "start": 192,
                    "length": 12,
                    "filename_relative": "assert.sol",
                    "filename_absolute": "/private/tmp/assert.sol",
                    "filename_short": "assert.sol",
                    "is_dependency": false,
                    "lines": [
                        15
                    ],
                    "starting_column": 32,
                    "ending_column": 44
                }
            ]
```
Here:
- `start` / `length` are direct offsets in the file
- `lines` / `starting_column`/ `ending_column` provide the equivalent info, but through a lines / column approach