### PR TITLE
Reduce the number of CI tests on PR

### DIFF
--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -5,14 +5,12 @@ defaults:
   run:
     shell: bash
 
-# We run all the CI tests only on cron job
-# This is to reduce the CI time, and prevent issues
-# Like with the etherscan API
-# All the test from ci_pr are run here + additional ones
 on:
-  schedule:
-    # run CI every day even if no PRs/merges occur
-    - cron: '0 12 * * *'
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,21 +24,14 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-2022"]
         python: ${{ (github.event_name == 'pull_request' && fromJSON('["3.8", "3.12"]')) || fromJSON('["3.8", "3.9", "3.10", "3.11", "3.12"]') }}
-        type: ["cli",
-               "dapp",
-               "data_dependency",
+        type: ["data_dependency",
                "path_filtering",
                "erc",
-               "etherscan",
                "find_paths",
                "flat",
                "interface",
-               "kspec",
                "printers",
-               # "prop"
-               "simil",
                "slither_config",
-               "truffle",
                "upgradability"]
         exclude:
           # Requires nix

--- a/.github/workflows/ci_pr.yml
+++ b/.github/workflows/ci_pr.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-2022"]
+        os: ["ubuntu-latest"] # Do not run on windows to save time. In practice not many users are on windows, and this is still run on the cron job
         python: ${{ (github.event_name == 'pull_request' && fromJSON('["3.8", "3.12"]')) || fromJSON('["3.8", "3.9", "3.10", "3.11", "3.12"]') }}
         type: ["data_dependency",
                "path_filtering",


### PR DESCRIPTION
Everything is still run on a daily basis with cron, but this PR remove unecessary/problematic CI checks on every PR