### PR TITLE
Fix are_variables_written analysis for named return variables

### DIFF
--- a/slither/analyses/write/are_variables_written.py
+++ b/slither/analyses/write/are_variables_written.py
@@ -86,7 +86,7 @@ def _visit(
             lvalue = refs_lvalues
 
     ret: List[Variable] = []
-    if not node.sons and node.type not in [NodeType.THROW, NodeType.RETURN]:
+    if not node.sons and node.type is not NodeType.THROW:
         ret += [v for v in variables_to_write if v not in variables_written]
 
     # Explore sons if


### PR DESCRIPTION
When a return variable is named it could appear only in the RETURN node hence we should also consider the variables there