### PR TITLE
Filtering

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import pstats
+import re
 import sys
 import traceback
 from importlib import metadata
@@ -19,6 +20,7 @@ from crytic_compile.platform.standard import generate_standard_export
 from crytic_compile.platform.etherscan import SUPPORTED_NETWORK
 from crytic_compile import compile_all, is_supported
 
+from slither.core.filtering import FilteringRule, FilteringAction
 from slither.detectors import all_detectors
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 from slither.printers import all_printers
@@ -273,13 +275,63 @@ def choose_printers(
 # region Command line parsing
 ###################################################################################
 ###################################################################################
+def parse_filter_paths(args: argparse.Namespace) -> List[FilteringRule]:
+    """Parses the include/exclude/filter options from command line."""
+    regex = re.compile(
+        r"^(?P<type>[+-])?(?P<path>[^:]+?)(?::(?P<contract>[^.])(?:\.(?P<function>.+)?)?)?$"
+    )
 
+    def parse_option(element: str, option: str) -> FilteringRule:
 
-def parse_filter_paths(args: argparse.Namespace, filter_path: bool) -> List[str]:
-    paths = args.filter_paths if filter_path else args.include_paths
-    if paths:
-        return paths.split(",")
-    return []
+        match = regex.match(element)
+        if match:
+            filtering_type = FilteringAction.ALLOW
+            if match.group("type") == "-" or option == "remove":
+                filtering_type = FilteringAction.REJECT
+
+            try:
+                return FilteringRule(
+                    type=filtering_type,
+                    path=re.compile(match.group("path")) if match.group("path") else None,
+                    contract=re.compile(match.group("contract"))
+                    if match.group("contract")
+                    else None,
+                    function=re.compile(match.group("function"))
+                    if match.group("function")
+                    else None,
+                )
+            except re.error:
+                raise ValueError(f"Unable to parse option {element}, invalid regex.")
+
+        raise ValueError(f"Unable to parse option {element}")
+
+    filters = []
+    if args.include_paths:
+        logger.info("--include-paths is deprecated, use --include instead.")
+        filters.extend(
+            [
+                FilteringRule(type=FilteringAction.ALLOW, path=re.compile(path))
+                for path in args.include_paths.split(",")
+            ]
+        )
+
+    elif args.filter_paths:
+        logger.info("--filter-paths is deprecated, use --remove instead.")
+        filters.extend(
+            [
+                FilteringRule(type=FilteringAction.REJECT, path=re.compile(path))
+                for path in args.filter_paths.split(",")
+            ]
+        )
+
+    else:
+        for arg_name in ["include", "remove", "filter"]:
+            args_value = getattr(args, arg_name)
+            if not args_value:
+                continue
+            filters.extend([parse_option(element, arg_name) for element in args_value.split(",")])
+
+    return filters
 
 
 # pylint: disable=too-many-statements
@@ -315,7 +367,23 @@ def parse_args(
         "Checklist (consider using https://github.com/crytic/slither-action)"
     )
     group_misc = parser.add_argument_group("Additional options")
-    group_filters = parser.add_mutually_exclusive_group()
+    group_filters = parser.add_argument_group(
+        "Filtering",
+        description="""
+            The following options allow to control which files will be analyzed by Slither.
+            While the initial steps (parsing, generating the IR) are done on the full project,
+            the target for the detectors and/or printers can be restricted using these options.
+
+            The filtering allow to to select directories, files, contract and functions. Each part 
+            is compiled as a regex (so A*\.sol) will match every file that starts with A and ends with .sol. 
+            Examples :
+
+                - `sub1/A.sol:A.constructor` will analyze only the function named constructor in the contract A
+                found in file A.sol a directory sub1.
+                - `sub1/.*` will analyze all files found in the directory sub1/
+                - `.*:A` will analyze all the contract named A 
+        """,
+    )
 
     group_detector.add_argument(
         "--detect",
@@ -580,20 +648,42 @@ def parse_args(
         default=defaults_flag_in_config["no_fail"],
     )
 
+    # Deprecated
     group_filters.add_argument(
         "--filter-paths",
-        help="Regex filter to exclude detector results matching file path e.g. (mocks/|test/)",
+        help=argparse.SUPPRESS,
         action="store",
         dest="filter_paths",
         default=defaults_flag_in_config["filter_paths"],
     )
 
+    # Deprecated
     group_filters.add_argument(
         "--include-paths",
-        help="Regex filter to include detector results matching file path e.g. (src/|contracts/). Opposite of --filter-paths",
+        help=argparse.SUPPRESS,
         action="store",
         dest="include_paths",
         default=defaults_flag_in_config["include_paths"],
+    )
+
+    group_filters.add_argument(
+        "--include",
+        help="Include directory/files/contract/functions and only run the analysis on the specified elements.",
+        dest="include",
+        default=defaults_flag_in_config["include"],
+    )
+
+    group_filters.add_argument(
+        "--remove",
+        help="Exclude directory/files/contract/functions and only run the analysis on the specified elements.",
+        dest="remove",
+        default=defaults_flag_in_config["remove"],
+    )
+    group_filters.add_argument(
+        "--filter",
+        help="Include/Exclude directory/files/contract/functions and only run the analysis on the specified elements. Prefix by +_(or nothing) to include, and by - to exclude.",
+        dest="filter",
+        default=defaults_flag_in_config["filter"],
     )
 
     codex.init_parser(parser)
@@ -648,8 +738,9 @@ def parse_args(
     args = parser.parse_args()
     read_config_file(args)
 
-    args.filter_paths = parse_filter_paths(args, True)
-    args.include_paths = parse_filter_paths(args, False)
+    # args.filter_paths = parse_filter_paths(args, True)
+    # args.include_paths = parse_filter_paths(args, False)
+    args.filters = parse_filter_paths(args)
 
     # Verify our json-type output is valid
     args.json_types = set(args.json_types.split(","))  # type:ignore

--- a/slither/core/compilation_unit.py
+++ b/slither/core/compilation_unit.py
@@ -20,6 +20,7 @@ from slither.core.declarations.event_top_level import EventTopLevel
 from slither.core.declarations.function_top_level import FunctionTopLevel
 from slither.core.declarations.structure_top_level import StructureTopLevel
 from slither.core.declarations.using_for_top_level import UsingForTopLevel
+from slither.core.filtering import FilteringRule
 from slither.core.scope.scope import FileScope
 from slither.core.solidity_types.type_alias import TypeAliasTopLevel
 from slither.core.variables.state_variable import StateVariable
@@ -55,7 +56,7 @@ class SlitherCompilationUnit(Context):
         self._language = Language.from_str(crytic_compilation_unit.compiler_version.compiler)
 
         # Top level object
-        self.contracts: List[Contract] = []
+        self._contracts: List[Contract] = []
         self._structures_top_level: List[StructureTopLevel] = []
         self._enums_top_level: List[EnumTopLevel] = []
         self._events_top_level: List[EventTopLevel] = []
@@ -151,6 +152,24 @@ class SlitherCompilationUnit(Context):
     # region Contracts
     ###################################################################################
     ###################################################################################
+
+    @property
+    def contracts(self) -> List[Contract]:
+        filtered_contracts = [
+            contract for contract in self._contracts if self.core.filter_contract(contract) is False
+        ]
+        return filtered_contracts
+
+    def add_contract(self, contract: Contract) -> None:
+        """Add a contract to the compilation unit.
+
+        This method is created, so we don't modify the view only `contracts` property defined above.
+        """
+        self._contracts.append(contract)
+
+    @contracts.setter
+    def contracts(self, contracts: List[Contract]) -> None:
+        self._contracts = contracts
 
     @property
     def contracts_derived(self) -> List[Contract]:

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -643,12 +643,19 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         """
         list(Function): List of the functions
         """
-        return list(self._functions.values())
+        functions = [
+            function
+            for function in self._functions.values()
+            if not self.compilation_unit.core.filter_function(function)
+        ]
+        return functions
 
     def available_functions_as_dict(self) -> Dict[str, "Function"]:
         if self._available_functions_as_dict is None:
             self._available_functions_as_dict = {
-                f.full_name: f for f in self._functions.values() if not f.is_shadowed
+                f.full_name: f
+                for f in self._functions.values()
+                if not f.is_shadowed and not self.compilation_unit.core.filter_function(f)
             }
         return self._available_functions_as_dict
 

--- a/slither/core/filtering.py
+++ b/slither/core/filtering.py
@@ -1,0 +1,64 @@
+import enum
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
+
+
+if TYPE_CHECKING:
+    from slither.core.declarations import Contract, FunctionContract
+
+
+class FilteringAction(enum.Enum):
+    ALLOW = enum.auto()
+    REJECT = enum.auto()
+
+
+@dataclass
+class FilteringRule:
+
+    type: FilteringAction = FilteringAction.ALLOW
+    path: Union[re.Pattern, None] = None
+    contract: Union[re.Pattern, None] = None
+    function: Union[re.Pattern, None] = None
+
+    def match_contract(self, contract: "Contract") -> bool:
+        """Check with this filter matches the contract.
+
+        Verity table is as followed:
+                            path
+            |        | None     | True  | False |
+        co  |-----------------------------------|
+        nt  | None  || default  | True  | False |
+        ra  | True  || True     | True  | False |
+        ct  | False || False    | False | False |
+
+        """
+
+        # If we have no constraint, we just follow the default rule
+        if self.path is None and self.contract is None:
+            return True if self.type == FilteringAction.ALLOW else False
+
+        path_match = None
+        if self.path is not None:
+            path_match = bool(re.search(self.path, contract.source_mapping.filename.short))
+
+        contract_match = None
+        if self.contract is not None:
+            contract_match = bool(re.search(self.contract, contract.name))
+
+        if path_match is None:
+            return contract_match
+        elif contract_match is None:
+            return path_match
+        elif contract_match and path_match:
+            return True
+        else:
+            return False
+
+    def match_function(self, function: "FunctionContract") -> bool:
+        """Check if this filter apply to this element."""
+        # If we have no constraint, follow default rule
+        if self.function is None:
+            return True if self.type == FilteringAction.ALLOW else False
+
+        return bool(re.search(self.function, function.name))

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -18,6 +18,7 @@ from slither.core.compilation_unit import SlitherCompilationUnit
 from slither.core.context.context import Context
 from slither.core.declarations import Contract, FunctionContract
 from slither.core.declarations.top_level import TopLevel
+from slither.core.filtering import FilteringRule, FilteringAction
 from slither.core.source_mapping.source_mapping import SourceMapping, Source
 from slither.slithir.variables import Constant
 from slither.utils.colors import red
@@ -63,6 +64,9 @@ class SlitherCore(Context):
         self._currently_seen_resuts: Set[str] = set()
         self._paths_to_filter: Set[str] = set()
         self._paths_to_include: Set[str] = set()
+
+        self.filters: List[FilteringRule] = []
+        self.default_action: FilteringAction = FilteringAction.ALLOW
 
         self._crytic_compile: Optional[CryticCompile] = None
 
@@ -332,6 +336,40 @@ class SlitherCore(Context):
     # region Filtering results
     ###################################################################################
     ###################################################################################
+    def filter_contract(self, contract: Contract) -> bool:
+        """Check within the filters if we should exclude the contract.
+        Returns True if the contract is excluded, False otherwise
+        """
+        action: FilteringAction = self.default_action
+        for element_filter in self.filters:
+            if element_filter.match_contract(contract):
+                action = (
+                    FilteringAction.ALLOW
+                    if element_filter.type == FilteringAction.ALLOW
+                    else FilteringAction.REJECT
+                )
+
+        if action == FilteringAction.ALLOW:
+            return False
+        else:
+            return True
+
+    def filter_function(self, function: "FunctionContract") -> bool:
+        """Checks within the filter if this function should be excluded."""
+
+        action: FilteringAction = self.default_action
+        for element_filter in self.filters:
+            if element_filter.match_function(function):
+                action = (
+                    FilteringAction.ALLOW
+                    if element_filter.type == FilteringAction.ALLOW
+                    else FilteringAction.REJECT
+                )
+
+        if action == FilteringAction.ALLOW:
+            return False
+        else:
+            return True
 
     def parse_ignore_comments(self, file: str) -> None:
         # The first time we check a file, find all start/end ignore comments and memoize them.
@@ -432,42 +470,6 @@ class SlitherCore(Context):
         if r["id"] in self._currently_seen_resuts:
             return False
         self._currently_seen_resuts.add(r["id"])
-
-        source_mapping_elements = [
-            elem["source_mapping"].get("filename_absolute", "unknown")
-            for elem in r["elements"]
-            if "source_mapping" in elem
-        ]
-
-        # Use POSIX-style paths so that filter_paths|include_paths works across different
-        # OSes. Convert to a list so elements don't get consumed and are lost
-        # while evaluating the first pattern
-        source_mapping_elements = list(
-            map(lambda x: pathlib.Path(x).resolve().as_posix() if x else x, source_mapping_elements)
-        )
-        (matching, paths, msg_err) = (
-            (True, self._paths_to_include, "--include-paths")
-            if self._paths_to_include
-            else (False, self._paths_to_filter, "--filter-paths")
-        )
-
-        for path in paths:
-            try:
-                if any(
-                    bool(re.search(_relative_path_format(path), src_mapping))
-                    for src_mapping in source_mapping_elements
-                ):
-                    matching = not matching
-                    break
-            except re.error:
-                logger.error(
-                    f"Incorrect regular expression for {msg_err} {path}."
-                    "\nSlither supports the Python re format"
-                    ": https://docs.python.org/3/library/re.html"
-                )
-
-        if r["elements"] and matching:
-            return False
 
         if self._show_ignored_findings:
             return True

--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -88,7 +88,6 @@ class AbstractDetector(metaclass=abc.ABCMeta):
         self, compilation_unit: SlitherCompilationUnit, slither: "Slither", logger: Logger
     ) -> None:
         self.compilation_unit: SlitherCompilationUnit = compilation_unit
-        self.contracts: List[Contract] = compilation_unit.contracts
         self.slither: "Slither" = slither
         # self.filename = slither.filename
         self.logger = logger
@@ -170,6 +169,11 @@ class AbstractDetector(metaclass=abc.ABCMeta):
             raise IncorrectDetectorInitialization(
                 f"CONFIDENCE is not initialized {self.__class__.__name__}"
             )
+
+    @property
+    def contracts(self) -> List[Contract]:
+        """Direct accessor to the compilation unit contracts."""
+        return self.compilation_unit.contracts
 
     def _log(self, info: str) -> None:
         if self.logger:

--- a/slither/printers/abstract_printer.py
+++ b/slither/printers/abstract_printer.py
@@ -22,7 +22,6 @@ class AbstractPrinter(metaclass=abc.ABCMeta):
 
     def __init__(self, slither: "Slither", logger: Optional[Logger]) -> None:
         self.slither = slither
-        self.contracts = slither.contracts
         self.filename = slither.filename
         self.logger = logger
 
@@ -40,6 +39,15 @@ class AbstractPrinter(metaclass=abc.ABCMeta):
             raise IncorrectPrinterInitialization(
                 f"WIKI is not initialized {self.__class__.__name__}"
             )
+
+    @property
+    def contracts(self):
+        """Direct accessor to the slither contracts.
+
+        We prefer to delay as much as possible the direct access of contracts to leave the possibility
+        for filtering to be applied.
+        """
+        return self.slither.contracts
 
     def info(self, info: str) -> None:
         if self.logger:

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -59,8 +59,12 @@ defaults_flag_in_config = {
     "sarif": None,
     "json-types": ",".join(DEFAULT_JSON_OUTPUT_TYPES),
     "disable_color": False,
-    "filter_paths": None,
-    "include_paths": None,
+    # Filtering
+    "filter_paths": None,  # deprecated
+    "include_paths": None,  # deprecated
+    "include": None,
+    "remove": None,
+    "filter": None,
     "generate_patches": False,
     # debug command
     "skip_assembly": False,

--- a/slither/vyper_parsing/vyper_compilation_unit.py
+++ b/slither/vyper_parsing/vyper_compilation_unit.py
@@ -38,7 +38,7 @@ class VyperCompilationUnit:
     def parse_contracts(self):
         for contract, contract_parser in self._underlying_contract_to_parser.items():
             self._contracts_by_id[contract.id] = contract
-            self._compilation_unit.contracts.append(contract)
+            self._compilation_unit.add_contract(contract)
 
             contract_parser.parse_enums()
             contract_parser.parse_structs()

--- a/tests/e2e/filtering/test_data/test_filtering/README.md
+++ b/tests/e2e/filtering/test_data/test_filtering/README.md
@@ -1,0 +1,8 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+This test should be installed using
+```shell
+forge install --no-commit --no-git foundry-rs/forge-std
+```

--- a/tests/e2e/filtering/test_data/test_filtering/foundry.toml
+++ b/tests/e2e/filtering/test_data/test_filtering/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/tests/e2e/filtering/test_data/test_filtering/src/sub1/A.sol
+++ b/tests/e2e/filtering/test_data/test_filtering/src/sub1/A.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract A {
+    constructor() {}
+    function a() public view {}
+}

--- a/tests/e2e/filtering/test_data/test_filtering/src/sub1/sub12/B.sol
+++ b/tests/e2e/filtering/test_data/test_filtering/src/sub1/sub12/B.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract B {
+    constructor(){}
+    function b() public view {}
+}

--- a/tests/e2e/filtering/test_data/test_filtering/src/sub2/C.sol
+++ b/tests/e2e/filtering/test_data/test_filtering/src/sub2/C.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract C {
+    constructor(){
+
+    }
+    function c() public view {}
+}

--- a/tests/e2e/filtering/test_data/test_filtering/src/sub2/D.sol
+++ b/tests/e2e/filtering/test_data/test_filtering/src/sub2/D.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract D {
+    constructor(){
+
+    }
+}
+
+contract E {
+    constructor() {}
+}

--- a/tests/e2e/filtering/test_filtering.py
+++ b/tests/e2e/filtering/test_filtering.py
@@ -1,0 +1,382 @@
+from argparse import Namespace
+import logging
+import shutil
+from pathlib import Path
+from typing import List, Dict, Set, Union, OrderedDict
+import re
+
+import pytest
+
+from slither import Slither
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from slither.printers.abstract_printer import AbstractPrinter
+from slither.utils.output import Output
+from slither.core.filtering import FilteringRule, FilteringAction
+from slither.__main__ import parse_filter_paths
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+
+foundry_available = shutil.which("forge") is not None
+project_ready = Path(TEST_DATA_DIR, "test_filtering/lib/forge-std").exists()
+
+
+class DummyPrinter(AbstractPrinter):
+    ARGUMENT = "dummy_printer"
+    HELP = ".."
+    WIKI = ".."
+
+    def output(self, _: str) -> Output:
+        output = []
+        for contract in self.contracts:
+            for function in contract.functions:
+                output.append(f"{function.contract_declarer.name}.{function.name}")
+
+        output = self.generate_output(",".join(output))
+        return output
+
+    @staticmethod
+    def analyze_dummy_output(output: OrderedDict) -> Set[str]:
+        return set(output["description"].split(","))
+
+
+class DummyDetector(AbstractDetector):
+    ARGUMENT = "dummy_detector"  # run the detector with slither.py --ARGUMENT
+    HELP = ".."  # help information
+    IMPACT = DetectorClassification.LOW
+    CONFIDENCE = DetectorClassification.LOW
+
+    WIKI = ".."
+
+    WIKI_TITLE = ".."
+    WIKI_DESCRIPTION = ".."
+    WIKI_EXPLOIT_SCENARIO = ".."
+    WIKI_RECOMMENDATION = ".."
+
+    def _detect(self) -> List[Output]:
+        results = []
+        for contract in self.compilation_unit.contracts_derived:
+            for function in contract.functions:
+                results.append(self.generate_result([function]))
+
+        return results
+
+    @staticmethod
+    def analyze_dummy_output(results: Dict) -> Set[str]:
+        output = set()
+        for result in results:
+            for element in result.get("elements", []):
+                assert element.get("type") == "function"
+                contract = element.get("type_specific_fields", {}).get("parent", {}).get("name")
+                output.add(f"{contract}.{element['name']}")
+
+        return output
+
+
+@pytest.mark.skipif(
+    not foundry_available or not project_ready, reason="requires Foundry and project setup"
+)
+def test_filtering():
+    def run_detector_for_filtering(
+        sl: Slither,
+        filtering: Union[List[FilteringRule], None],
+        default_action: FilteringAction,
+    ):
+
+        # First, reset any results
+        sl._currently_seen_resuts = set()
+
+        # Set up default action
+        sl.default_action = default_action
+
+        if filtering is not None:
+            sl.filters = filtering
+
+        return DummyDetector.analyze_dummy_output(sl.run_detectors().pop())
+
+    slither = Slither(Path(TEST_DATA_DIR, "test_filtering").as_posix())
+    slither.register_detector(DummyDetector)
+
+    # First, check that if we deny everything, we don't run on anything
+    output = run_detector_for_filtering(slither, [], FilteringAction.REJECT)
+    assert not output
+
+    # Then, if we run on everything, lets check that we get all
+    output = run_detector_for_filtering(slither, [], FilteringAction.ALLOW)
+    assert not output ^ {
+        "A.constructor",
+        "A.a",
+        "B.constructor",
+        "B.b",
+        "C.constructor",
+        "C.c",
+        "D.constructor",
+        "E.constructor",
+    }
+
+    # Then, test more closely
+    # Reject all but a single directory
+    output = run_detector_for_filtering(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, path=re.compile(r"sub1/"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"B.b", "A.constructor", "B.constructor", "A.a"}
+
+    # Allow all but deny a directory
+    output = run_detector_for_filtering(
+        slither,
+        [FilteringRule(type=FilteringAction.REJECT, path=re.compile(r"sub1/"))],
+        FilteringAction.ALLOW,
+    )
+    assert not output ^ {"C.c", "C.constructor", "D.constructor", "E.constructor"}
+
+    # Allow all functions named constructor
+    output = run_detector_for_filtering(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, function=re.compile(r"constructor"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {
+        "A.constructor",
+        "B.constructor",
+        "C.constructor",
+        "D.constructor",
+        "E.constructor",
+    }
+
+    # Allow only contract C
+    output = run_detector_for_filtering(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, contract=re.compile(r"C"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"C.constructor", "C.c"}
+
+    # Allow everything in sub1 but not in sub1/sub12
+    output = run_detector_for_filtering(
+        slither,
+        [
+            FilteringRule(type=FilteringAction.ALLOW, path=re.compile("sub1/")),
+            FilteringRule(type=FilteringAction.REJECT, path=re.compile("sub12/")),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"A.constructor", "A.a"}
+
+    # Allow everything in D.sol
+    output = run_detector_for_filtering(
+        slither,
+        [
+            FilteringRule(type=FilteringAction.ALLOW, path=re.compile("D.sol")),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"D.constructor", "E.constructor"}
+
+    # Allow only E in D.sol
+    output = run_detector_for_filtering(
+        slither,
+        [
+            FilteringRule(
+                type=FilteringAction.ALLOW, path=re.compile("D.sol"), contract=re.compile("E")
+            ),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"E.constructor"}
+
+
+def get_default_namespace(
+    include_paths: Union[str, None] = None,
+    filter_paths: Union[str, None] = None,
+    include: Union[str, None] = None,
+    remove: Union[str, None] = None,
+    filter: Union[str, None] = None,
+) -> Namespace:
+    return Namespace(
+        include_paths=include_paths,
+        filter_paths=filter_paths,
+        include=include,
+        remove=remove,
+        filter=filter,
+    )
+
+
+def test_filtering_cl_deprecated(caplog):
+    with caplog.at_level(logging.INFO):
+        parsed_args = parse_filter_paths(get_default_namespace(include_paths="sub1/"))
+
+    assert parsed_args == [FilteringRule(path=re.compile("sub1/"))]
+    assert "include-paths is deprecated" in caplog.text
+
+    with caplog.at_level(logging.INFO):
+        parsed_args = parse_filter_paths(get_default_namespace(filter_paths="sub1/"))
+
+    assert parsed_args == [FilteringRule(type=FilteringAction.REJECT, path=re.compile("sub1/"))]
+    assert "filter-paths is deprecated" in caplog.text
+
+
+def test_filtering_cl_multiple():
+    parsed_args = parse_filter_paths(get_default_namespace(include="sub12/,sub2/"))
+
+    assert parsed_args == [
+        FilteringRule(type=FilteringAction.ALLOW, path=re.compile("sub12/")),
+        FilteringRule(type=FilteringAction.ALLOW, path=re.compile("sub2/")),
+    ]
+
+    parsed_args = parse_filter_paths(get_default_namespace(remove="sub12/,sub2/"))
+
+    assert parsed_args == [
+        FilteringRule(type=FilteringAction.REJECT, path=re.compile("sub12/")),
+        FilteringRule(type=FilteringAction.REJECT, path=re.compile("sub2/")),
+    ]
+
+
+def test_filtering_cl_full():
+    parsed_args = parse_filter_paths(get_default_namespace(include="sub1/A.sol:A.a"))
+    assert parsed_args == [
+        FilteringRule(
+            type=FilteringAction.ALLOW,
+            path=re.compile("sub1/A.sol"),
+            contract=re.compile("A"),
+            function=re.compile("a"),
+        ),
+    ]
+
+    parsed_args = parse_filter_paths(get_default_namespace(remove="sub1/A.sol:A.a"))
+    assert parsed_args == [
+        FilteringRule(
+            type=FilteringAction.REJECT,
+            path=re.compile("sub1/A.sol"),
+            contract=re.compile("A"),
+            function=re.compile("a"),
+        ),
+    ]
+
+
+def test_filtering_cl_filter():
+    parsed_args = parse_filter_paths(get_default_namespace(filter="sub1/,-sub1/sub12/"))
+    assert parsed_args == [
+        FilteringRule(
+            type=FilteringAction.ALLOW,
+            path=re.compile("sub1/"),
+        ),
+        FilteringRule(
+            type=FilteringAction.REJECT,
+            path=re.compile("sub1/sub12/"),
+        ),
+    ]
+
+
+def test_invalid_regex():
+    with pytest.raises(ValueError):
+        parse_filter_paths(get_default_namespace(filter="sub1(/"))
+
+    with pytest.raises(ValueError):
+        parse_filter_paths(get_default_namespace(filter=":not-matching:"))
+
+
+@pytest.mark.skipif(
+    not foundry_available or not project_ready, reason="requires Foundry and project setup"
+)
+def test_filtering_printer():
+    def run_printer(
+        sl: Slither, filtering_rules: List[FilteringRule], default_action: FilteringAction
+    ):
+        sl.filters = filtering_rules
+        sl._contracts = []  # Reset the list of contracts so it gets recomputed
+        sl.default_action = default_action
+        return DummyPrinter.analyze_dummy_output(sl.run_printers().pop())
+
+    slither = Slither(Path(TEST_DATA_DIR, "test_filtering").as_posix())
+    slither.register_printer(DummyPrinter)
+
+    output = run_printer(slither, [], FilteringAction.ALLOW)
+    assert not output ^ {
+        "A.a",
+        "A.constructor",
+        "B.b",
+        "B.constructor",
+        "C.c",
+        "C.constructor",
+        "D.constructor",
+        "E.constructor",
+    }
+
+    # First, check that if we deny everything, we don't run on anything
+    slither.default_action = FilteringAction.REJECT
+    output = run_printer(slither, [], FilteringAction.REJECT)
+    assert output == {""}
+
+    # Then, test more closely
+    # Reject all but a single directory
+    output = run_printer(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, path=re.compile(r"sub1/"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"B.b", "A.constructor", "B.constructor", "A.a"}
+
+    # Allow all but deny a directory
+    output = run_printer(
+        slither,
+        [FilteringRule(type=FilteringAction.REJECT, path=re.compile(r"sub1/"))],
+        FilteringAction.ALLOW,
+    )
+    assert not output ^ {"C.c", "C.constructor", "D.constructor", "E.constructor"}
+
+    # Allow all functions named constructor
+    output = run_printer(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, function=re.compile(r"constructor"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {
+        "A.constructor",
+        "B.constructor",
+        "C.constructor",
+        "D.constructor",
+        "E.constructor",
+    }
+
+    # Allow only contract C
+    output = run_printer(
+        slither,
+        [FilteringRule(type=FilteringAction.ALLOW, contract=re.compile(r"C"))],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"C.constructor", "C.c"}
+
+    # Allow everything in sub1 but not in sub1/sub12
+    output = run_printer(
+        slither,
+        [
+            FilteringRule(type=FilteringAction.ALLOW, path=re.compile("sub1/")),
+            FilteringRule(type=FilteringAction.REJECT, path=re.compile("sub12/")),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"A.constructor", "A.a"}
+
+    # Allow everything in D.sol
+    output = run_printer(
+        slither,
+        [
+            FilteringRule(type=FilteringAction.ALLOW, path=re.compile("D.sol")),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"D.constructor", "E.constructor"}
+
+    # Allow only E in D.sol
+    output = run_printer(
+        slither,
+        [
+            FilteringRule(
+                type=FilteringAction.ALLOW, path=re.compile("D.sol"), contract=re.compile("E")
+            ),
+        ],
+        FilteringAction.REJECT,
+    )
+    assert not output ^ {"E.constructor"}


### PR DESCRIPTION
Adds three new options to the Slither CLI to filter results.

This PR adds granularity in the filtering system provided by slither on which files, contracts or function to run.

# Help

```shell
➜ slither --help

...

Filtering:
  The following options allow to control which files will be analyzed by Slither. While the initial steps (parsing, generating the IR) are done on the full project, the
  target for the detectors and/or printers can be restricted using these options. The filtering allow to to select directories, files, contract and functions. Each part
  is compiled as a regex (so A*\.sol) will match every file that starts with A and ends with .sol. 
Examples :
 - `sub1/A.sol:A.constructor` will analyze only the
  function named constructor in the contract A found in file A.sol a directory sub1. 
- `sub1/.*` will analyze all files found in the directory sub1/ 
- `.*:A` will analyze all the contract named A

  --include INCLUDE     Include directory/files/contract/functions and only run the analysis on the specified elements.
  --remove REMOVE       Exclude directory/files/contract/functions and only run the analysis on the specified elements.
  --filter FILTER       Include/Exclude directory/files/contract/functions and only run the analysis on the specified elements. Prefix by +_(or nothing) to include, and by - to exclude.

```
 
# Implementation details

1. Migrate `filter-paths`, `include-paths` option to the new system and add a deprecation warning

The previous options are kept for backward compatibility but they are removed from the help output
They are migrated to the new filtering system.

2. Filtering

The filtering is done at the `CompilationUnit` level, the `contracts`, and `functions` method now only return the restricted results instead of the complete results. 
This way the impact on current detectors and/or printers is kept minimal.

3. Filtering syntax

We use a comma separted list of values with this format : 
```shell
<+-><path/subdir/file>:<contract>.<function>
```
The leading +- can be used for the `filter` option to list positive and negative rules.

Each element is compiled as a regex so the following examples work:

- `.*:A.*`: Matches every contract that contains an A
- `+sub1/,-sub1/sub12` : Matches everything in sub1 that is not in sub2.

Of note, the exact regex is: 
```python
    regex = re.compile(
        r"^(?P<type>[+-])?(?P<path>[^:]+?)(?::(?P<contract>[^.])(?:\.(?P<function>.+)?)?)?$"
    )
```

And the tests were made using [here](https://regex101.com/r/NPJlgh/1)

 

