### PR TITLE
Typo fix  README.md

### DIFF
--- a/slither/tools/documentation/README.md
+++ b/slither/tools/documentation/README.md
@@ -1,5 +1,5 @@
 # slither-documentation
 
-`slither-documentation` uses [codex](https://platform.openai.com) to generate natspec documenation.
+`slither-documentation` uses [codex](https://platform.openai.com) to generate natspec documentation.
 
 This tool is experimental. See [solmate documentation](https://github.com/montyly/solmate/pull/1) for an example of usage.


### PR DESCRIPTION
Changed "documenation" to "documentation" for accurate spelling.