### PR TITLE
fix is_reentrant for internal vyper functions

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1500,10 +1500,13 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
         """
         Determine if the function can be re-entered
         """
+        reentrancy_modifier = "nonReentrant"
+
+        if self.function_language == FunctionLanguage.Vyper:
+            reentrancy_modifier = "nonreentrant(lock)"
+
         # TODO: compare with hash of known nonReentrant modifier instead of the name
-        if "nonReentrant" in [m.name for m in self.modifiers] or "nonreentrant(lock)" in [
-            m.name for m in self.modifiers
-        ]:
+        if reentrancy_modifier in [m.name for m in self.modifiers]:
             return False
 
         if self.visibility in ["public", "external"]:
@@ -1515,7 +1518,9 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
         ]
         if not all_entry_points:
             return True
-        return not all(("nonReentrant" in [m.name for m in f.modifiers] for f in all_entry_points))
+        return not all(
+            (reentrancy_modifier in [m.name for m in f.modifiers] for f in all_entry_points)
+        )
 
     # endregion
     ###################################################################################

--- a/tests/unit/core/test_function_declaration.py
+++ b/tests/unit/core/test_function_declaration.py
@@ -324,6 +324,9 @@ def withdraw():
 @external
 @nonreentrant("lock")
 def withdraw_locked():
+    self.withdraw_locked_internal()
+@internal
+def withdraw_locked_internal():
     raw_call(msg.sender, b"", value= self.balances[msg.sender])
 @payable
 @external
@@ -376,9 +379,13 @@ def __default__():
         assert not f.is_empty
 
         f = functions["withdraw_locked()"]
-        assert not f.is_reentrant
+        assert f.is_reentrant is False
         assert f.is_implemented
         assert not f.is_empty
+
+        f = functions["withdraw_locked_internal()"]
+        assert f.is_reentrant is False
+        assert f.visibility == "internal"
 
         var = contract.get_state_variable_from_name("balances")
         assert var


### PR DESCRIPTION
`is_reentrant`  was returning True for internal functions even if all entry points had the nonreentrant decorator, causing FPs on examples like:
```
balances: HashMap[address, uint256]

@external
@nonreentrant("lock")
def withdraw_locked():
    self.withdraw()

@internal
def withdraw():
    raw_call(msg.sender, b"", value= self.balances[msg.sender])
    self.balances[msg.sender] = 0


``` 