### PR TITLE
Make triage database path customizable

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -528,10 +528,18 @@ def parse_args(
 
     group_misc.add_argument(
         "--triage-mode",
-        help="Run triage mode (save results in slither.db.json)",
+        help="Run triage mode (save results in triage database)",
         action="store_true",
         dest="triage_mode",
         default=False,
+    )
+
+    group_misc.add_argument(
+        "--triage-database",
+        help="File path to the triage database (default: slither.db.json)",
+        action="store",
+        dest="triage_database",
+        default=defaults_flag_in_config["triage_database"],
     )
 
     group_misc.add_argument(

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -135,7 +135,9 @@ class Slither(
         self._exclude_dependencies = kwargs.get("exclude_dependencies", False)
 
         triage_mode = kwargs.get("triage_mode", False)
+        triage_database = kwargs.get("triage_database", "slither.db.json")
         self._triage_mode = triage_mode
+        self._previous_results_filename = triage_database
 
         printers_to_run = kwargs.get("printers_to_run", "")
         if printers_to_run == "echidna":

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -70,6 +70,7 @@ defaults_flag_in_config = {
     "no_fail": False,
     "sarif_input": "export.sarif",
     "sarif_triage": "export.sarif.sarifexplorer",
+    "triage_database": "slither.db.json",
     **DEFAULTS_FLAG_IN_CONFIG_CRYTIC_COMPILE,
 }
 


### PR DESCRIPTION
This makes the triage database file customizable. By default it will continue being `slither.db.json` but the user can now point to a different file or a file in another directory.