### PR TITLE
Updated slither-mutate logs

### DIFF
--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -177,7 +177,7 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
     # get all the contracts as a list from given codebase
     sol_file_list: List[str] = get_sol_file_list(Path(args.codebase), paths_to_ignore_list)
 
-    logger.info(blue("Preparing to mutate files:\n- " + '\n- '.join(sol_file_list)))
+    logger.info(blue("Preparing to mutate files:\n- " + "\n- ".join(sol_file_list)))
 
     # folder where backup files and uncaught mutants are saved
     if output_dir is None:

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -165,6 +165,9 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
 
     logger.info(blue(f"Starting mutation campaign in {args.codebase}"))
 
+    if very_verbose: # very_verbose should always be a superset of verbose logs
+        verbose = True
+
     if paths_to_ignore:
         paths_to_ignore_list = paths_to_ignore.strip("][").split(",")
     else:

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -167,7 +167,6 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
 
     if paths_to_ignore:
         paths_to_ignore_list = paths_to_ignore.strip("][").split(",")
-        logger.info(blue(f"Ignored paths - {', '.join(paths_to_ignore_list)}"))
     else:
         paths_to_ignore_list = []
 
@@ -177,6 +176,8 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
 
     # get all the contracts as a list from given codebase
     sol_file_list: List[str] = get_sol_file_list(Path(args.codebase), paths_to_ignore_list)
+
+    logger.info(blue("Preparing to mutate files:\n- " + '\n- '.join(sol_file_list)))
 
     # folder where backup files and uncaught mutants are saved
     if output_dir is None:
@@ -247,9 +248,11 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
         # lines those need not be mutated (taken from RR and CR)
         dont_mutate_lines = []
 
-        # mutation
+        # perform mutations on {target_contract} in file {file_name}
+        # setup placeholder val to signal whether we need to skip if no target_contract is found
         target_contract = "SLITHER_SKIP_MUTATIONS" if contract_names else ""
         try:
+            # loop through all contracts in file_name
             for compilation_unit_of_main_file in sl.compilation_units:
                 for contract in compilation_unit_of_main_file.contracts:
                     if contract.name in contract_names and contract.name not in mutated_contracts:

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -77,15 +77,6 @@ def parse_args() -> argparse.Namespace:
         default=False,
     )
 
-    # to print just all the mutants
-    parser.add_argument(
-        "-vv",
-        "--very-verbose",
-        help="log mutants that are caught, uncaught, and fail to compile. And more!",
-        action="store_true",
-        default=False,
-    )
-
     # select list of mutators to run
     parser.add_argument(
         "--mutators-to-run",
@@ -159,14 +150,10 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
     timeout: Optional[int] = args.timeout
     solc_remappings: Optional[str] = args.solc_remaps
     verbose: Optional[bool] = args.verbose
-    very_verbose: Optional[bool] = args.very_verbose
     mutators_to_run: Optional[List[str]] = args.mutators_to_run
     comprehensive_flag: Optional[bool] = args.comprehensive
 
     logger.info(blue(f"Starting mutation campaign in {args.codebase}"))
-
-    if very_verbose: # very_verbose should always be a superset of verbose logs
-        verbose = True
 
     if paths_to_ignore:
         paths_to_ignore_list = paths_to_ignore.strip("][").split(",")
@@ -293,7 +280,6 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
                         target_contract,
                         solc_remappings,
                         verbose,
-                        very_verbose,
                         output_folder,
                         dont_mutate_lines,
                     )
@@ -378,8 +364,6 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
             logger.info(magenta("Zero Tweak mutants analyzed\n"))
 
         # Reset mutant counts before moving on to the next file
-        if very_verbose:
-            logger.info(blue("Reseting mutant counts to zero"))
         total_mutant_counts[0] = 0
         total_mutant_counts[1] = 0
         total_mutant_counts[2] = 0

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -29,7 +29,6 @@ class AbstractMutator(
         contract_instance: Contract,
         solc_remappings: Union[str, None],
         verbose: bool,
-        very_verbose: bool,
         output_folder: Path,
         dont_mutate_line: List[int],
         rate: int = 10,
@@ -44,7 +43,6 @@ class AbstractMutator(
         self.timeout = timeout
         self.solc_remappings = solc_remappings
         self.verbose = verbose
-        self.very_verbose = very_verbose
         self.output_folder = output_folder
         self.contract = contract_instance
         self.in_file = self.contract.source_mapping.filename.absolute
@@ -98,7 +96,6 @@ class AbstractMutator(
                     self.timeout,
                     self.solc_remappings,
                     self.verbose,
-                    self.very_verbose,
                 )
 
                 # count the uncaught mutants, flag RR/CR mutants to skip further mutations
@@ -131,19 +128,5 @@ class AbstractMutator(
                         self.total_mutant_counts[1] += 1
                     else:
                         self.total_mutant_counts[2] += 1
-
-                if self.very_verbose:
-                    if self.NAME == "RR":
-                        logger.info(
-                            f"Found {self.uncaught_mutant_counts[0]} uncaught revert mutants so far (out of {self.total_mutant_counts[0]} that compile)"
-                        )
-                    elif self.NAME == "CR":
-                        logger.info(
-                            f"Found {self.uncaught_mutant_counts[1]} uncaught comment mutants so far (out of {self.total_mutant_counts[1]} that compile)"
-                        )
-                    else:
-                        logger.info(
-                            f"Found {self.uncaught_mutant_counts[2]} uncaught tweak mutants so far (out of {self.total_mutant_counts[2]} that compile)"
-                        )
 
         return self.total_mutant_counts, self.uncaught_mutant_counts, self.dont_mutate_line

--- a/slither/tools/mutator/utils/testing_generated_mutant.py
+++ b/slither/tools/mutator/utils/testing_generated_mutant.py
@@ -91,7 +91,6 @@ def test_patch(  # pylint: disable=too-many-arguments
     timeout: int,
     mappings: Union[str, None],
     verbose: bool,
-    very_verbose: bool,
 ) -> int:
     """
     function to verify whether each patch is caught by tests
@@ -118,7 +117,7 @@ def test_patch(  # pylint: disable=too-many-arguments
 
             return 0  # uncaught
     else:
-        if very_verbose:
+        if verbose:
             logger.info(
                 yellow(
                     f"[{generator_name}] Line {patch['line_number']}: '{patch['old_string']}' ==> '{patch['new_string']}' --> COMPILATION FAILURE"


### PR DESCRIPTION
Mutation campaigns take a long time, it's a bummer if we get an hour into it and then realize we're mutating the wrong set of files. We used to log a list of ignored files, but that gives us incomplete info. With this change, we instead log the list of files that are going to be mutated (ie walk the given `codebase` and remove anything in the `paths_to_ignore_list`)