### PR TITLE
Must depend on Analysis

### DIFF
--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -332,7 +332,7 @@ def compute_must_dependencies(v: SUPPORTED_TYPES) -> Set[Variable]:
         lvalue = lvalue_details[0]
         ir = lvalue_details[2]
 
-        if not lvalue in function_dependencies["context"]:
+        if lvalue not in function_dependencies["context"]:
             function_dependencies["context"][lvalue] = set()
         read: Union[List[Union[LVALUE, SolidityVariableComposed]], List[SlithIRVariable]]
 
@@ -348,11 +348,7 @@ def compute_must_dependencies(v: SUPPORTED_TYPES) -> Set[Variable]:
     function_dependencies["context"] = convert_to_non_ssa(function_dependencies["context"])
 
     must_dependencies = set()
-    data_dependencies = (
-        list(function_dependencies["context"][v])
-        if function_dependencies["context"] is not None
-        else []
-    )
+    data_dependencies = list(function_dependencies["context"].get(v, set()))
     for i, data_dependency in enumerate(data_dependencies):
         result = compute_must_dependencies(data_dependency)
         if i > 0:

--- a/tests/unit/core/test_data/must_depend_on.sol
+++ b/tests/unit/core/test_data/must_depend_on.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.19;
 
 interface IERC20 {
@@ -21,7 +22,7 @@ contract Unsafe {
     // This is not detected
     function bad2(address from, address to, uint256 am) public {
         address from_msgsender = msg.sender;
-        int_transferFrom(from_msgsender, to, amount); // from is not a constant
+        int_transferFrom(from_msgsender, to, am); // from is not a constant
     }
 
     function int_transferFrom(address from, address to, uint256 amount) internal {

--- a/tests/unit/core/test_must_depend_on.py
+++ b/tests/unit/core/test_must_depend_on.py
@@ -1,12 +1,11 @@
 from pathlib import Path
+from typing import Union
+
 from slither import Slither
 from slither.analyses.data_dependency.data_dependency import get_must_depends_on
-from slither.core.variables.variable import Variable
 from slither.core.declarations import SolidityVariable, SolidityVariableComposed
-from typing import Union
-from slither.slithir.variables import (
-    Constant,
-)
+from slither.core.variables.variable import Variable
+from slither.slithir.variables import Constant
 
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 SUPPORTED_TYPES = Union[Variable, SolidityVariable, Constant]
@@ -19,7 +18,7 @@ def test_must_depend_on_returns(solc_binary_path):
 
     for contract in slither_obj.contracts:
         for function in contract.functions:
-            if contract == "Unsafe" and function == "int_transferFrom":
+            if contract.name == "Unsafe" and function.name == "int_transferFrom":
                 result = get_must_depends_on(function.parameters[0])
                 break
     assert isinstance(result, list)


### PR DESCRIPTION
This implements #175 . 

Linter and reformatter ran locally.

Brief analysis description:

1.  Given a target variable, infer its dependencies within the function
2. Then for each such dependencies, take the intersection of the original variables that resulted in those dependencies
3. Stop when we find public/external function parameters, constants, and solidity variable as origin variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to determine and compute must dependencies for variables in smart contracts.

- **Tests**
  - Added tests to validate the new must dependency features, ensuring correct behavior and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->