### PR TITLE
Fix the dependency issue when using SSA variables

### DIFF
--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -460,7 +460,7 @@ def compute_dependency_function(function: Function) -> None:
                 unset_local_ir_vars[ir.lvalue] = False
                 add_dependency(ir.lvalue, function, ir, is_protected)
 
-    # If an SSA locl IR variable is read but never written to,, 
+    # If an SSA locl IR variable is read but never written to,,
     # and it is from a parameter, we should add a dependency edge from the variable to the parameter
     for node in function.nodes:
         for ir in node.irs_ssa:

--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -440,17 +440,45 @@ def compute_dependency_function(function: Function) -> None:
     function.context[KEY_SSA] = {}
     function.context[KEY_SSA_UNPROTECTED] = {}
 
+    unset_local_ir_vars = {}
+
     is_protected = function.is_protected()
     for node in function.nodes:
         for ir in node.irs_ssa:
+            for v in ir.used:
+                if isinstance(v, LocalIRVariable):
+                    if v not in unset_local_ir_vars:
+                        unset_local_ir_vars[v] = True
             if isinstance(ir, OperationWithLValue) and ir.lvalue:
                 if isinstance(ir.lvalue, LocalIRVariable) and ir.lvalue.is_storage:
                     continue
                 if isinstance(ir.lvalue, ReferenceVariable):
                     lvalue = ir.lvalue.points_to
                     if lvalue:
+                        unset_local_ir_vars[lvalue] = False
                         add_dependency(lvalue, function, ir, is_protected)
+                unset_local_ir_vars[ir.lvalue] = False
                 add_dependency(ir.lvalue, function, ir, is_protected)
+
+    # If an SSA locl IR variable is read but never written to,, 
+    # and it is from a parameter, we should add a dependency edge from the variable to the parameter
+    for node in function.nodes:
+        for ir in node.irs_ssa:
+            for v in ir.used:
+                # We need to make sure that this variable is never used as lvalue
+                if isinstance(v, LocalIRVariable) and unset_local_ir_vars.get(v):
+                    # We need to check the parameter
+                    for param_ssa in function.parameters_ssa:
+                        if v.non_ssa_version == param_ssa.non_ssa_version:
+                            if v not in function.context[KEY_SSA]:
+                                function.context[KEY_SSA][v] = set()
+                            function.context[KEY_SSA][v].add(param_ssa)
+                            if not is_protected:
+                                if v not in function.context[KEY_SSA_UNPROTECTED]:
+                                    function.context[KEY_SSA_UNPROTECTED][v] = set()
+                                function.context[KEY_SSA_UNPROTECTED][v].add(param_ssa)
+                                unset_local_ir_vars[param_ssa] = False
+                                break
 
     function.context[KEY_NON_SSA] = convert_to_non_ssa(function.context[KEY_SSA])
     function.context[KEY_NON_SSA_UNPROTECTED] = convert_to_non_ssa(

--- a/tests/unit/analyses/test_data/parameter_dependency_ssa.sol
+++ b/tests/unit/analyses/test_data/parameter_dependency_ssa.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.8.24;
+
+contract TSURUWrapper{
+    bool private _opened = false;
+    address public immutable erc721Contract;
+    uint256 public constant _maxTotalSupply = 431_386_000 * 1e18;
+    uint256 private constant ERC721_RATIO = 400 * 1e18;
+    mapping(address owner => uint256) private _balancesOfOwner;
+    uint256 private _holders;
+    uint256 private _totalSupply;
+    function totalSupply() public view virtual returns (uint256) {
+        return _totalSupply;
+    }
+    function onERC721Received(
+        address,
+        address from,
+        uint256,
+        bytes calldata
+    ) external returns (bytes4) {
+        require(_opened, "Already yet open.");
+        require(msg.sender == address(erc721Contract), "Unauthorized token");
+        _safeMint(from, ERC721_RATIO); // Adjust minting based on the ERC721_RATIO
+        return this.onERC721Received.selector;
+    }
+
+    function _safeMint(address account, uint256 value) internal {
+        require(_maxTotalSupply > totalSupply() + value, "Max supply exceeded.");
+
+        // _mint(account, value);
+        
+        if (_balancesOfOwner[account] == 0) {
+            ++_holders;
+        }
+        _balancesOfOwner[account] = _balancesOfOwner[account] + value;
+    }
+}

--- a/tests/unit/analyses/test_data_dependencies.py
+++ b/tests/unit/analyses/test_data_dependencies.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from slither import Slither
+from slither.analyses.data_dependency.data_dependency import is_dependent_ssa
+from slither.slithir.variables import LocalIRVariable
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+
+def test_param_dependency(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.24")
+    slither = Slither(
+        Path(TEST_DATA_DIR, "parameter_dependency_ssa.sol").as_posix(), solc=solc_path
+    )
+
+    target_function = slither.contracts[0].get_function_from_signature(
+        "onERC721Received(address,address,uint256,bytes)"
+    )
+
+    # Param is from (from_0 in SSA)
+    # Local SSA variable is from_1
+
+    param_var = None
+
+    for param_ssa in target_function.parameters_ssa:
+        if param_ssa.non_ssa_version.name == "from":
+            param_var = param_ssa
+            break
+
+    assert param_var is not None, "Param variable not found in SSA"
+
+    local_var = None
+    for ir in target_function.slithir_ssa_operations:
+        for v in ir.used:
+            if isinstance(v, LocalIRVariable) and v.non_ssa_version.name == "from" and v.index == 1:
+                local_var = v
+                break
+
+    assert local_var is not None, "Local variable not found in SSA"
+
+    assert is_dependent_ssa(
+        local_var, param_var, target_function
+    ), "Param and local variable are not dependent"


### PR DESCRIPTION
## What is happening in the previous version

```solidity
function onERC721Received(
      address,
      address from,
      uint256,
      bytes calldata
  ) external returns (bytes4) {
      require(_opened, "Already yet open.");
      require(msg.sender == address(erc721Contract), "Unauthorized token");
      _safeMint(from, ERC721_RATIO); // Adjust minting based on the ERC721_RATIO
      return this.onERC721Received.selector;
}
```

If I'm using Slither to analyze the above code, the SSA variables will be generated for the parameter `from` in `slither/slithir/utils/ssa.py` line 127-135 and 162-172:

```solidity
init_definition = {}
    for v in function.parameters:
        if v.name:
            init_definition[v.name] = (v, function.entry_point)
            function.entry_point.add_ssa_ir(Phi(LocalIRVariable(v), set()))

    for v in function.returns:
        if v.name:
            init_definition[v.name] = (v, function.entry_point)
```

```solidity 
for v in function.parameters:
    if v.name:
        new_var = LocalIRVariable(v)
        function.add_parameter_ssa(new_var)
        if new_var.is_storage:
            fake_variable = LocalIRVariable(v)
            fake_variable.name = "STORAGE_" + fake_variable.name
            fake_variable.set_location("reference_to_storage")
            new_var.refers_to = {fake_variable}
            init_local_variables_instances[fake_variable.name] = fake_variable
        init_local_variables_instances[v.name] = new_var
```

In this case, even a parameter is never written in a function, it will have two SSA variable, one is for the parameter (in the given case is `from_0`), and another for the usage (`from_1`).

When building the data dependency of SSA variables in `slither/analyses/data_dependency/data_dependency.py`, function `compute_dependency_function`, it will not consider such dependency. So `from_1` will not have dependency with `from_0`, which is wrong.

## How I solved this

I added some code into `slither/analyses/data_dependency/data_dependency.py`, function `compute_dependency_function`. When a function is analyzed, I will record all the SSA variables that are never written (used as lvalue) but used (as rvalue). If these variables' non-ssa version is the same with parameters, I will add a dependency edge between them.

The new test case is provided a proof-of-concept. 