### PR TITLE
slither-function-filter tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "slither-doctor = slither.tools.doctor.__main__:main",
             "slither-documentation = slither.tools.documentation.__main__:main",
             "slither-interface = slither.tools.interface.__main__:main",
+            "slither-function-filter = slither.tools.function_filter.__main__:main",
         ]
     },
 )

--- a/slither/tools/function_filter/__main__.py
+++ b/slither/tools/function_filter/__main__.py
@@ -1,0 +1,109 @@
+import sys
+import logging
+from argparse import ArgumentParser, Namespace
+
+from crytic_compile import cryticparser
+from slither import Slither
+from slither.core.declarations import Function
+from slither.utils.colors import green
+
+logging.basicConfig()
+logging.getLogger("Slither").setLevel(logging.INFO)
+
+
+def parse_args() -> Namespace:
+    """
+    Parse the underlying arguments for the program.
+    :return: Returns the arguments for the program.
+    """
+    parser: ArgumentParser = ArgumentParser(
+        description="FunctionSummarySelection",
+        usage="function_summary_selection.py filename [options]",
+    )
+
+    parser.add_argument(
+        "filename", help="The filename of the contract or truffle directory to analyze."
+    )
+
+    parser.add_argument(
+        "--contract-name", type=str, help="If set, filter functions declared only in that contract."
+    )
+
+    parser.add_argument("--visibility", type=str, help="Visibility of the functions.")
+
+    parser.add_argument(
+        "--modifiers", action="store_true", help="If set, filter functions that have modifiers."
+    )
+
+    parser.add_argument(
+        "--ext-calls",
+        action="store_true",
+        help="If set, filter functions that make external calls.",
+    )
+
+    parser.add_argument(
+        "--int-calls",
+        action="store_true",
+        help="If set, filter functions that make internal calls.",
+    )
+
+    parser.add_argument(
+        "--state-change", action="store_true", help="If set, filter functions that change state."
+    )
+
+    cryticparser.init(parser)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    # ------------------------------
+    # FunctionSummarySelection.py
+    #       Usage: python3 function_summary_selection.py filename [options]
+    #       Example: python3 function_summary_selection.py contract.sol ----
+    # ------------------------------
+    args = parse_args()
+
+    # Perform slither analysis on the given filename
+    # args's empty
+    slither = Slither(args.filename, **vars(args))
+
+    # Access the arguments
+    contract_name = args.contract_name
+    visibility = args.visibility
+    modifiers = args.modifiers
+    ext_calls = args.ext_calls
+    int_calls = args.int_calls
+    state_change = args.state_change
+
+    for contract in slither.contracts:
+        if contract.name == contract_name:
+            # get all contracts for target contract, drop interfaces
+            contracts_inherited = [
+                parent for parent in contract.immediate_inheritance if not parent.is_interface
+            ]
+
+            for function in contract.functions:
+                print("contract.name == contract_name, contract.functions", function.name)
+
+            for function in contracts_inherited:
+                print(
+                    "contract.name == contract_name, function in contracts_inherited", function.name
+                )
+
+        else:
+            for function in contract.functions:
+                print("contract.name != contract_name", function.name)
+
+    # # Extract function summaries based on selected options
+    # function_summaries = summarize_functions(slither, args.options if args.options else range(1, 8))
+
+    # # Output the function summaries
+    # for function_summary in function_summaries:
+    #     print(green(function_summary))
+
+    print("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/slither/tools/function_filter/__main__.py
+++ b/slither/tools/function_filter/__main__.py
@@ -47,36 +47,43 @@ def parse_args() -> Namespace:
         help="If set, filter functions that make internal calls.",
     )
 
-    # parser.add_argument(
-    #     "--state-change", action="store_true", help="If set, filter functions that change state."
-    # )
+    parser.add_argument(
+        "--state-change", action="store_true", help="If set, filter functions that change state."
+    )
 
     cryticparser.init(parser)
 
     return parser.parse_args()
+
 
 def filter_function(function: Function, args) -> bool:
     # Check visibility
     if args.visibility and function.visibility != args.visibility:
         return False
 
-    # Check for modifiers
+    # Check for existence of modifiers
     if args.modifiers:
-        if not function.modifiers():
+        if not function.modifiers:
             return False
 
-    # Check for external calls
+    # Check for existence of external calls
     if args.ext_calls:
-        if not function.high_level_calls():
+        if not function.high_level_calls:
             return False
 
-    # Check for internal calls
+    # Check for existence of internal calls
     if args.int_calls:
-        if not function.internal_calls():
+        if not function.internal_calls:
+            return False
+
+    # Check if function potentially changes state
+    if args.state_change:
+        if not function._view or not function._pure:
             return False
 
     # If none of the conditions have returned False, the function matches all provided criteria
     return True
+
 
 def main() -> None:
     args = parse_args()
@@ -91,35 +98,34 @@ def main() -> None:
 
     for contract in slither.contracts:
         # Scan only target contract's functions (declared and inherited)
-        if contract.name == contract_name:
-            # Find directly inherited contracts
-            contracts_inherited = [
-                parent for parent in contract.immediate_inheritance if not parent.is_interface
-            ]
+        if contract_name:
+            if contract.name == contract_name:
+                # Find directly inherited contracts
+                contracts_inherited = [
+                    parent for parent in contract.immediate_inheritance if not parent.is_interface
+                ]
 
-            # Iterate declared functions
-            for function in contract.functions:
-                if filter_function(function, args):
-                    filter_results.append(function.get_summary())
-
-            # Iterate inherited functions
-            for contracts in contracts_inherited:
-                for function in contracts.functions:
+                # Iterate declared functions
+                for function in contract.functions:
                     if filter_function(function, args):
                         filter_results.append(function.get_summary())
 
-        # Scan everything if no target contract is specified
-        if not contract_name:
+                # Iterate inherited functions
+                for contracts in contracts_inherited:
+                    for function in contracts.functions:
+                        if filter_function(function, args):
+                            filter_results.append(function.get_summary())
+        else:
             for function in contract.functions:
                 if filter_function(function, args):
                     filter_results.append(function.get_summary())
-    
+
     if filter_results:
         for result in filter_results:
             print(result)
     else:
         print("No results found.")
-    
+
 
 if __name__ == "__main__":
     main()

--- a/slither/tools/function_filter/__main__.py
+++ b/slither/tools/function_filter/__main__.py
@@ -5,10 +5,11 @@ from argparse import ArgumentParser, Namespace
 from crytic_compile import cryticparser
 from slither import Slither
 from slither.core.declarations import Function
-from slither.utils.colors import green
+from slither.utils.colors import green, bold, blue
 
 logging.basicConfig()
-logging.getLogger("Slither").setLevel(logging.INFO)
+logger = logging.getLogger("Slither-function-filter")
+logger.setLevel(logging.INFO)
 
 
 def parse_args() -> Namespace:
@@ -115,16 +116,38 @@ def main() -> None:
                     for function in contracts.functions:
                         if filter_function(function, args):
                             filter_results.append(function.get_summary())
+
+        # Scan all contracts in the SourceMapping of filename provided
         else:
             for function in contract.functions:
                 if filter_function(function, args):
                     filter_results.append(function.get_summary())
 
     if filter_results:
+        logger.info(green(f"Found {len(filter_results)} functions matching flags\n"))
         for result in filter_results:
-            print(result)
+            (
+                contract_name,
+                function_sig,
+                visibility,
+                modifiers,
+                vars_read,
+                vars_written,
+                internal_calls,
+                external_calls,
+                cyclomatic_complexity,
+            ) = result
+
+            logger.info(bold(f"Function: {contract_name}.{function_sig}"))
+            logger.info(blue(f"Visibility: {visibility}"))
+            logger.info(blue(f"Modifiers: {modifiers}"))
+            logger.info(blue(f"Variables Read: {vars_read}"))
+            logger.info(blue(f"Variables Written: {vars_written}"))
+            logger.info(blue(f"Internal Calls: {internal_calls}"))
+            logger.info(blue(f"External Calls: {external_calls}"))
+            logger.info(blue(f"Cyclomatic Complexity: {cyclomatic_complexity}\n"))
     else:
-        print("No results found.")
+        logger.info("No results found.")
 
 
 if __name__ == "__main__":

--- a/slither/tools/function_filter/__main__.py
+++ b/slither/tools/function_filter/__main__.py
@@ -77,6 +77,7 @@ def main() -> None:
     state_change = args.state_change
 
     for contract in slither.contracts:
+        
         if contract.name == contract_name:
             # get all contracts for target contract, drop interfaces
             contracts_inherited = [
@@ -90,8 +91,10 @@ def main() -> None:
                 print(
                     "contract.name == contract_name, function in contracts_inherited", function.name
                 )
+            
+            break
 
-        else:
+        if not contract_name:
             for function in contract.functions:
                 print("contract.name != contract_name", function.name)
 


### PR DESCRIPTION
reference: https://github.com/crytic/slither/issues/2233

`slither-function-filter` tool. for the time being it supports basic flag-based filtering (no way to specify details of search, only true/false)

two example inputs:

`slither-function-filter contract.sol --visibility external --modifiers --ext-calls` or

`slither-function-filter contract.sol --read-only` etc.

so, it's possible to:

_"Return all functions that are {visibility}, have/don't have internal OR external calls , have/don't have modifiers, are/aren't mutable (involve a potential state change)"_

all allowed flags:

```
--contract-name (str)
--visibility (str)
--modifiers (bool)
--ext-calls (bool)
--int-calls (bool)
--state-change (bool)
--read-only (bool)
```

every flag is optional, if none is specified, all contract functions will be returned

implementation is focused around output of function.get_summary() but filter_functions() is easy to extend.

output is formatted in logger and with coloring.

![image](https://github.com/crytic/slither/assets/56428630/79479ef9-e9fd-408e-805d-573ab32d35f0)
