### PR TITLE
remap offsets from bytes to chars during source map conversion

### DIFF
--- a/slither/core/source_mapping/source_mapping.py
+++ b/slither/core/source_mapping/source_mapping.py
@@ -150,9 +150,10 @@ def _compute_line(
     return list(range(start_line, end_line + 1)), starting_column, ending_column
 
 
+# pylint: disable=too-many-locals
 def _convert_source_mapping(
     offset: str, compilation_unit: "SlitherCompilationUnit"
-) -> Source:  # pylint: disable=too-many-locals
+) -> Source:
     """
     Convert a text offset to a real offset
     see https://solidity.readthedocs.io/en/develop/miscellaneous.html#source-mappings
@@ -186,11 +187,15 @@ def _convert_source_mapping(
     filename: Filename = compilation_unit.core.crytic_compile.filename_lookup(filename_used)
     is_dependency = compilation_unit.core.crytic_compile.is_dependency(filename.absolute)
 
-    # convert byte-offset indicies to char-offset
-    source_code = compilation_unit.core.source_code[filename.absolute]
-    s = int(len(source_code.encode("utf-8")[:s_bytes].decode("utf-8")))
-    l = int(len(source_code.encode("utf-8")[s_bytes : s_bytes + l_bytes].decode("utf-8")))
-    f = int(f)
+    if filename.absolute in compilation_unit.core.source_code:
+        # convert byte-offset indicies to char-offset
+        source_code = compilation_unit.core.source_code[filename.absolute]
+        s = int(len(source_code.encode("utf-8")[:s_bytes].decode("utf-8")))
+        l = int(len(source_code.encode("utf-8")[s_bytes : s_bytes + l_bytes].decode("utf-8")))
+    else:
+        # no source code is available, hopefully the source code doesn't contain unicode
+        s = int(s_bytes)
+        l = int(l_bytes)
 
     (lines, starting_column, ending_column) = _compute_line(compilation_unit, filename, s, l)
 


### PR DESCRIPTION
Remaps byte offsets to char offsets in the `_convert_source_mapping` method of the `Source` class.

This method now:
- uses utf-8 encoding to convert the source code string to a bytes array
- applies the byte offsets
- decodes back to a normal string
- uses the length of the resulting string to determine new char-denominated offsets

Assumptions:
- this method is only ever used to ingest output from the solc compiler, which [infamously](https://github.com/ethereum/solidity/issues/14733) outputs byte-denominated src map offsets.
- other platforms (eg foundry, hardhat) already provide char-denominated src map offsets

Problem: `if f not in sourceUnits` then we don't have reliable access to the source filename or code so we can't use the aforementioned method to convert to byte offsets. It's not clear to me when or why this logic branch would be taken, however.