### PR TITLE
slither-mutate: bugfix when two files have the same name

### DIFF
--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import time
+from pathlib import Path
 from typing import Type, List, Any, Optional
 from crytic_compile import cryticparser
 from slither import Slither
@@ -172,13 +173,14 @@ def main() -> (None):  # pylint: disable=too-many-statements,too-many-branches,t
         paths_to_ignore_list = []
 
     # get all the contracts as a list from given codebase
-    sol_file_list: List[str] = get_sol_file_list(args.codebase, paths_to_ignore_list)
+    sol_file_list: List[str] = get_sol_file_list(Path(args.codebase), paths_to_ignore_list)
 
     # folder where backup files and uncaught mutants are saved
     if output_dir is None:
         output_dir = "/mutation_campaign"
-    output_folder = os.getcwd() + output_dir
-    if os.path.exists(output_folder):
+
+    output_folder = Path(output_dir).resolve()
+    if output_folder.is_dir():
         shutil.rmtree(output_folder)
 
     # setting RR mutator as first mutator
@@ -322,6 +324,7 @@ def main() -> (None):  # pylint: disable=too-many-statements,too-many-branches,t
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(e)
+            transfer_and_delete(files_dict)
 
         except KeyboardInterrupt:
             # transfer and delete the backup files if interrupted

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -177,7 +177,7 @@ def main() -> (None):  # pylint: disable=too-many-statements,too-many-branches,t
 
     # folder where backup files and uncaught mutants are saved
     if output_dir is None:
-        output_dir = "/mutation_campaign"
+        output_dir = "./mutation_campaign"
 
     output_folder = Path(output_dir).resolve()
     if output_folder.is_dir():

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+from pathlib import Path
 from typing import Optional, Dict, Tuple, List
 from slither.core.compilation_unit import SlitherCompilationUnit
 from slither.formatters.utils.patches import apply_patch, create_diff
@@ -29,7 +30,7 @@ class AbstractMutator(
         solc_remappings: str | None,
         verbose: bool,
         very_verbose: bool,
-        output_folder: str,
+        output_folder: Path,
         dont_mutate_line: List[int],
         rate: int = 10,
         seed: Optional[int] = None,
@@ -116,9 +117,7 @@ class AbstractMutator(
                         logger.info(f"Impossible to generate patch; empty {patches}")
 
                     # add uncaught mutant patches to a output file
-                    with open(
-                        self.output_folder + "/patches_file.txt", "a", encoding="utf8"
-                    ) as patches_file:
+                    with (self.output_folder / "patches_files.txt").open("a", encoding="utf8") as patches_file:
                         patches_file.write(diff + "\n")
 
                 # count the total number of mutants that we were able to compile

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -117,7 +117,9 @@ class AbstractMutator(
                         logger.info(f"Impossible to generate patch; empty {patches}")
 
                     # add uncaught mutant patches to a output file
-                    with (self.output_folder / "patches_files.txt").open("a", encoding="utf8") as patches_file:
+                    with (self.output_folder / "patches_files.txt").open(
+                        "a", encoding="utf8"
+                    ) as patches_file:
                         patches_file.write(diff + "\n")
 
                 # count the total number of mutants that we were able to compile

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -90,6 +90,7 @@ class AbstractMutator(
             for patch in patches:
                 # test the patch
                 patchWasCaught = test_patch(
+                    self.output_folder,
                     file,
                     patch,
                     self.test_command,

--- a/slither/tools/mutator/utils/file_handling.py
+++ b/slither/tools/mutator/utils/file_handling.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 from typing import Dict, List, Union
 import logging
@@ -37,7 +36,7 @@ def transfer_and_delete(files_dict: Dict[str, HashedPath]) -> None:
             with open(original_path, "w", encoding="utf8") as original_file:
                 original_file.write(content)
 
-            os.remove(hashed_path)
+            Path(hashed_path).unlink()
 
             # delete elements from the global dict
             del backuped_files[original_path]
@@ -85,7 +84,6 @@ def create_mutant_file(output_folder: Path, file: str, rule: str) -> None:
 def reset_file(file: str) -> None:
     """function to reset the file"""
     try:
-        # directory, filename = os.path.split(file)
         # reset the file
         with open(backuped_files[file], "r", encoding="utf8") as duplicated_file:
             duplicate_content = duplicated_file.read()

--- a/slither/tools/mutator/utils/file_handling.py
+++ b/slither/tools/mutator/utils/file_handling.py
@@ -70,7 +70,7 @@ def create_mutant_file(output_folder: Path, file: str, rule: str) -> None:
         global_counter[rule] += 1
 
         # reset the file
-        duplicate_content = Path(backuped_files[file]).read_text("utf&")
+        duplicate_content = Path(backuped_files[file]).read_text("utf8")
 
         with open(file, "w", encoding="utf8") as source_file:
             source_file.write(duplicate_content)

--- a/slither/tools/mutator/utils/file_handling.py
+++ b/slither/tools/mutator/utils/file_handling.py
@@ -110,7 +110,7 @@ def get_sol_file_list(codebase: Path, ignore_paths: Union[List[str], None]) -> L
 
     # if input is folder
     if codebase.is_dir():
-        for file_name in codebase.rglob("*"):
+        for file_name in codebase.rglob("*.sol"):
             if not any(part in ignore_paths for part in file_name.parts):
                 sol_file_list.append(file_name.as_posix())
 


### PR DESCRIPTION
This PR provides several bugfixes on top of #2302:

- If to files were backuped / mutated with the same name (e.g. `path/Token.sol` and `path2/Token.sol`).
- If the mutation directory was not set to  `mutation_campaign`, the mutants were not written in the appropriate directory
- If the `contracts-name` parameter was used, contracts were not properly filtered
- Contracts could be mutated more than once

On the quality side, it also try to replace most of the `os` module usage with `Pathlib` for additional clarity.

