### PR TITLE
Substituted the letter `z` with `x` in pre-declaration

### DIFF
--- a/slither/detectors/variables/predeclaration_usage_local.py
+++ b/slither/detectors/variables/predeclaration_usage_local.py
@@ -36,7 +36,7 @@ class PredeclarationUsageLocal(AbstractDetector):
 ```solidity
 contract C {
     function f(uint z) public returns (uint) {
-        uint y = x + 9 + z; // 'z' is used pre-declaration
+        uint y = x + 9 + z; // 'x' is used pre-declaration
         uint x = 7;
 
         if (z % 2 == 0) {


### PR DESCRIPTION
## Description
Replaced the character `z` with `x` in the pre-declaration section of the detector documentation under the `Pre-declaration Usage of Local Variables` segment.

## Issues
fixes: #2245 