### PR TITLE
Dockerfile: fix `ckzg` build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:jammy AS python-wheels
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     gcc \
     git \
+    make \
     python3-dev \
     python3-pip \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Building `ckzg` requires `make` to be present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the `make` package installation in the Dockerfile to enhance build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->