### PR TITLE
Added length check on `bugs_by_version` for specific `version_number`

### DIFF
--- a/slither/detectors/attributes/incorrect_solc.py
+++ b/slither/detectors/attributes/incorrect_solc.py
@@ -71,7 +71,7 @@ Consider using the latest version of Solidity for testing."""
         if op and op not in [">", ">=", "^"]:
             return self.LESS_THAN_TXT
         version_number = ".".join(version[2:])
-        if version_number in bugs_by_version:
+        if version_number in bugs_by_version and len(bugs_by_version[version_number]):
             bugs = "\n".join([f"\t- {bug}" for bug in bugs_by_version[version_number]])
             return self.BUGGY_VERSION_TXT + f"\n{bugs}"
         return None


### PR DESCRIPTION
## Description:

The `incorrect_sol` detector previously checked for known issues using the condition `if version_number in bugs_by_version`. This approach did not account for cases where the list of issues for a given version was empty, leading to false positives.

Updated the _check_version method to include a check for non-empty issue lists:
```
if version_number in bugs_by_version and len(bugs_by_version[version_number]):
```

Resolves #2478 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved version check to accurately detect and handle buggy versions, ensuring more reliable feedback on potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->