### PR TITLE
Improve message error for when Crytic throws a KeyError.

### DIFF
--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -1,6 +1,5 @@
 import re
 from abc import ABCMeta
-import logging
 from typing import Dict, Union, List, Tuple, TYPE_CHECKING, Optional, Any
 
 from Crypto.Hash import SHA1
@@ -11,8 +10,6 @@ from slither.exceptions import SlitherException
 if TYPE_CHECKING:
     from slither.core.compilation_unit import SlitherCompilationUnit
 
-
-logger: logging.Logger = logging.getLogger("SourceMapping")
 
 # We split the source mapping into two objects
 # The reasoning is to allow any object to just inherit from SourceMapping
@@ -142,7 +139,7 @@ def _compute_line(
         # See the GitHub issue https://github.com/crytic/slither/issues/2296
         msg = f"""The source code appears to be out of sync with the build artifacts on disk.
         This discrepancy can occur after recent modifications to {filename.short}. To resolve this
-        issue, consider executing the clean command of the build system (e.g., forge clean).
+        issue, consider executing the clean command of the build system (e.g. forge clean).
         """
         # We still re-raise the exception as a SlitherException here
         raise SlitherException(msg) from None

--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -1,14 +1,18 @@
 import re
 from abc import ABCMeta
+import logging
 from typing import Dict, Union, List, Tuple, TYPE_CHECKING, Optional, Any
 
 from Crypto.Hash import SHA1
 from crytic_compile.utils.naming import Filename
 from slither.core.context.context import Context
+from slither.exceptions import SlitherException
 
 if TYPE_CHECKING:
     from slither.core.compilation_unit import SlitherCompilationUnit
 
+
+logger: logging.Logger = logging.getLogger("SourceMapping")
 
 # We split the source mapping into two objects
 # The reasoning is to allow any object to just inherit from SourceMapping
@@ -129,9 +133,20 @@ def _compute_line(
     start_line, starting_column = compilation_unit.core.crytic_compile.get_line_from_offset(
         filename, start
     )
-    end_line, ending_column = compilation_unit.core.crytic_compile.get_line_from_offset(
-        filename, start + length
-    )
+    try:
+        end_line, ending_column = compilation_unit.core.crytic_compile.get_line_from_offset(
+            filename, start + length
+        )
+    except KeyError:
+        # This error may occur when the build is not synchronised with the source code on disk.
+        # See the GitHub issue https://github.com/crytic/slither/issues/2296
+        msg = f"""The source code appears to be out of sync with the build artifacts on disk.
+        This discrepancy can occur after recent modifications to {filename.short}. To resolve this
+        issue, consider executing the clean command of the build system (e.g., forge clean).
+        """
+        # We still re-raise the exception as a SlitherException here
+        raise SlitherException(msg) from None
+
     return list(range(start_line, end_line + 1)), starting_column, ending_column
 
 

--- a/tests/e2e/compilation/test_data/test_change/README.md
+++ b/tests/e2e/compilation/test_data/test_change/README.md
@@ -1,0 +1,3 @@
+# Foundry
+
+To init this test case, run `forge install --no-commit --no-git foundry-rs/forge-std`

--- a/tests/e2e/compilation/test_data/test_change/foundry.toml
+++ b/tests/e2e/compilation/test_data/test_change/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/tests/e2e/compilation/test_data/test_change/src/Counter.sol
+++ b/tests/e2e/compilation/test_data/test_change/src/Counter.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    //START
+    function increment() public {
+        number++;
+    }
+    //END
+}

--- a/tests/e2e/compilation/test_diagnostic.py
+++ b/tests/e2e/compilation/test_diagnostic.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import shutil
+import re
+
+import pytest
+
+from slither import Slither
+from slither.exceptions import SlitherException
+
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+foundry_available = shutil.which("forge") is not None
+project_ready = Path(TEST_DATA_DIR, "test_change/lib/forge-std").exists()
+
+
+@pytest.mark.skipif(
+    not foundry_available or not project_ready, reason="requires Foundry and project setup"
+)
+def test_diagnostic():
+
+    test_file_directory = TEST_DATA_DIR / "test_change"
+
+    sl = Slither(test_file_directory.as_posix())
+    assert len(sl.compilation_units) == 1
+
+    counter_file = test_file_directory / "src" / "Counter.sol"
+    shutil.copy(counter_file, counter_file.with_suffix(".bak"))
+
+    with counter_file.open("r") as file:
+        content = file.read()
+
+    with counter_file.open("w") as file:
+        file.write(re.sub(r"//START.*?//END\n?", "", content, flags=re.DOTALL))
+
+    with pytest.raises(SlitherException):
+        Slither(test_file_directory.as_posix(), ignore_compile=True)
+
+    # Restore the original counter so the test is idempotent
+    Path(counter_file.with_suffix(".bak")).rename(counter_file)


### PR DESCRIPTION
Fixes https://github.com/crytic/slither/issues/2328

The new error message is a bit more explicit than the previous one.

However, I was unsure on what Exception to throw there: I opted for the `SlitherException` but it yields to some clutter in the error log because it prints the backtrace.

## Example output

```shell
➜ slither --ignore-compile tests/e2e/compilation/test_data/test_change/
--ignore-compile used, if something goes wrong, consider removing the ignore compile flag
Traceback (most recent call last):
  File "/Users/dm/Projects/slither/slither/__main__.py", line 859, in main_impl
    ) = process_all(filename, args, detector_classes, printer_classes)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dm/Projects/slither/slither/__main__.py", line 107, in process_all
    ) = process_single(compilation, args, detector_classes, printer_classes)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dm/Projects/slither/slither/__main__.py", line 80, in process_single
    slither = Slither(target, ast_format=ast, **vars(args))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dm/Projects/slither/slither/slither.py", line 156, in __init__
    sol_parser.parse_top_level_items(ast, path)
  File "/Users/dm/Projects/slither/slither/solc_parsing/slither_compilation_unit_solc.py", line 268, in parse_top_level_items
    contract.set_offset(top_level_data["src"], self._compilation_unit)
  File "/Users/dm/Projects/slither/slither/core/source_mapping/source_mapping.py", line 214, in set_offset
    self.source_mapping = _convert_source_mapping(offset, compilation_unit)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dm/Projects/slither/slither/core/source_mapping/source_mapping.py", line 186, in _convert_source_mapping
    (lines, starting_column, ending_column) = _compute_line(compilation_unit, filename, s, l)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dm/Projects/slither/slither/core/source_mapping/source_mapping.py", line 148, in _compute_line
    raise SlitherException(msg) from None
slither.exceptions.SlitherException: The source code appears to be out of sync with the build artifacts on disk.
        This discrepancy can occur after recent modifications to src/Counter.sol. To resolve this
        issue, consider executing the clean command of the build system (e.g., forge clean).
        
ERROR:root:Error:
ERROR:root:The source code appears to be out of sync with the build artifacts on disk.
        This discrepancy can occur after recent modifications to src/Counter.sol. To resolve this
        issue, consider executing the clean command of the build system (e.g., forge clean).
        
ERROR:root:Please report an issue to https://github.com/crytic/slither/issues
```
