### PR TITLE
Update inheritance graph printer to handle multiple contracts with same names 

### DIFF
--- a/slither/printers/abstract_printer.py
+++ b/slither/printers/abstract_printer.py
@@ -20,7 +20,7 @@ class AbstractPrinter(metaclass=abc.ABCMeta):
 
     WIKI = ""
 
-    def __init__(self, slither: "Slither", logger: Logger) -> None:
+    def __init__(self, slither: "Slither", logger: Optional[Logger]) -> None:
         self.slither = slither
         self.contracts = slither.contracts
         self.filename = slither.filename

--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -100,10 +100,11 @@ class PrinterInheritanceGraph(AbstractPrinter):
 
         # Add arrows (number them if there is more than one path so we know order of declaration for inheritance).
         if len(contract.immediate_inheritance) == 1:
-            ret += f"{contract.name} -> {contract.immediate_inheritance[0]};\n"
+            immediate_inheritance = contract.immediate_inheritance[0]
+            ret += f"c{contract.id}_{contract.name} -> c{immediate_inheritance.id}_{immediate_inheritance};\n"
         else:
             for i, immediate_inheritance in enumerate(contract.immediate_inheritance):
-                ret += f'{contract.name} -> {immediate_inheritance} [ label="{i + 1}" ];\n'
+                ret += f'c{contract.id}_{contract.name} -> c{immediate_inheritance.id}_{immediate_inheritance} [ label="{i + 1}" ];\n'
 
         # Functions
         visibilities = ["public", "external"]
@@ -151,7 +152,7 @@ class PrinterInheritanceGraph(AbstractPrinter):
         indirect_shadowing_information = self._get_indirect_shadowing_information(contract)
 
         # Build the node label
-        ret += f'{contract.name}[shape="box"'
+        ret += f'c{contract.id}_{contract.name}[shape="box"'
         ret += 'label=< <TABLE border="0">'
         ret += f'<TR><TD align="center"><B>{contract.name}</B></TD></TR>'
         if public_functions:

--- a/tests/e2e/printers/test_data/test_contract_names/A.sol
+++ b/tests/e2e/printers/test_data/test_contract_names/A.sol
@@ -1,0 +1,4 @@
+contract A {
+    function a_main() public pure {}
+}
+

--- a/tests/e2e/printers/test_data/test_contract_names/B.sol
+++ b/tests/e2e/printers/test_data/test_contract_names/B.sol
@@ -1,0 +1,8 @@
+import "./A.sol";
+
+contract B is A {
+    function b_main() public pure {
+        a_main();
+    }
+}
+

--- a/tests/e2e/printers/test_data/test_contract_names/B2.sol
+++ b/tests/e2e/printers/test_data/test_contract_names/B2.sol
@@ -1,0 +1,7 @@
+import "./A.sol";
+
+contract B is A {
+    function b2_main() public pure {
+        a_main();
+    }
+}

--- a/tests/e2e/printers/test_data/test_contract_names/C.sol
+++ b/tests/e2e/printers/test_data/test_contract_names/C.sol
@@ -1,0 +1,7 @@
+import "./A.sol";
+
+contract C is A {
+    function c_main() public pure {
+        a_main();
+    }
+}

--- a/tests/e2e/printers/test_printers.py
+++ b/tests/e2e/printers/test_printers.py
@@ -15,24 +15,16 @@ TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 def test_inheritance_printer(solc_binary_path) -> None:
     solc_path = solc_binary_path("0.8.0")
     standard_json = SolcStandardJson()
-    standard_json.add_source_file(
-        Path(TEST_DATA_DIR, "test_contract_names", "A.sol").as_posix()
-    )
-    standard_json.add_source_file(
-        Path(TEST_DATA_DIR, "test_contract_names", "B.sol").as_posix()
-    )
-    standard_json.add_source_file(
-        Path(TEST_DATA_DIR, "test_contract_names", "B2.sol").as_posix()
-    )
-    standard_json.add_source_file(
-        Path(TEST_DATA_DIR, "test_contract_names", "C.sol").as_posix()
-    )
+    standard_json.add_source_file(Path(TEST_DATA_DIR, "test_contract_names", "A.sol").as_posix())
+    standard_json.add_source_file(Path(TEST_DATA_DIR, "test_contract_names", "B.sol").as_posix())
+    standard_json.add_source_file(Path(TEST_DATA_DIR, "test_contract_names", "B2.sol").as_posix())
+    standard_json.add_source_file(Path(TEST_DATA_DIR, "test_contract_names", "C.sol").as_posix())
     compilation = CryticCompile(standard_json, solc=solc_path)
     slither = Slither(compilation)
     printer = PrinterInheritanceGraph(slither=slither, logger=None)
 
-    output = printer.output('test_printer.dot')
-    content = output.elements[0]['name']['content']
+    output = printer.output("test_printer.dot")
+    content = output.elements[0]["name"]["content"]
 
     pattern = re.compile(r"(?:c\d+_)?(\w+ -> )(?:c\d+_)(\w+)")
     matches = re.findall(pattern, content)

--- a/tests/e2e/printers/test_printers.py
+++ b/tests/e2e/printers/test_printers.py
@@ -1,0 +1,45 @@
+import re
+from collections import Counter
+from pathlib import Path
+
+from crytic_compile import CryticCompile
+from crytic_compile.platform.solc_standard_json import SolcStandardJson
+
+from slither import Slither
+from slither.printers.inheritance.inheritance_graph import PrinterInheritanceGraph
+
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+
+def test_inheritance_printer(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.0")
+    standard_json = SolcStandardJson()
+    standard_json.add_source_file(
+        Path(TEST_DATA_DIR, "test_contract_names", "A.sol").as_posix()
+    )
+    standard_json.add_source_file(
+        Path(TEST_DATA_DIR, "test_contract_names", "B.sol").as_posix()
+    )
+    standard_json.add_source_file(
+        Path(TEST_DATA_DIR, "test_contract_names", "B2.sol").as_posix()
+    )
+    standard_json.add_source_file(
+        Path(TEST_DATA_DIR, "test_contract_names", "C.sol").as_posix()
+    )
+    compilation = CryticCompile(standard_json, solc=solc_path)
+    slither = Slither(compilation)
+    printer = PrinterInheritanceGraph(slither=slither, logger=None)
+
+    content = ""
+    for contract in slither.contracts:
+        content += printer._summary(contract)
+
+    pattern = re.compile(r"(?:c\d+_)?(\w+ -> )(?:c\d+_)(\w+)")
+    matches = re.findall(pattern, content)
+    relations = ["".join(m) for m in matches]
+
+    counter = Counter(relations)
+
+    assert counter["B -> A"] == 2
+    assert counter["C -> A"] == 1

--- a/tests/e2e/printers/test_printers.py
+++ b/tests/e2e/printers/test_printers.py
@@ -31,9 +31,8 @@ def test_inheritance_printer(solc_binary_path) -> None:
     slither = Slither(compilation)
     printer = PrinterInheritanceGraph(slither=slither, logger=None)
 
-    content = ""
-    for contract in slither.contracts:
-        content += printer._summary(contract)
+    output = printer.output('test_printer.dot')
+    content = output.elements[0]['name']['content']
 
     pattern = re.compile(r"(?:c\d+_)?(\w+ -> )(?:c\d+_)(\w+)")
     matches = re.findall(pattern, content)


### PR DESCRIPTION
Hello!

This is my attempt at addressing #2107 with 1 test added. 

The updated inheritance graph printer generates the following graph for the example provided in the issue:

![contract_inheritance](https://github.com/crytic/slither/assets/38355190/478b171e-7cd3-4693-89e7-3e261fabe11f)

The call graph printer already uses contract id to handle multiple contracts with same names: 

![callgraph](https://github.com/crytic/slither/assets/38355190/e26abab4-444d-4da4-b44c-815a21992743)

Thanks!