### PR TITLE
Raise an error when a missing contract is specified to read-storage

### DIFF
--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -7,6 +7,7 @@ import argparse
 from crytic_compile import cryticparser
 
 from slither import Slither
+from slither.exceptions import SlitherError
 from slither.tools.read_storage.read_storage import SlitherReadStorage, RpcInfo
 
 
@@ -129,6 +130,8 @@ def main() -> None:
 
     if args.contract_name:
         contracts = slither.get_contract_from_name(args.contract_name)
+        if len(contracts) == 0:
+            raise SlitherError(f"Contract {args.contract_name} not found.")
     else:
         contracts = slither.contracts
 


### PR DESCRIPTION
Before:
```bash
$ slither-read-storage 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --contract-name WETH8 # woops! did you mean WETH9?
$ # silently fails
```

After
```bash
$ slither-read-storage 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --contract-name WETH8
Traceback (most recent call last):
  File "/Users/usmannkhan/Development/slither/env/bin/slither-read-storage", line 8, in <module>
    sys.exit(main())
  File "/Users/usmannkhan/Development/slither/slither/tools/read_storage/__main__.py", line 134, in main
    raise SlitherError(f"Contract {args.contract_name} not found.")
slither.exceptions.SlitherError: Contract WETH8 not found.
```