### PR TITLE
Fix broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ Num | Detector | What it Detects | Impact | Confidence
 20 | `controlled-delegatecall` | [Controlled delegatecall destination](https://github.com/crytic/slither/wiki/Detector-Documentation#controlled-delegatecall) | High | Medium
 21 | `delegatecall-loop` | [Payable functions using `delegatecall` inside a loop](https://github.com/crytic/slither/wiki/Detector-Documentation/#payable-functions-using-delegatecall-inside-a-loop) | High | Medium
 22 | `incorrect-exp` | [Incorrect exponentiation](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-exponentiation) | High | Medium
-23 | `incorrect-return` | [If a `return` is incorrectly used in assembly mode.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-assembly-return) | High | Medium
+23 | `incorrect-return` | [If a `return` is incorrectly used in assembly mode.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly) | High | Medium
 24 | `msg-value-loop` | [msg.value inside a loop](https://github.com/crytic/slither/wiki/Detector-Documentation/#msgvalue-inside-a-loop) | High | Medium
 25 | `reentrancy-eth` | [Reentrancy vulnerabilities (theft of ethers)](https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities) | High | Medium
-26 | `return-leave` | [If a `return` is used instead of a `leave`.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-assembly-return) | High | Medium
+26 | `return-leave` | [If a `return` is used instead of a `leave`.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly) | High | Medium
 27 | `storage-array` | [Signed storage integer array compiler bug](https://github.com/crytic/slither/wiki/Detector-Documentation#storage-signed-integer-array) | High | Medium
 28 | `unchecked-transfer` | [Unchecked tokens transfer](https://github.com/crytic/slither/wiki/Detector-Documentation#unchecked-transfer) | High | Medium
 29 | `weak-prng` | [Weak PRNG](https://github.com/crytic/slither/wiki/Detector-Documentation#weak-PRNG) | High | Medium

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Num | Detector | What it Detects | Impact | Confidence
 23 | `incorrect-return` | [If a `return` is incorrectly used in assembly mode.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly) | High | Medium
 24 | `msg-value-loop` | [msg.value inside a loop](https://github.com/crytic/slither/wiki/Detector-Documentation/#msgvalue-inside-a-loop) | High | Medium
 25 | `reentrancy-eth` | [Reentrancy vulnerabilities (theft of ethers)](https://github.com/crytic/slither/wiki/Detector-Documentation#reentrancy-vulnerabilities) | High | Medium
-26 | `return-leave` | [If a `return` is used instead of a `leave`.](https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly) | High | Medium
+26 | `return-leave` | [If a `return` is used instead of a `leave`.](https://github.com/crytic/slither/wiki/Detector-Documentation#return-instead-of-leave-in-assembly) | High | Medium
 27 | `storage-array` | [Signed storage integer array compiler bug](https://github.com/crytic/slither/wiki/Detector-Documentation#storage-signed-integer-array) | High | Medium
 28 | `unchecked-transfer` | [Unchecked tokens transfer](https://github.com/crytic/slither/wiki/Detector-Documentation#unchecked-transfer) | High | Medium
 29 | `weak-prng` | [Weak PRNG](https://github.com/crytic/slither/wiki/Detector-Documentation#weak-PRNG) | High | Medium

--- a/slither/detectors/assembly/incorrect_return.py
+++ b/slither/detectors/assembly/incorrect_return.py
@@ -39,7 +39,7 @@ class IncorrectReturn(AbstractDetector):
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.MEDIUM
 
-    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-assembly-return"
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly"
 
     WIKI_TITLE = "Incorrect return in assembly"
     WIKI_DESCRIPTION = "Detect if `return` in an assembly block halts unexpectedly the execution."

--- a/slither/detectors/assembly/return_instead_of_leave.py
+++ b/slither/detectors/assembly/return_instead_of_leave.py
@@ -20,7 +20,7 @@ class ReturnInsteadOfLeave(AbstractDetector):
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.MEDIUM
 
-    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-assembly-return"
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly"
 
     WIKI_TITLE = "Return instead of leave in assembly"
     WIKI_DESCRIPTION = "Detect if a `return` is used where a `leave` should be used."

--- a/slither/detectors/assembly/return_instead_of_leave.py
+++ b/slither/detectors/assembly/return_instead_of_leave.py
@@ -20,7 +20,7 @@ class ReturnInsteadOfLeave(AbstractDetector):
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.MEDIUM
 
-    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly"
+    WIKI = "https://github.com/crytic/slither/wiki/Detector-Documentation#return-instead-of-leave-in-assembly"
 
     WIKI_TITLE = "Return instead of leave in assembly"
     WIKI_DESCRIPTION = "Detect if a `return` is used where a `leave` should be used."


### PR DESCRIPTION
Fix `incorrect-assembly-return` in URLs to `incorrect-return-in-assembly`
https://github.com/crytic/slither/wiki/Detector-Documentation#incorrect-return-in-assembly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated URLs in the detector descriptions for more accurate guidance on handling incorrect returns in assembly mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->