### PR TITLE
Enable running slither as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: slither
+  name: Slither
+  description: Run Slither on your project
+  entry: slither .
+  pass_filenames: false
+  language: python
+  files: \.sol$

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ docker run -it -v /home/share:/share trailofbits/eth-security-toolbox
 ### Integration
 
 * For GitHub action integration, use [slither-action](https://github.com/marketplace/actions/slither-action).
+* For pre-commit integratio, use (replace `$GIT_TAG` with real tag)
+  ```
+  - repo: https://github.com/crytic/slither
+    rev: $GIT_TAG
+    hooks:
+      - slither
+  ```
 * To generate a Markdown report, use `slither [target] --checklist`.
 * To generate a Markdown with GitHub source code highlighting, use `slither [target] --checklist --markdown-root https://github.com/ORG/REPO/blob/COMMIT/` (replace `ORG`, `REPO`, `COMMIT`)
 


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) became pretty popular as framework to combine linters / code-formatters via [hooks](https://pre-commit.com/hooks.html) across different languages. It can be enabled as actual git hook or just used by running `pre-commit run -a`. pre-commit does its own dependency management and uses virtual envs for the Python hooks (= no need to put linters requirements*.txt files for Python projects)

This adds a `.pre-commit-hooks.yaml`, which allows other projects to run slither via pre-commit.

Tested it in my fork with custom test tag, see https://github.com/dbast/sol-press/pull/10