### PR TITLE
fix: use contract declarer's scope for name resolution

### DIFF
--- a/slither/solc_parsing/expressions/find_variable.py
+++ b/slither/solc_parsing/expressions/find_variable.py
@@ -304,7 +304,7 @@ def _find_variable_init(
             scope = underlying_function.file_scope
         else:
             assert isinstance(underlying_function, FunctionContract)
-            scope = underlying_function.contract.file_scope
+            scope = underlying_function.contract_declarer.file_scope
 
     elif isinstance(caller_context, StructureTopLevelSolc):
         direct_contracts = []

--- a/tests/unit/core/test_data/scope_with_renaming/core/MainContract.sol
+++ b/tests/unit/core/test_data/scope_with_renaming/core/MainContract.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {
+    ParentContract
+} from "./ParentContract.sol";
+
+import {
+    MainErrors as Errors
+} from "./../errors/MainErrors.sol";
+
+
+contract MainContract is ParentContract {
+
+    
+    function functionWithMainError1(uint256 a, uint256 b) external pure returns (uint256) {
+        if (a == b) {
+            revert Errors.MainError1();
+        }
+        // Add some arithmetic operations here
+        return a + b;
+    }
+
+    function functionWithMainError2(uint256 a, uint256 b) external pure returns (uint256) {
+        if (a < b) {
+            revert Errors.MainError2();
+        }
+        // Add some arithmetic operations here
+        return a - b;
+    }
+
+    function functionWithMainError3(uint256 a, uint256 b) external pure returns (uint256) {
+        if (b == 0) {
+            revert Errors.MainError3();
+        }
+        // Add some arithmetic operations here
+        return a * b;
+    }
+
+
+}

--- a/tests/unit/core/test_data/scope_with_renaming/core/ParentContract.sol
+++ b/tests/unit/core/test_data/scope_with_renaming/core/ParentContract.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+
+import {
+    AccessControlErrors as Errors 
+} from "../errors/ParentContractErrors.sol";
+
+
+contract ParentContract {
+     
+     
+    function functionWithAccessControlErrors1(uint256 a, uint256 b) external pure returns (uint256) {
+        if (a == b) {
+            revert Errors.AccessControlErrors1();
+        }
+        // Add some arithmetic operations here
+        return a + b;
+    }
+
+    function functionWithAccessControlErrors2(uint256 a, uint256 b) external pure returns (uint256) {
+        if (a < b) {
+            revert Errors.AccessControlErrors2();
+        }
+        // Add some arithmetic operations here
+        return a - b;
+    }
+  
+
+}

--- a/tests/unit/core/test_data/scope_with_renaming/errors/MainErrors.sol
+++ b/tests/unit/core/test_data/scope_with_renaming/errors/MainErrors.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+// TODO: remove unused errors
+library MainErrors {
+    error MainError1();
+    error MainError2();
+    error MainError3();
+}

--- a/tests/unit/core/test_data/scope_with_renaming/errors/ParentContractErrors.sol
+++ b/tests/unit/core/test_data/scope_with_renaming/errors/ParentContractErrors.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+library AccessControlErrors {
+    error AccessControlErrors1();
+    error AccessControlErrors2();
+}

--- a/tests/unit/core/test_scope_with_renaming.py
+++ b/tests/unit/core/test_scope_with_renaming.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from crytic_compile import CryticCompile
+from crytic_compile.platform.solc_standard_json import SolcStandardJson
+
+from slither import Slither
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+SCOPE_RENAMING_TEST_DATA_DIR = Path(TEST_DATA_DIR, "scope_with_renaming")
+
+# https://github.com/crytic/slither/issues/2454
+def test_find_variable_scope_with_renaming(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.24")
+    standard_json = SolcStandardJson()
+    for source_file in SCOPE_RENAMING_TEST_DATA_DIR.rglob("**/*.sol"):
+        standard_json.add_source_file(Path(source_file).as_posix())
+    compilation = CryticCompile(standard_json, solc=solc_path)
+    Slither(compilation, disallow_partial=True)

--- a/tests/unit/core/test_using_for.py
+++ b/tests/unit/core/test_using_for.py
@@ -17,7 +17,7 @@ def test_using_for_global_collision(solc_binary_path) -> None:
     for source_file in Path(USING_FOR_TEST_DATA_DIR, "using_for_global_collision").rglob("*.sol"):
         standard_json.add_source_file(Path(source_file).as_posix())
     compilation = CryticCompile(standard_json, solc=solc_path)
-    sl = Slither(compilation)
+    sl = Slither(compilation, disallow_partial=True)
     _run_all_detectors(sl)
 
 


### PR DESCRIPTION
closes https://github.com/crytic/slither/issues/2454
replaces https://github.com/crytic/slither/pull/2455

The scope for `FunctionContract` was using the inherited contract's scope and not the declarer's so it was find the wrong alias