### PR TITLE
Add vyper to dev dependencies to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,23 +57,6 @@ jobs:
             npm install hardhat
             popd || exit
           fi
-      - name: Install Vyper
-        run: |
-          INSTALLDIR="$RUNNER_TEMP/vyper-install"
-          if [[ "$RUNNER_OS" = "Windows" ]]; then
-              URL="https://github.com/vyperlang/vyper/releases/download/v0.3.7/vyper.0.3.7+commit.6020b8bb.windows.exe"
-              FILENAME="vyper.exe"
-          elif [[ "$RUNNER_OS" = "Linux" ]]; then
-              URL="https://github.com/vyperlang/vyper/releases/download/v0.3.7/vyper.0.3.7+commit.6020b8bb.linux"
-              FILENAME="vyper"
-          else
-              echo "Unknown OS"
-              exit 1
-          fi
-          mkdir -p "$INSTALLDIR"
-          curl "$URL" -o "$INSTALLDIR/$FILENAME" -L
-          chmod 755 "$INSTALLDIR/$FILENAME"
-          echo "$INSTALLDIR" >> "$GITHUB_PATH"
       - name: Run ${{ matrix.type }} tests
         env:
           TEST_TYPE: ${{ matrix.type }}

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             "coverage[toml]",
             "filelock",
             "pytest-insta",
+            "vyper",
         ],
         "doc": [
             "pdoc",


### PR DESCRIPTION
When running tests on local computer using `make test`, some fails with the following error:  

```
...
ERROR tests/e2e/vyper_parsing/test_ast_parsing.py - FileNotFoundError: [Errno 2] No such file or directory: 'vyper'
...
```

This PR adds `vyper` to the dev dependencies and remove the GitHub Workflow to install it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated GitHub Actions workflow to enhance test execution efficiency.
- **New Features**
	- Integrated Vyper into the project dependencies for improved functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->