### PR TITLE
Reduce verbosity for InvalidCompilation errors

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -14,7 +14,7 @@ from importlib import metadata
 from typing import Tuple, Optional, List, Dict, Type, Union, Any, Sequence
 
 
-from crytic_compile import cryticparser, CryticCompile
+from crytic_compile import cryticparser, CryticCompile, InvalidCompilation
 from crytic_compile.platform.standard import generate_standard_export
 from crytic_compile.platform.etherscan import SUPPORTED_NETWORK
 from crytic_compile import compile_all, is_supported
@@ -93,7 +93,13 @@ def process_all(
     detector_classes: List[Type[AbstractDetector]],
     printer_classes: List[Type[AbstractPrinter]],
 ) -> Tuple[List[Slither], List[Dict], List[Output], int]:
-    compilations = compile_all(target, **vars(args))
+
+    try:
+        compilations = compile_all(target, **vars(args))
+    except InvalidCompilation:
+        logger.error("Unable to compile all targets.")
+        sys.exit(2)
+
     slither_instances = []
     results_detectors = []
     results_printers = []

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,0 +1,20 @@
+import sys
+import tempfile
+import pytest
+
+from slither.__main__ import main_impl
+
+
+def test_cli_exit_on_invalid_compilation_file(caplog):
+
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write("pragma solidity ^0.10000.0;")
+
+        sys.argv = ["slither", f.name]
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            main_impl([], [])
+
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 2
+
+    assert caplog.record_tuples[0] == ("Slither", 40, "Unable to compile all targets.")


### PR DESCRIPTION
Following #2011

# Problem

When trying to analyze a bogus Solidity file, `slither` output is a bit crowded with multiple stacktraces of exception thrown (as shown in the previous issue).

# Tentative solution

If the compilation fails in Crytic with an `InvalidCompilation` exception, we don't print the backtrace and instead exit with a new error code (`2`).

The new output will be like this:

```shell
➜ slither Test.sol             
'solc --version' running
'solc Test.sol --combined-json abi,ast,bin,bin-runtime,srcmap,srcmap-runtime,userdoc,devdoc,hashes,compact-format --allow-paths .,./slither' running
Compilation warnings/errors on Test.sol:
Test.sol:2:1: Error: Source file requires different compiler version (current compiler is 0.5.1+commit.c8a2cb62.Darwin.appleclang - note that nightly builds are considered to be strictly less than the released version
pragma solidity ^0.9.0;
^---------------------^

ERROR:Slither:Unable to compile all targets.
```

 A new test is added (maybe the location is wrong though) to test this behavior: 

- Checks that error code is appropriate
- Checks that the logger output is correctly set