### PR TITLE
slither-mutate: fix AOR mutator

### DIFF
--- a/slither/tools/mutator/README.md
+++ b/slither/tools/mutator/README.md
@@ -33,8 +33,7 @@ options:
   --timeout TIMEOUT     Set timeout for test command (by default 30 seconds)
   --output-dir OUTPUT_DIR
                         Name of output directory (by default 'mutation_campaign')
-  -v, --verbose         log mutants that are caught as well as those that are uncaught
-  -vv, --very-verbose   log mutants that are caught, uncaught, and fail to compile. And more!
+  -v, --verbose         log mutants that are caught, uncaught, and fail to compile
   --mutators-to-run MUTATORS_TO_RUN
                         mutant generators to run
   --contract-names CONTRACT_NAMES

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -72,7 +72,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-v",
         "--verbose",
-        help="log mutants that are caught as well as those that are uncaught",
+        help="log mutants that are caught, uncaught, and fail to compile",
         action="store_true",
         default=False,
     )

--- a/slither/tools/mutator/mutators/AOR.py
+++ b/slither/tools/mutator/mutators/AOR.py
@@ -2,12 +2,9 @@ from typing import Dict
 from slither.slithir.operations import Binary, BinaryType
 from slither.tools.mutator.utils.patch import create_patch_with_line
 from slither.tools.mutator.mutators.abstract_mutator import AbstractMutator
-from slither.core.variables.variable import Variable
 from slither.core.expressions.unary_operation import UnaryOperation
 from slither.core.expressions.call_expression import CallExpression
 from slither.core.expressions.member_access import MemberAccess
-from slither.core.expressions.identifier import Identifier
-from slither.core.solidity_types.array_type import ArrayType
 
 arithmetic_operators = [
     BinaryType.ADDITION,
@@ -42,9 +39,6 @@ class AOR(AbstractMutator):  # pylint: disable=too-few-public-methods
                     isinstance(ir_expression, CallExpression)
                     and isinstance(ir_expression.called, MemberAccess)
                     and ir_expression.called.member_name == "pop"
-                    and isinstance(ir_expression.called.expression, Identifier)
-                    and isinstance(ir_expression.called.expression.value, Variable)
-                    and isinstance(ir_expression.called.expression.value.type, ArrayType)
                 ):
                     continue
 
@@ -58,9 +52,6 @@ class AOR(AbstractMutator):  # pylint: disable=too-few-public-methods
                     if isinstance(ir_expression, CallExpression)
                     and isinstance(ir_expression.called, MemberAccess)
                     and ir_expression.called.member_name == "push"
-                    and isinstance(ir_expression.called.expression, Identifier)
-                    and isinstance(ir_expression.called.expression.value, Variable)
-                    and isinstance(ir_expression.called.expression.value.type, ArrayType)
                     else node.irs
                 )
 


### PR DESCRIPTION
Before the AOR mutator could crash when an array was accessed through multi levels such as as a value of a mapping because the `ir_expression.called.expression` would be an Index operator. Removing the specific checks on the `Identifier` being an `ArrayType` make it works for all the possible cases with no practical downsides, maybe it could be a problem if there is a library with custom functions called `pop` and `push` used with the using-for directive
```
contract Counter {
    mapping(uint => uint[]) p;

    function s() public {
       p[1].push(2);
   }
}
```
