### PR TITLE
Prioritize checking canonical_name for type inference

### DIFF
--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -82,9 +82,9 @@ def _find_from_type_name(  # pylint: disable=too-many-locals,too-many-branches,t
         # all_enums = [c.enums for c in contracts]
         # all_enums = [item for sublist in all_enums for item in sublist]
         # all_enums += contract.slither.enums_top_level
-        var_type = next((e for e in all_enums if e.name == enum_name), None)
+        var_type = next((e for e in all_enums if e.canonical_name == enum_name), None)
         if not var_type:
-            var_type = next((e for e in all_enums if e.canonical_name == enum_name), None)
+            var_type = next((e for e in all_enums if e.name == enum_name), None)
     if not var_type:
         # any contract can refer to another contract's structure
         name_struct = name
@@ -94,9 +94,9 @@ def _find_from_type_name(  # pylint: disable=too-many-locals,too-many-branches,t
         # all_structures = [c.structures for c in contracts]
         # all_structures = [item for sublist in all_structures for item in sublist]
         # all_structures += contract.slither.structures_top_level
-        var_type = next((st for st in all_structures if st.name == name_struct), None)
+        var_type = next((st for st in all_structures if st.canonical_name == name_struct), None)
         if not var_type:
-            var_type = next((st for st in all_structures if st.canonical_name == name_struct), None)
+            var_type = next((st for st in all_structures if st.name == name_struct), None)
         # case where struct xxx.xx[] where not well formed in the AST
         if not var_type:
             depth = 0


### PR DESCRIPTION
Fix #2117.
```
pragma solidity 0.8.19;

interface Interface {
    struct ZZZ {
        int x;
        int y;
    }

    enum QQQ {
      A,
      B
    }
}

struct ZZZ {
    int x;
    int y;
    int z;
}

enum QQQ {
  A,
  B
}

contract A {
    function test(ZZZ memory zzz, QQQ qqq) external {
        zzz.z = 3;
        Interface.QQQ qqq2 = Interface.QQQ.A;
        Interface.ZZZ memory zzz2 = Interface.ZZZ(1,2);
    }
}
```
ir
```
Contract A
	Function A.test(ZZZ,QQQ) (*)
		Expression: zzz.z = 3
		IRs:
			REF_0(int256) -> zzz.z
			REF_0(int256) (->zzz) := 3(int256)
		Expression: qqq2 = Interface.QQQ.A
		IRs:
			REF_1(None) -> Interface.QQQ
			REF_2(None) -> REF_1.A
			qqq2(Interface.QQQ) := REF_2(None)
		Expression: zzz2 = Interface.ZZZ(1,2)
		IRs:
			TMP_0(Interface.ZZZ) = new ZZZ(1,2)
			zzz2(Interface.ZZZ) := TMP_0(Interface.ZZZ)

```