### PR TITLE
fix: filtering of unused-import,incorrect-solc, pragma

### DIFF
--- a/slither/detectors/attributes/constant_pragma.py
+++ b/slither/detectors/attributes/constant_pragma.py
@@ -36,21 +36,19 @@ class ConstantPragma(AbstractDetector):
         for pragma in self.compilation_unit.pragma_directives:
             if pragma.is_solidity_version:
                 if pragma.version not in pragma_directives_by_version:
-                    pragma_directives_by_version[
-                        pragma.version
-                    ] = f"\t\t- {str(pragma.source_mapping)}\n"
+                    pragma_directives_by_version[pragma.version] = [pragma]
                 else:
-                    pragma_directives_by_version[
-                        pragma.version
-                    ] += f"\t\t- {str(pragma.source_mapping)}\n"
+                    pragma_directives_by_version[pragma.version].append(pragma)
 
         versions = list(pragma_directives_by_version.keys())
         if len(versions) > 1:
             info: DETECTOR_INFO = [f"{len(versions)} different versions of Solidity are used:\n"]
 
             for version in versions:
-                pragma = pragma_directives_by_version[version]
-                info += [f"\t- Version constraint {version} is used by:\n {pragma}"]
+                pragmas = pragma_directives_by_version[version]
+                info += [f"\t- Version constraint {version} is used by:\n"]
+                for pragma in pragmas:
+                    info += ["\t\t-", pragma, "\n"]
 
             res = self.generate_result(info)
 

--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -115,16 +115,18 @@ Consider using the latest version of Solidity for testing."""
                 continue
 
             if p.version in disallowed_pragmas and reason in disallowed_pragmas[p.version]:
-                disallowed_pragmas[p.version][reason] += f"\t- {str(p.source_mapping)}\n"
+                disallowed_pragmas[p.version][reason].append(p)
             else:
-                disallowed_pragmas[p.version] = {reason: f"\t- {str(p.source_mapping)}\n"}
+                disallowed_pragmas[p.version] = {reason: [p]}
 
         # If we found any disallowed pragmas, we output our findings.
         if len(disallowed_pragmas.keys()):
             for p, reasons in disallowed_pragmas.items():
                 info: DETECTOR_INFO = []
-                for r, v in reasons.items():
-                    info += [f"Version constraint {p} {r}.\n It is used by:\n{v}"]
+                for r, vers in reasons.items():
+                    info += [f"Version constraint {p} {r}.\nIt is used by:\n"]
+                    for ver in vers:
+                        info += ["\t- ", ver, "\n"]
 
                 json = self.generate_result(info)
 

--- a/slither/detectors/statements/unused_import.py
+++ b/slither/detectors/statements/unused_import.py
@@ -74,7 +74,7 @@ class UnusedImport(AbstractDetector):
                 if unit.crytic_compile.is_dependency(filename.absolute):
                     continue
 
-                unused = []
+                unused_list = []
                 for i in current_scope.imports:
                     # `scope.imports` contains all transitive imports so we need to filter out imports not explicitly imported in the file.
                     # Otherwise, we would recommend removing an import that is used by a leaf contract and cause compilation errors.
@@ -105,17 +105,15 @@ class UnusedImport(AbstractDetector):
                             break
 
                     if not use_found:
-                        unused.append(f"{i.source_mapping.content} ({i.source_mapping})")
+                        unused_list.append(f"{i.source_mapping.content} ({i.source_mapping})")
 
-                if len(unused) > 0:
-                    unused_list = "\n\t-" + "\n\t-".join(unused)
+                if len(unused_list) > 0:
+                    info = [
+                        f"The following unused import(s) in {filename.used} should be removed:",
+                    ]
+                    for unused in unused_list:
+                        info += ["\n\t-", unused, "\n"]
 
-                    results.append(
-                        self.generate_result(
-                            [
-                                f"The following unused import(s) in {filename.used} should be removed: {unused_list}\n",
-                            ]
-                        )
-                    )
+                    results.append(self.generate_result(info))
 
         return results

--- a/slither/detectors/statements/unused_import.py
+++ b/slither/detectors/statements/unused_import.py
@@ -63,7 +63,7 @@ class UnusedImport(AbstractDetector):
                 return False
         return True
 
-    def _detect(self) -> List[Output]:
+    def _detect(self) -> List[Output]:  # pylint: disable=too-many-branches
         results: List[Output] = []
         # This is computed lazily and then memoized so we need to trigger the computation.
         self.slither._compute_offsets_to_ref_impl_decl()

--- a/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_4_25_pragma_0_4_25_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_4_25_pragma_0_4_25_sol__0.txt
@@ -1,6 +1,6 @@
 2 different versions of Solidity are used:
 	- Version constraint ^0.4.25 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.4.25/pragma.0.4.25.sol#1
+		-^0.4.25 (tests/e2e/detectors/test_data/pragma/0.4.25/pragma.0.4.25.sol#1)
 	- Version constraint ^0.4.24 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.4.25/pragma.0.4.24.sol#1
+		-^0.4.24 (tests/e2e/detectors/test_data/pragma/0.4.25/pragma.0.4.24.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_5_16_pragma_0_5_16_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_5_16_pragma_0_5_16_sol__0.txt
@@ -1,6 +1,6 @@
 2 different versions of Solidity are used:
 	- Version constraint ^0.5.16 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.5.16/pragma.0.5.16.sol#1
+		-^0.5.16 (tests/e2e/detectors/test_data/pragma/0.5.16/pragma.0.5.16.sol#1)
 	- Version constraint ^0.5.15 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.5.16/pragma.0.5.15.sol#1
+		-^0.5.15 (tests/e2e/detectors/test_data/pragma/0.5.16/pragma.0.5.15.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_6_11_pragma_0_6_11_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_6_11_pragma_0_6_11_sol__0.txt
@@ -1,6 +1,6 @@
 2 different versions of Solidity are used:
 	- Version constraint ^0.6.11 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.6.11/pragma.0.6.11.sol#1
+		-^0.6.11 (tests/e2e/detectors/test_data/pragma/0.6.11/pragma.0.6.11.sol#1)
 	- Version constraint ^0.6.10 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.6.11/pragma.0.6.10.sol#1
+		-^0.6.10 (tests/e2e/detectors/test_data/pragma/0.6.11/pragma.0.6.10.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_7_6_pragma_0_7_6_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_ConstantPragma_0_7_6_pragma_0_7_6_sol__0.txt
@@ -1,6 +1,6 @@
 2 different versions of Solidity are used:
 	- Version constraint ^0.7.6 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.7.6/pragma.0.7.6.sol#1
+		-^0.7.6 (tests/e2e/detectors/test_data/pragma/0.7.6/pragma.0.7.6.sol#1)
 	- Version constraint ^0.7.5 is used by:
- 		- tests/e2e/detectors/test_data/pragma/0.7.6/pragma.0.7.5.sol#1
+		-^0.7.5 (tests/e2e/detectors/test_data/pragma/0.7.6/pragma.0.7.5.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_4_25_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_4_25_static_sol__0.txt
@@ -1,5 +1,3 @@
-solc-0.4.25 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
-
 Version constraint 0.4.25 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
 	- DirtyBytesArrayToStorage
 	- ABIDecodeTwoDimensionalArrayMemory
@@ -16,6 +14,8 @@ Version constraint 0.4.25 contains known severe issues (https://solidity.readthe
 	- UninitializedFunctionPointerInConstructor_0.4.x
 	- IncorrectEventSignatureInLibraries_0.4.x
 	- ABIEncoderV2PackedStorage_0.4.x.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.4.25/static.sol#1
+It is used by:
+	- 0.4.25 (tests/e2e/detectors/test_data/solc-version/0.4.25/static.sol#1)
+
+solc-0.4.25 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_14_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_14_static_sol__0.txt
@@ -13,8 +13,8 @@ Version constraint 0.5.14 contains known severe issues (https://solidity.readthe
 	- privateCanBeOverridden
 	- YulOptimizerRedundantAssignmentBreakContinue0.5
 	- ABIEncoderV2LoopYulOptimizer.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.5.14/static.sol#1
+It is used by:
+	- 0.5.14 (tests/e2e/detectors/test_data/solc-version/0.5.14/static.sol#1)
 
 solc-0.5.14 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_dynamic_1_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_dynamic_1_sol__0.txt
@@ -12,8 +12,8 @@ Version constraint ^0.5.15 contains known severe issues (https://solidity.readth
 	- MemoryArrayCreationOverflow
 	- privateCanBeOverridden
 	- YulOptimizerRedundantAssignmentBreakContinue0.5.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.5.16/dynamic_1.sol#1
+It is used by:
+	- ^0.5.15 (tests/e2e/detectors/test_data/solc-version/0.5.16/dynamic_1.sol#1)
 
 solc-0.5.16 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_dynamic_2_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_dynamic_2_sol__0.txt
@@ -14,8 +14,8 @@ Version constraint >=0.5.0<0.6.0 contains known severe issues (https://solidity.
 	- UninitializedFunctionPointerInConstructor
 	- IncorrectEventSignatureInLibraries
 	- ABIEncoderV2PackedStorage.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.5.16/dynamic_2.sol#1
+It is used by:
+	- >=0.5.0<0.6.0 (tests/e2e/detectors/test_data/solc-version/0.5.16/dynamic_2.sol#1)
 
 solc-0.5.16 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_5_16_static_sol__0.txt
@@ -11,8 +11,8 @@ Version constraint 0.5.16 contains known severe issues (https://solidity.readthe
 	- TupleAssignmentMultiStackSlotComponents
 	- MemoryArrayCreationOverflow
 	- privateCanBeOverridden.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.5.16/static.sol#1
+It is used by:
+	- 0.5.16 (tests/e2e/detectors/test_data/solc-version/0.5.16/static.sol#1)
 
 solc-0.5.16 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_10_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_10_static_sol__0.txt
@@ -12,6 +12,6 @@ Version constraint 0.6.10 contains known severe issues (https://solidity.readthe
 	- KeccakCaching
 	- EmptyByteArrayCopy
 	- DynamicArrayCleanup.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.6.10/static.sol#1
+It is used by:
+	- 0.6.10 (tests/e2e/detectors/test_data/solc-version/0.6.10/static.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_dynamic_1_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_dynamic_1_sol__0.txt
@@ -10,8 +10,8 @@ Version constraint ^0.6.10 contains known severe issues (https://solidity.readth
 	- KeccakCaching
 	- EmptyByteArrayCopy
 	- DynamicArrayCleanup.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.6.11/dynamic_1.sol#1
+It is used by:
+	- ^0.6.10 (tests/e2e/detectors/test_data/solc-version/0.6.11/dynamic_1.sol#1)
 
 solc-0.6.11 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_dynamic_2_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_dynamic_2_sol__0.txt
@@ -12,8 +12,8 @@ Version constraint >=0.6.0<0.7.0 contains known severe issues (https://solidity.
 	- TupleAssignmentMultiStackSlotComponents
 	- MemoryArrayCreationOverflow
 	- YulOptimizerRedundantAssignmentBreakContinue.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.6.11/dynamic_2.sol#1
+It is used by:
+	- >=0.6.0<0.7.0 (tests/e2e/detectors/test_data/solc-version/0.6.11/dynamic_2.sol#1)
 
 solc-0.6.11 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_6_11_static_sol__0.txt
@@ -10,8 +10,8 @@ Version constraint 0.6.11 contains known severe issues (https://solidity.readthe
 	- KeccakCaching
 	- EmptyByteArrayCopy
 	- DynamicArrayCleanup.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.6.11/static.sol#1
+It is used by:
+	- 0.6.11 (tests/e2e/detectors/test_data/solc-version/0.6.11/static.sol#1)
 
 solc-0.6.11 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_4_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_4_static_sol__0.txt
@@ -1,3 +1,5 @@
+solc-0.7.4 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
+
 Version constraint 0.7.4 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
 	- FullInlinerNonExpressionSplitArgumentEvaluationOrder
 	- MissingSideEffectsOnSelectorAccess
@@ -8,8 +10,6 @@ Version constraint 0.7.4 contains known severe issues (https://solidity.readthed
 	- SignedImmutables
 	- ABIDecodeTwoDimensionalArrayMemory
 	- KeccakCaching.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.7.4/static.sol#1
-
-solc-0.7.4 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
+It is used by:
+	- 0.7.4 (tests/e2e/detectors/test_data/solc-version/0.7.4/static.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_dynamic_1_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_dynamic_1_sol__0.txt
@@ -1,5 +1,3 @@
-solc-0.7.6 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
-
 Version constraint ^0.7.4 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
 	- FullInlinerNonExpressionSplitArgumentEvaluationOrder
 	- MissingSideEffectsOnSelectorAccess
@@ -10,6 +8,8 @@ Version constraint ^0.7.4 contains known severe issues (https://solidity.readthe
 	- SignedImmutables
 	- ABIDecodeTwoDimensionalArrayMemory
 	- KeccakCaching.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.7.6/dynamic_1.sol#1
+It is used by:
+	- ^0.7.4 (tests/e2e/detectors/test_data/solc-version/0.7.6/dynamic_1.sol#1)
+
+solc-0.7.6 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_dynamic_2_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_dynamic_2_sol__0.txt
@@ -1,6 +1,6 @@
-Version constraint >=0.7.0<=0.7.6 is too complex.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.7.6/dynamic_2.sol#1
-
 solc-0.7.6 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
+
+Version constraint >=0.7.0<=0.7.6 is too complex.
+It is used by:
+	- >=0.7.0<=0.7.6 (tests/e2e/detectors/test_data/solc-version/0.7.6/dynamic_2.sol#1)
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_static_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_IncorrectSolc_0_7_6_static_sol__0.txt
@@ -1,5 +1,3 @@
-solc-0.7.6 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
-
 Version constraint 0.7.6 contains known severe issues (https://solidity.readthedocs.io/en/latest/bugs.html)
 	- FullInlinerNonExpressionSplitArgumentEvaluationOrder
 	- MissingSideEffectsOnSelectorAccess
@@ -10,6 +8,8 @@ Version constraint 0.7.6 contains known severe issues (https://solidity.readthed
 	- SignedImmutables
 	- ABIDecodeTwoDimensionalArrayMemory
 	- KeccakCaching.
- It is used by:
-	- tests/e2e/detectors/test_data/solc-version/0.7.6/static.sol#1
+It is used by:
+	- 0.7.6 (tests/e2e/detectors/test_data/solc-version/0.7.6/static.sol#1)
+
+solc-0.7.6 is an outdated solc version. Use a more recent version (at least 0.8.0), if possible.
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_UnusedImport_0_8_16_C_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_UnusedImport_0_8_16_C_sol__0.txt
@@ -1,6 +1,6 @@
-The following unused import(s) in tests/e2e/detectors/test_data/unused-imports/0.8.16/B.sol should be removed: 
-	-import "./A.sol"; (tests/e2e/detectors/test_data/unused-imports/0.8.16/B.sol#4)
-
-The following unused import(s) in tests/e2e/detectors/test_data/unused-imports/0.8.16/C.sol should be removed: 
+The following unused import(s) in tests/e2e/detectors/test_data/unused-imports/0.8.16/C.sol should be removed:
 	-import "./B.sol"; (tests/e2e/detectors/test_data/unused-imports/0.8.16/C.sol#4)
+
+The following unused import(s) in tests/e2e/detectors/test_data/unused-imports/0.8.16/B.sol should be removed:
+	-import "./A.sol"; (tests/e2e/detectors/test_data/unused-imports/0.8.16/B.sol#4)
 


### PR DESCRIPTION
closes https://github.com/crytic/slither/issues/2415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling and output formatting of Solidity pragma directives by version.
  - Enhanced detection logic for disallowed pragma versions.

- **New Features**
  - Added functionality to handle import containers in unused import detection.

- **Tests**
  - Updated test data and snapshots to reflect new formatting and version constraints for Solidity pragmas.
  - Improved test messages for outdated Solidity versions, recommending updates to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->