### PR TITLE
Fix slither-read-storage crash when a structure has only other structs as fields

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -578,6 +578,7 @@ class SlitherReadStorage:
         slot = int.from_bytes(slot_as_bytes, "big")
         offset = 0
         type_to = ""
+        size = 0
         for var in elems:
             var_type = var.type
             if isinstance(var_type, ElementaryType):


### PR DESCRIPTION
Fix a crash when a struct has only other structs. The `size` variable would not be initialized.
```solidity
contract T {
  struct A {
   uint256 value;
  }

  struct T {
   A _inner;
  }

  T _t;
}
```
```
  File ".../slither/tools/read_storage/read_storage.py", line 597, in _find_struct_var_slot
    return info, type_to, slot_as_bytes, size, offset
                                         ^^^^
UnboundLocalError: cannot access local variable 'size' where it is not associated with a value
```