### PR TITLE
slither-mutate: Check if a contract is an interface properly

### DIFF
--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -265,9 +265,7 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
                 if target_contract == skip_flag:
                     continue
 
-                # TODO: find a more specific way to omit interfaces
-                # Ideally, we wouldn't depend on naming conventions
-                if target_contract.name.startswith("I"):
+                if target_contract.is_interface:
                     logger.debug(f"Skipping mutations on interface {filename}")
                     continue
 

--- a/slither/tools/mutator/mutators/LIR.py
+++ b/slither/tools/mutator/mutators/LIR.py
@@ -10,7 +10,7 @@ literal_replacements = []
 
 class LIR(AbstractMutator):  # pylint: disable=too-few-public-methods
     NAME = "LIR"
-    HELP = "Literal Interger Replacement"
+    HELP = "Literal Integer Replacement"
 
     def _mutate(self) -> Dict:  # pylint: disable=too-many-branches
         result: Dict = {}


### PR DESCRIPTION
Small improvement to slither-mutate by checking if a contract is an interface properly and not relying on naming convention