### PR TITLE
Fix regex patterns

### DIFF
--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -501,7 +501,7 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                 referenced_declaration = expression["attributes"]["referencedDeclaration"]
 
         if t:
-            found = re.findall(r"[struct|enum|function|modifier] \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
+            found = re.findall(r"struct|enum|function|modifier \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
             assert len(found) <= 1
             if found:
                 value = value + "(" + found[0] + ")"

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -501,7 +501,9 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                 referenced_declaration = expression["attributes"]["referencedDeclaration"]
 
         if t:
-            found = re.findall(r"(?:struct|enum|function|modifier) \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
+            found = re.findall(
+                r"(?:struct|enum|function|modifier) \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t
+            )
             assert len(found) <= 1
             if found:
                 value = value + "(" + found[0] + ")"

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -501,7 +501,7 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
                 referenced_declaration = expression["attributes"]["referencedDeclaration"]
 
         if t:
-            found = re.findall(r"struct|enum|function|modifier \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
+            found = re.findall(r"(?:struct|enum|function|modifier) \(([\[\] ()a-zA-Z0-9\.,_]*)\)", t)
             assert len(found) <= 1
             if found:
                 value = value + "(" + found[0] + ")"


### PR DESCRIPTION
To properly consider the identifiers, we need to use `()` instead of `[]` in regex definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the regular expression pattern in the parsing function to ensure accurate keyword matching.

- **Improvements**
  - Updated the regular expression in the parsing function to include a non-capturing group for better type identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->