### PR TITLE
support python3.12

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -10,9 +10,8 @@ import os
 import pstats
 import sys
 import traceback
+from importlib import metadata
 from typing import Tuple, Optional, List, Dict, Type, Union, Any, Sequence
-
-from pkg_resources import iter_entry_points, require
 
 from crytic_compile import cryticparser, CryticCompile
 from crytic_compile.platform.standard import generate_standard_export
@@ -166,7 +165,14 @@ def get_detectors_and_printers() -> Tuple[
     printers = [p for p in printers_ if inspect.isclass(p) and issubclass(p, AbstractPrinter)]
 
     # Handle plugins!
-    for entry_point in iter_entry_points(group="slither_analyzer.plugin", name=None):
+    if sys.version_info >= (3, 10):
+        entry_points = metadata.entry_points(group="slither_analyzer.plugin")
+    else:
+        from pkg_resources import iter_entry_points  # pylint: disable=import-outside-toplevel
+
+        entry_points = iter_entry_points(group="slither_analyzer.plugin", name=None)
+
+    for entry_point in entry_points:
         make_plugin = entry_point.load()
 
         plugin_detectors, plugin_printers = make_plugin()
@@ -297,7 +303,7 @@ def parse_args(
     parser.add_argument(
         "--version",
         help="displays the current version",
-        version=require("slither-analyzer")[0].version,
+        version=metadata.version("slither-analyzer"),
         action="version",
     )
 

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -4,10 +4,9 @@ import logging
 import os
 import zipfile
 from collections import OrderedDict
+from importlib import metadata
 from typing import Tuple, Optional, Dict, List, Union, Any, TYPE_CHECKING, Type
 from zipfile import ZipFile
-
-from pkg_resources import require
 
 from slither.core.cfg.node import Node
 from slither.core.declarations import (
@@ -161,7 +160,7 @@ def output_to_sarif(
                     "driver": {
                         "name": "Slither",
                         "informationUri": "https://github.com/crytic/slither",
-                        "version": require("slither-analyzer")[0].version,
+                        "version": metadata.version("slither-analyzer"),
                         "rules": [],
                     }
                 },


### PR DESCRIPTION
Python 3.12 has removed its bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved plugin handling and version information retrieval in `slither-analyzer`, ensuring compatibility with Python 3.10.
	- Replaced `pkg_resources` with `importlib.metadata` for handling entry points and version information retrieval.
	- Updated the `output_to_sarif` function to use `metadata` instead of `require`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->