### PR TITLE
Allow function parameter name to be empty when casting to string

### DIFF
--- a/slither/core/variables/variable.py
+++ b/slither/core/variables/variable.py
@@ -179,5 +179,4 @@ class Variable(SourceMapping):
         return f'{name}({",".join(parameters)})'
 
     def __str__(self) -> str:
-        assert self._name
         return self._name

--- a/tests/e2e/compilation/test_data/test_contract_data/test_contract_data.sol
+++ b/tests/e2e/compilation/test_data/test_contract_data/test_contract_data.sol
@@ -1,0 +1,5 @@
+contract TestSlither {
+    function testFunction(uint256 param1, uint256, address param3) public {
+
+    }
+}

--- a/tests/e2e/compilation/test_resolution.py
+++ b/tests/e2e/compilation/test_resolution.py
@@ -43,3 +43,18 @@ def test_cycle(solc_binary_path) -> None:
     solc_path = solc_binary_path("0.8.0")
     slither = Slither(Path(TEST_DATA_DIR, "test_cyclic_import", "a.sol").as_posix(), solc=solc_path)
     _run_all_detectors(slither)
+
+
+def test_contract_function_parameter(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.0")
+    standard_json = SolcStandardJson()
+    standard_json.add_source_file(
+        Path(TEST_DATA_DIR, "test_contract_data", "test_contract_data.sol").as_posix()
+    )
+    compilation = CryticCompile(standard_json, solc=solc_path)
+    slither = Slither(compilation)
+    contract = slither.contracts[0]
+
+    for function in contract.functions:
+        for parameter in function.parameters:
+            str(parameter)

--- a/tests/e2e/compilation/test_resolution.py
+++ b/tests/e2e/compilation/test_resolution.py
@@ -54,7 +54,9 @@ def test_contract_function_parameter(solc_binary_path) -> None:
     compilation = CryticCompile(standard_json, solc=solc_path)
     slither = Slither(compilation)
     contract = slither.contracts[0]
+    function = contract.functions[0]
+    parameters = function.parameters
 
-    for function in contract.functions:
-        for parameter in function.parameters:
-            str(parameter)
+    assert (parameters[0].name == 'param1')
+    assert (parameters[1].name == '')
+    assert (parameters[2].name == 'param3')


### PR DESCRIPTION
Hello!

This is my attempt at addressing #2127  with 1 test added.

Thanks!