### PR TITLE
Rename father/son to predecessor/successor

### DIFF
--- a/examples/scripts/taint_mapping.py
+++ b/examples/scripts/taint_mapping.py
@@ -46,8 +46,8 @@ def visit_node(node, visited):
 
     node.function.compilation_unit.context[KEY] = list(set(taints))
 
-    for son in node.sons:
-        visit_node(son, visited)
+    for successor in node.successors:
+        visit_node(successor, visited)
 
 
 def check_call(func, taints):

--- a/slither/analyses/write/are_variables_written.py
+++ b/slither/analyses/write/are_variables_written.py
@@ -86,18 +86,18 @@ def _visit(
             lvalue = refs_lvalues
 
     ret: List[Variable] = []
-    if not node.sons and node.type not in [NodeType.THROW, NodeType.RETURN]:
+    if not node.successors and node.type not in [NodeType.THROW, NodeType.RETURN]:
         ret += [v for v in variables_to_write if v not in variables_written]
 
-    # Explore sons if
+    # Explore successors if
     # - Before is none: its the first time we explored the node
     # - variables_written is not before: it means that this path has a configuration of set variables
     # that we haven't seen yet
     before = state.nodes[node] if node in state.nodes else None
     if before is None or variables_written not in before:
         state.nodes[node].append(variables_written)
-        for son in node.sons:
-            ret += _visit(son, state, variables_written, variables_to_write)
+        for successor in node.successors:
+            ret += _visit(successor, state, variables_written, variables_to_write)
     return ret
 
 

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -1480,8 +1480,8 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                                 constructor_variable, counter, v, prev_node.scope
                             )
                             v.node_initialization = next_node
-                            prev_node.add_son(next_node)
-                            next_node.add_father(prev_node)
+                            prev_node.add_successor(next_node)
+                            next_node.add_predecessor(prev_node)
                             prev_node = next_node
                             counter += 1
                     break
@@ -1512,8 +1512,8 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
                                 constructor_variable, counter, v, prev_node.scope
                             )
                             v.node_initialization = next_node
-                            prev_node.add_son(next_node)
-                            next_node.add_father(prev_node)
+                            prev_node.add_successor(next_node)
+                            next_node.add_predecessor(prev_node)
                             prev_node = next_node
                             counter += 1
 

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1397,8 +1397,8 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
             f.write("digraph{\n")
             for node in self.nodes:
                 f.write(f'{node.node_id}[label="{str(node)}"];\n')
-                for son in node.sons:
-                    f.write(f"{node.node_id}->{son.node_id};\n")
+                for successor in node.successors:
+                    f.write(f"{node.node_id}->{successor.node_id};\n")
 
             f.write("}\n")
 
@@ -1453,15 +1453,15 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
                 label += "\nIRs:\n" + "\n".join([str(ir) for ir in node.irs])
             content += f'{node.node_id}[label="{label}"];\n'
             if node.type in [NodeType.IF, NodeType.IFLOOP]:
-                true_node = node.son_true
+                true_node = node.successor_true
                 if true_node:
                     content += f'{node.node_id}->{true_node.node_id}[label="True"];\n'
-                false_node = node.son_false
+                false_node = node.successor_false
                 if false_node:
                     content += f'{node.node_id}->{false_node.node_id}[label="False"];\n'
             else:
-                for son in node.sons:
-                    content += f"{node.node_id}->{son.node_id};\n"
+                for successor in node.successors:
+                    content += f"{node.node_id}->{successor.node_id};\n"
 
         content += "}\n"
         return content
@@ -1761,8 +1761,8 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
                         ret[name] = set()
                     ret[name] |= instances
 
-            for son in node.sons:
-                to_explore.append((son, dict(values)))
+            for successor in node.successors:
+                to_explore.append((successor, dict(values)))
 
         return ret
 

--- a/slither/core/dominators/utils.py
+++ b/slither/core/dominators/utils.py
@@ -7,20 +7,20 @@ if TYPE_CHECKING:
 
 
 def intersection_predecessor(node: "Node") -> Set["Node"]:
-    if not node.fathers:
+    if not node.predecessors:
         return set()
 
-    ret = node.fathers[0].dominators
-    for pred in node.fathers[1:]:
+    ret = node.predecessors[0].dominators
+    for pred in node.predecessors[1:]:
         ret = ret.intersection(pred.dominators)
-    if not any(father.is_reachable for father in node.fathers):
+    if not any(predecessor.is_reachable for predecessor in node.predecessors):
         return set()
 
     ret = set()
-    for pred in node.fathers:
+    for pred in node.predecessors:
         ret = ret.union(pred.dominators)
 
-    for pred in node.fathers:
+    for pred in node.predecessors:
         if pred.is_reachable:
             ret = ret.intersection(pred.dominators)
     return ret
@@ -93,11 +93,11 @@ def compute_dominance_frontier(nodes: List["Node"]) -> None:
     Compute dominance frontier
     """
     for node in nodes:
-        if len(node.fathers) >= 2:
-            for father in node.fathers:
-                if not father.is_reachable:
+        if len(node.predecessors) >= 2:
+            for predecessor in node.predecessors:
+                if not predecessor.is_reachable:
                     continue
-                runner = father
+                runner = predecessor
                 # Corner case: if there is a if without else
                 # we need to add update the conditional node
                 if (

--- a/slither/detectors/assembly/incorrect_return.py
+++ b/slither/detectors/assembly/incorrect_return.py
@@ -72,7 +72,7 @@ The function will return 6 bytes starting from offset 5, instead of returning a 
             for f in c.functions_and_modifiers_declared:
 
                 for node in f.nodes:
-                    if node.sons:
+                    if node.successors:
                         for function_called in node.internal_calls:
                             if isinstance(function_called, Function):
                                 found = _assembly_node(function_called)

--- a/slither/detectors/functions/modifier.py
+++ b/slither/detectors/functions/modifier.py
@@ -26,10 +26,10 @@ def _get_false_son(node: Node) -> Node:
     Following this node stays on the outer scope of the function
     """
     if node.type == NodeType.IF:
-        return node.sons[1]
+        return node.successors[1]
 
     if node.type == NodeType.IFLOOP:
-        return next(s for s in node.sons if s.type == NodeType.ENDLOOP)
+        return next(s for s in node.successors if s.type == NodeType.ENDLOOP)
 
     return None
 
@@ -80,8 +80,8 @@ If the condition in `myModif` is false, the execution of `get()` will return 0."
                         break
 
                     # Move down, staying on the outer scope in branches
-                    if len(node.sons) > 0:
-                        node = _get_false_son(node) if node.contains_if() else node.sons[0]
+                    if len(node.successors) > 0:
+                        node = _get_false_son(node) if node.contains_if() else node.successors[0]
                     else:
                         node = None
                 else:

--- a/slither/detectors/functions/out_of_order_retryable.py
+++ b/slither/detectors/functions/out_of_order_retryable.py
@@ -81,23 +81,23 @@ Bob calls `doStuffOnL2` but the first retryable ticket calling `claim_rewards` f
 
         visited = visited + [node]
 
-        fathers_context = []
+        predecessors_context = []
 
-        for father in node.fathers:
-            if self.key in father.context:
-                fathers_context += father.context[self.key]
+        for predecessor in node.predecessors:
+            if self.key in predecessor.context:
+                predecessors_context += predecessor.context[self.key]
 
         # Exclude path that dont bring further information
         if node in self.visited_all_paths:
-            if all(f_c in self.visited_all_paths[node] for f_c in fathers_context):
+            if all(f_c in self.visited_all_paths[node] for f_c in predecessors_context):
                 return
         else:
             self.visited_all_paths[node] = []
 
-        self.visited_all_paths[node] = self.visited_all_paths[node] + fathers_context
+        self.visited_all_paths[node] = self.visited_all_paths[node] + predecessors_context
 
         if self.key not in node.context:
-            node.context[self.key] = fathers_context
+            node.context[self.key] = predecessors_context
 
         # include ops from internal function calls
         internal_ops = []
@@ -123,8 +123,8 @@ Bob calls `doStuffOnL2` but the first retryable ticket calling `claim_rewards` f
             self.results.append(node.context[self.key])
             return
 
-        for son in node.sons:
-            self._detect_multiple_tickets(function, son, visited)
+        for successor in node.successors:
+            self._detect_multiple_tickets(function, successor, visited)
 
     def _detect(self) -> List[Output]:
         results = []

--- a/slither/detectors/operations/cache_array_length.py
+++ b/slither/detectors/operations/cache_array_length.py
@@ -141,9 +141,11 @@ contract C
                 ):
                     return True
 
-        for son in node.sons:
-            if son not in visited:
-                if CacheArrayLength._is_loop_referencing_array_length(son, visited, array, depth):
+        for successor in node.successors:
+            if successor not in visited:
+                if CacheArrayLength._is_loop_referencing_array_length(
+                    successor, visited, array, depth
+                ):
                     return True
         return False
 
@@ -157,7 +159,7 @@ contract C
         """
         for node in nodes:
             if node.type == NodeType.STARTLOOP:
-                if_node = node.sons[0]
+                if_node = node.successors[0]
                 if if_node.type != NodeType.IFLOOP:
                     continue
                 if not isinstance(if_node.expression, BinaryOperation):

--- a/slither/detectors/operations/missing_zero_address_validation.py
+++ b/slither/detectors/operations/missing_zero_address_validation.py
@@ -93,8 +93,8 @@ Bob calls `updateOwner` without specifying the `newOwner`, so Bob loses ownershi
             return True
 
         # Check recursively in all the parent nodes
-        for father in node.fathers:
-            if self._zero_address_validation(var, father, explored):
+        for predecessor in node.predecessors:
+            if self._zero_address_validation(var, predecessor, explored):
                 return True
         return False
 

--- a/slither/detectors/reentrancy/reentrancy.py
+++ b/slither/detectors/reentrancy/reentrancy.py
@@ -110,7 +110,7 @@ class AbstractState:
     def merge_fathers(
         self, node: Node, skip_father: Optional[Node], detector: "Reentrancy"
     ) -> None:
-        for father in node.fathers:
+        for father in node.predecessors:
             if detector.KEY in father.context:
                 self._send_eth = union_dict(
                     self._send_eth,
@@ -249,36 +249,36 @@ class Reentrancy(AbstractDetector):
         if node is None:
             return
 
-        fathers_context = AbstractState()
-        fathers_context.merge_fathers(node, skip_father, self)
+        predecessors_context = AbstractState()
+        predecessors_context.merge_fathers(node, skip_father, self)
 
-        # Exclude path that dont bring further information
+        # Exclude path that don't bring further information
         if node in self.visited_all_paths:
-            if self.visited_all_paths[node].does_not_bring_new_info(fathers_context):
+            if self.visited_all_paths[node].does_not_bring_new_info(predecessors_context):
                 return
         else:
             self.visited_all_paths[node] = AbstractState()
 
-        self.visited_all_paths[node].add(fathers_context)
+        self.visited_all_paths[node].add(predecessors_context)
 
-        node.context[self.KEY] = fathers_context
+        node.context[self.KEY] = predecessors_context
 
-        contains_call = fathers_context.analyze_node(node, self)
-        node.context[self.KEY] = fathers_context
+        contains_call = predecessors_context.analyze_node(node, self)
+        node.context[self.KEY] = predecessors_context
 
-        sons = node.sons
+        successors = node.successors
         if contains_call and node.type in [NodeType.IF, NodeType.IFLOOP]:
             if _filter_if(node):
-                son = sons[0]
-                self._explore(son, skip_father=node)
-                sons = sons[1:]
+                successor = successors[0]
+                self._explore(successor, skip_father=node)
+                successors = successors[1:]
             else:
-                son = sons[1]
-                self._explore(son, skip_father=node)
-                sons = [sons[0]]
+                successor = successors[1]
+                self._explore(successor, skip_father=node)
+                successors = [successors[0]]
 
-        for son in sons:
-            self._explore(son)
+        for successor in successors:
+            self._explore(successor)
 
     def detect_reentrancy(self, contract: Contract) -> None:
         for function in contract.functions_and_modifiers_declared:

--- a/slither/detectors/statements/calls_in_loop.py
+++ b/slither/detectors/statements/calls_in_loop.py
@@ -51,8 +51,8 @@ def call_in_loop(
                 assert ir.function
                 call_in_loop(ir.function.entry_point, in_loop_counter, visited, ret)
 
-    for son in node.sons:
-        call_in_loop(son, in_loop_counter, visited, ret)
+    for successor in node.successors:
+        call_in_loop(successor, in_loop_counter, visited, ret)
 
 
 class MultipleCallsInLoop(AbstractDetector):

--- a/slither/detectors/statements/costly_operations_in_loop.py
+++ b/slither/detectors/statements/costly_operations_in_loop.py
@@ -46,8 +46,8 @@ def costly_operations_in_loop(
             if isinstance(ir, (InternalCall)) and ir.function:
                 costly_operations_in_loop(ir.function.entry_point, in_loop_counter, visited, ret)
 
-    for son in node.sons:
-        costly_operations_in_loop(son, in_loop_counter, visited, ret)
+    for successor in node.successors:
+        costly_operations_in_loop(successor, in_loop_counter, visited, ret)
 
 
 class CostlyOperationsInLoop(AbstractDetector):

--- a/slither/detectors/statements/delegatecall_in_loop.py
+++ b/slither/detectors/statements/delegatecall_in_loop.py
@@ -45,8 +45,8 @@ def delegatecall_in_loop(
         if isinstance(ir, (InternalCall)) and ir.function:
             delegatecall_in_loop(ir.function.entry_point, in_loop_counter, visited, results)
 
-    for son in node.sons:
-        delegatecall_in_loop(son, in_loop_counter, visited, results)
+    for successor in node.successors:
+        delegatecall_in_loop(successor, in_loop_counter, visited, results)
 
 
 class DelegatecallInLoop(AbstractDetector):

--- a/slither/detectors/statements/divide_before_multiply.py
+++ b/slither/detectors/statements/divide_before_multiply.py
@@ -113,8 +113,8 @@ def _explore(
             if not (is_assert(node) and equality_found):
                 f_results.append(node_results)
 
-        for son in node.sons:
-            to_explore.append(son)
+        for successor in node.successors:
+            to_explore.append(successor)
 
 
 def detect_divide_before_multiply(

--- a/slither/detectors/statements/msg_value_in_loop.py
+++ b/slither/detectors/statements/msg_value_in_loop.py
@@ -59,8 +59,8 @@ def msg_value_in_loop(
         if isinstance(ir, (InternalCall)):
             msg_value_in_loop(ir.function.entry_point, in_loop_counter, visited, results)
 
-    for son in node.sons:
-        msg_value_in_loop(son, in_loop_counter, visited, results)
+    for successor in node.successors:
+        msg_value_in_loop(successor, in_loop_counter, visited, results)
 
 
 class MsgValueInLoop(AbstractDetector):

--- a/slither/detectors/statements/write_after_write.py
+++ b/slither/detectors/statements/write_after_write.py
@@ -94,10 +94,10 @@ def _detect_write_after_write(
         for ir in node.irs:
             _handle_ir(ir, written, ret)
 
-    if len(node.sons) > 1:
+    if len(node.successors) > 1:
         written = {}
-    for son in node.sons:
-        _detect_write_after_write(son, explored, dict(written), ret)
+    for successor in node.successors:
+        _detect_write_after_write(successor, explored, dict(written), ret)
 
 
 class WriteAfterWrite(AbstractDetector):

--- a/slither/detectors/variables/predeclaration_usage_local.py
+++ b/slither/detectors/variables/predeclaration_usage_local.py
@@ -103,8 +103,8 @@ Additionally, the for-loop uses the variable `max`, which is declared in a previ
                 if result not in results:
                     results.append(result)
 
-        for son in node.sons:
-            self.detect_predeclared_local_usage(son, results, already_declared, visited)
+        for successor in node.successors:
+            self.detect_predeclared_local_usage(successor, results, already_declared, visited)
 
     def detect_predeclared_in_contract(
         self, contract: Contract

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -227,7 +227,7 @@ def generate_ssa_irs(
         return
 
     if node.type in [NodeType.ENDIF, NodeType.ENDLOOP] and any(
-        not father in visited for father in node.fathers
+        not predecessor in visited for predecessor in node.predecessors
     ):
         return
 
@@ -398,9 +398,9 @@ def is_used_later(
                 for v in node.state_variables_written
             ):
                 return False
-        for son in node.sons:
-            if not son in explored:
-                to_explore.add(son)
+        for successor in node.successors:
+            if not successor in explored:
+                to_explore.add(successor)
 
     return False
 

--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -434,7 +434,7 @@ class SlitherReadStorage:
         while len(queue) > 0:
             node = queue.pop(0)
             visited.append(node)
-            queue.extend(son for son in node.sons if son not in visited)
+            queue.extend(son for son in node.successors if son not in visited)
             if node.type == NodeType.ASSEMBLY and isinstance(node.inline_asm, str):
                 return SlitherReadStorage.find_hardcoded_slot_in_asm_str(node.inline_asm, contract)
             if node.type == NodeType.EXPRESSION:

--- a/slither/utils/code_complexity.py
+++ b/slither/utils/code_complexity.py
@@ -16,7 +16,7 @@ def compute_number_edges(function: "Function") -> int:
     """
     n = 0
     for node in function.nodes:
-        n += len(node.sons)
+        n += len(node.successors)
     return n
 
 
@@ -38,8 +38,8 @@ def compute_strongly_connected_components(function: "Function") -> List[List["No
     def visit(node: "Node") -> None:
         if not visited[node]:
             visited[node] = True
-            for son in node.sons:
-                visit(son)
+            for successor in node.successors:
+                visit(successor)
             l.append(node)
 
     for n in function.nodes:
@@ -49,8 +49,8 @@ def compute_strongly_connected_components(function: "Function") -> List[List["No
         if not assigned[node]:
             assigned[node] = True
             root.append(node)
-            for father in node.fathers:
-                assign(father, root)
+            for predecessor in node.predecessors:
+                assign(predecessor, root)
 
     for n in reversed(l):
         component: List["Node"] = []

--- a/slither/utils/upgradeability.py
+++ b/slither/utils/upgradeability.py
@@ -333,8 +333,8 @@ def is_function_modified(f1: Function, f2: Function) -> bool:
         node_f1 = queue_f1.pop(0)
         node_f2 = queue_f2.pop(0)
         visited.extend([node_f1, node_f2])
-        queue_f1.extend(son for son in node_f1.sons if son not in visited)
-        queue_f2.extend(son for son in node_f2.sons if son not in visited)
+        queue_f1.extend(son for son in node_f1.successors if son not in visited)
+        queue_f2.extend(son for son in node_f2.successors if son not in visited)
         if len(node_f1.irs) != len(node_f2.irs):
             return True
         for i, ir in enumerate(node_f1.irs):

--- a/slither/vyper_parsing/declarations/function.py
+++ b/slither/vyper_parsing/declarations/function.py
@@ -248,8 +248,8 @@ class FunctionVyper:  # pylint: disable=too-many-instance-attributes
         if node.is_reachable:
             return
         node.set_is_reachable(True)
-        for son in node.sons:
-            self._update_reachability(son)
+        for successor in node.successors:
+            self._update_reachability(successor)
 
     # pylint: disable=too-many-branches,too-many-statements,protected-access,too-many-locals
     def _parse_cfg(self, cfg: List[ASTNode]) -> None:

--- a/tests/unit/slithir/test_implicit_returns.py
+++ b/tests/unit/slithir/test_implicit_returns.py
@@ -27,16 +27,16 @@ def test_with_explicit_return(slither_from_solidity_source, legacy) -> None:
         c: Contract = slither.get_contract_from_name("Contract")[0]
         f: Function = c.functions[0]
         node_if: Node = f.nodes[1]
-        node_true = node_if.son_true
-        node_false = node_if.son_false
+        node_true = node_if.successor_true
+        node_false = node_if.successor_false
         assert node_true.type == NodeType.RETURN
         assert isinstance(node_true.irs[0], Return)
         assert node_true.irs[0].values[0] == f.get_local_variable_from_name("x")
-        assert len(node_true.sons) == 0
-        node_end_if = node_false.sons[0]
+        assert len(node_true.successors) == 0
+        node_end_if = node_false.successors[0]
         assert node_end_if.type == NodeType.ENDIF
-        assert node_end_if.sons[0].type == NodeType.RETURN
-        node_ret = node_end_if.sons[0]
+        assert node_end_if.successors[0].type == NodeType.RETURN
+        node_ret = node_end_if.successors[0]
         assert isinstance(node_ret.irs[0], Return)
         assert node_ret.irs[0].values[0] == f.get_local_variable_from_name("y")
 
@@ -93,19 +93,19 @@ def test_nested_ifs_with_loop_legacy(slither_from_solidity_source) -> None:
         c: Contract = slither.get_contract_from_name("Contract")[0]
         f: Function = c.functions[0]
         node_if = f.nodes[2]
-        assert node_if.son_true.type == NodeType.RETURN
-        node_explicit = node_if.son_true
+        assert node_if.successor_true.type == NodeType.RETURN
+        node_explicit = node_if.successor_true
         assert isinstance(node_explicit.irs[0], Return)
         assert node_explicit.irs[0].values[0] == f.get_local_variable_from_name("a")
         node_end_if = f.nodes[16]
         assert node_end_if.type == NodeType.ENDIF
-        assert node_end_if.sons[0].type == NodeType.RETURN
-        node_implicit = node_end_if.sons[0]
+        assert node_end_if.successors[0].type == NodeType.RETURN
+        node_implicit = node_end_if.successors[0]
         assert isinstance(node_implicit.irs[0], Return)
         assert node_implicit.irs[0].values[0] == f.get_local_variable_from_name("x")
         node_throw = f.nodes[11]
         assert node_throw.type == NodeType.THROW
-        assert len(node_throw.sons) == 0
+        assert len(node_throw.successors) == 0
 
 
 def test_nested_ifs_with_loop_compact(slither_from_solidity_source) -> None:
@@ -136,14 +136,14 @@ def test_nested_ifs_with_loop_compact(slither_from_solidity_source) -> None:
         c: Contract = slither.get_contract_from_name("Contract")[0]
         f: Function = c.functions[0]
         node_if = f.nodes[2]
-        assert node_if.son_true.type == NodeType.RETURN
-        node_explicit = node_if.son_true
+        assert node_if.successor_true.type == NodeType.RETURN
+        node_explicit = node_if.successor_true
         assert isinstance(node_explicit.irs[0], Return)
         assert node_explicit.irs[0].values[0] == f.get_local_variable_from_name("a")
         node_end_if = f.nodes[17]
         assert node_end_if.type == NodeType.ENDIF
-        assert node_end_if.sons[0].type == NodeType.RETURN
-        node_implicit = node_end_if.sons[0]
+        assert node_end_if.successors[0].type == NodeType.RETURN
+        node_implicit = node_end_if.successors[0]
         assert isinstance(node_implicit.irs[0], Return)
         assert node_implicit.irs[0].values[0] == f.get_local_variable_from_name("x")
 
@@ -175,14 +175,14 @@ def test_assembly_switch_cases(slither_from_solidity_source, legacy):
             assert node.irs[0].values[0] == f.get_local_variable_from_name("x")
         else:
             node_end_if = f.nodes[5]
-            assert node_end_if.sons[0].type == NodeType.RETURN
-            node_implicit = node_end_if.sons[0]
+            assert node_end_if.successors[0].type == NodeType.RETURN
+            node_implicit = node_end_if.successors[0]
             assert isinstance(node_implicit.irs[0], Return)
             assert node_implicit.irs[0].values[0] == f.get_local_variable_from_name("x")
             # This part will fail until issue #1927 is fixed
             node_explicit = f.nodes[10]
             assert node_explicit.type == NodeType.RETURN
-            assert len(node_explicit.sons) == 0
+            assert len(node_explicit.successors) == 0
 
 
 @pytest.mark.parametrize("legacy", [True, False])
@@ -199,8 +199,8 @@ def test_issue_1846_ternary_in_ternary(slither_from_solidity_source, legacy):
         f = c.functions[0]
         node_end_if = f.nodes[3]
         assert node_end_if.type == NodeType.ENDIF
-        assert len(node_end_if.sons) == 1
-        node_ret = node_end_if.sons[0]
+        assert len(node_end_if.successors) == 1
+        node_ret = node_end_if.successors[0]
         assert node_ret.type == NodeType.RETURN
         assert isinstance(node_ret.irs[0], Return)
         assert node_ret.irs[0].values[0] == f.get_local_variable_from_name("y")

--- a/tests/unit/slithir/test_ssa_generation.py
+++ b/tests/unit/slithir/test_ssa_generation.py
@@ -155,7 +155,7 @@ def ssa_phi_node_properties(f: Function) -> None:
             if isinstance(ssa, Phi):
                 n = len(ssa.read)
                 if not isinstance(ssa.lvalue, StateIRVariable):
-                    assert len(node.fathers) == n
+                    assert len(node.predecessors) == n
 
 
 # TODO (hbrodin): This should probably go into another file, not specific to SSA
@@ -168,13 +168,13 @@ def dominance_properties(f: Function) -> None:
 
     def find_path(from_node: Node, to: Node) -> bool:
         visited = set()
-        worklist = list(from_node.sons)
+        worklist = list(from_node.successors)
         while worklist:
             first, *worklist = worklist
             if first == to:
                 return True
             visited.add(first)
-            for successor in first.sons:
+            for successor in first.successors:
                 if successor not in visited:
                     worklist.append(successor)
         return False
@@ -1098,8 +1098,8 @@ def test_issue_1846_ternary_in_if(slither_from_solidity_source):
         f = c.functions[0]
         node = f.nodes[1]
         assert node.type == NodeType.IF
-        assert node.son_true.type == NodeType.IF
-        assert node.son_false.type == NodeType.EXPRESSION
+        assert node.successor_true.type == NodeType.IF
+        assert node.successor_false.type == NodeType.EXPRESSION
 
 
 def test_issue_1846_ternary_in_ternary(slither_from_solidity_source):
@@ -1115,8 +1115,8 @@ def test_issue_1846_ternary_in_ternary(slither_from_solidity_source):
         f = c.functions[0]
         node = f.nodes[1]
         assert node.type == NodeType.IF
-        assert node.son_true.type == NodeType.IF
-        assert node.son_false.type == NodeType.EXPRESSION
+        assert node.successor_true.type == NodeType.IF
+        assert node.successor_false.type == NodeType.EXPRESSION
 
 
 def test_issue_2016(slither_from_solidity_source):

--- a/tests/unit/slithir/test_ternary_expressions.py
+++ b/tests/unit/slithir/test_ternary_expressions.py
@@ -24,7 +24,7 @@ def test_ternary_conversions(solc_binary_path) -> None:
             if node.type in [NodeType.IF, NodeType.IFLOOP]:
 
                 # Iterate over true and false son
-                for inner_node in node.sons:
+                for inner_node in node.successors:
                     # Count all variables declared
                     expression = inner_node.expression
                     if isinstance(
@@ -60,11 +60,20 @@ def test_ternary_tuple(solc_binary_path) -> None:
     assert len(if_nodes) == 1
 
     if_node = if_nodes[0]
-    assert isinstance(if_node.son_true.expression, AssignmentOperation)
+    assert isinstance(if_node.successor_true.expression, AssignmentOperation)
     assert (
-        len([ir for ir in if_node.son_true.all_slithir_operations() if isinstance(ir, Unpack)]) == 1
+        len(
+            [ir for ir in if_node.successor_true.all_slithir_operations() if isinstance(ir, Unpack)]
+        )
+        == 1
     )
     assert (
-        len([ir for ir in if_node.son_false.all_slithir_operations() if isinstance(ir, Unpack)])
+        len(
+            [
+                ir
+                for ir in if_node.successor_false.all_slithir_operations()
+                if isinstance(ir, Unpack)
+            ]
+        )
         == 1
     )


### PR DESCRIPTION
This is a breaking change in the API but for the moment, we keep the compatibility layer in the cfg/node.py.

Fixes https://github.com/crytic/slither/issues/2398

The main changes are in `node.py` where we use a `__getattr__` to proxy calls to `son` or `father` methods (with an explicit list), print a deprecation warning and forward to the new implementation.  


I expect the linter to break, but I tried to keep changes minimal.
Of note, this PR is quite large because it tries to replace usages of `son` or `father` variable in common places in the code.