### PR TITLE
Filter name-reused detector to only run on Truffle projects (#2390)

### DIFF
--- a/slither/detectors/slither/name_reused.py
+++ b/slither/detectors/slither/name_reused.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from typing import List
 
+from crytic_compile.platform import Type as PlatformType
+
 from slither.core.compilation_unit import SlitherCompilationUnit
 from slither.core.declarations import Contract
 from slither.detectors.abstract_detector import (
@@ -61,6 +63,8 @@ As a result, the second contract cannot be analyzed.
     def _detect(self) -> List[Output]:
         results = []
         compilation_unit = self.compilation_unit
+        if compilation_unit.core.crytic_compile.platform != PlatformType.TRUFFLE:
+            return []
 
         all_contracts = compilation_unit.contracts
         all_contracts_name = [c.name for c in all_contracts]


### PR DESCRIPTION
Set `name-reused` detector to only run on Truffle projects 

closes #2390