### PR TITLE
Fixed data dependencies for `ReferenceVariable`

### DIFF
--- a/examples/scripts/data_dependency.py
+++ b/examples/scripts/data_dependency.py
@@ -126,3 +126,19 @@ print(f"{var_tainted} is tainted: {is_tainted(var_tainted, contract)}")
 assert is_tainted(var_tainted, contract)
 print(f"{var_not_tainted} is tainted: {is_tainted(var_not_tainted, contract)}")
 assert not is_tainted(var_not_tainted, contract)
+
+print("Index contract")
+contracts = slither.get_contract_from_name("Index")
+assert len(contracts) == 1
+contract = contracts[0]
+ref = contract.get_state_variable_from_name("ref")
+assert ref
+mapping_var = contract.get_state_variable_from_name("mapping_var")
+assert mapping_var
+
+print(f"{ref} is dependent of {mapping_var}: {is_dependent(ref, mapping_var, contract)}")
+assert is_dependent(ref, mapping_var, contract)
+print(f"{ref} is dependent of {msgsender}: {is_dependent(ref, msgsender, contract)}")
+assert is_dependent(ref, msgsender, contract)
+print(f"{mapping_var} is dependent of {msgsender}: {is_dependent(mapping_var, msgsender, contract)}")
+assert not is_dependent(mapping_var, msgsender, contract)

--- a/examples/scripts/data_dependency.sol
+++ b/examples/scripts/data_dependency.sol
@@ -115,3 +115,13 @@ contract PropagateThroughReturnValue {
     return (var_state);
   }
 }
+
+contract Index {
+    mapping(address => uint) public mapping_var;
+    uint public ref;
+
+    function set() external {
+        ref = mapping_var[msg.sender];
+    }
+
+}

--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -420,6 +420,8 @@ def add_dependency(lvalue: Variable, function: Function, ir: Operation, is_prote
     read: Union[List[Union[LVALUE, SolidityVariableComposed]], List[SlithIRVariable]]
     if isinstance(ir, Index):
         read = [ir.variable_left]
+        if isinstance(lvalue, ReferenceVariable):
+            read.append(ir.variable_right)
     elif isinstance(ir, InternalCall) and ir.function:
         read = ir.function.return_values_ssa
     else:


### PR DESCRIPTION
In an `Index` operation, `ir.lvalue` depends on `ir.variable_left` and `ir.variable_right`.