### PR TITLE
Fix arguments passed to `func` callable in `get_all_storage_variables`

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -397,7 +397,7 @@ class SlitherReadStorage:
         """
         for contract in self.contracts:
             for var in contract.state_variables_ordered:
-                if func(var):
+                if func((contract, var)):
                     if var.is_stored:
                         self._target_variables.append((contract, var))
                     elif (


### PR DESCRIPTION
Running `slither-read-storage` with the `--variable-name` argument results in an exception: `TypeError: 'StateVariable' object is not subscriptable`

Here is an example of reading the WETH balance for the Uniswap V4 PoolManager on mainnet:

```
(slither) btd@dev:~/code/slither_read_storage_fix$ slither-read-storage 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --variable-name balanceOf --key 0x000000000004444c
5dc75cB358380D2e3dE08A90 --value --rpc-url http://localhost:8545
Traceback (most recent call last):
  File "/home/btd/code/slither_read_storage_fix/.venv/bin/slither-read-storage", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/btd/code/slither_read_storage_fix/slither/tools/read_storage/__main__.py", line 156, in main
    srs.get_all_storage_variables(lambda x: bool(x[1].name == args.variable_name))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/btd/code/slither_read_storage_fix/slither/tools/read_storage/read_storage.py", line 400, in get_all_storage_variables
    if func(var):
       ~~~~^^^^^
  File "/home/btd/code/slither_read_storage_fix/slither/tools/read_storage/__main__.py", line 156, in <lambda>
    srs.get_all_storage_variables(lambda x: bool(x[1].name == args.variable_name))
                                                 ~^^^
TypeError: 'StateVariable' object is not subscriptable
```

The issue occurs because `func` is called within `read_storage.py` with a single argument `var`, but the lambda passed in the entrypoint expects a tuple:

```
if args.variable_name:
    # Use a lambda func to only return variables that have same name as target.
    # x is a tuple (`Contract`, `StateVariable`).
    srs.get_all_storage_variables(lambda x: bool(x[1].name == args.variable_name))
    srs.get_target_variables(**vars(args))
else:
    srs.get_all_storage_variables()
    srs.get_storage_layout()
```

This PR fixes the call by passing `(contract, var)` as the argument to `func`.

After fix:
```
(slither_read_storage_fix) btd@dev:~/code/slither_read_storage_fix$ slither-read-storage 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --variable-name balanceOf --key 0x000000000004444c5dc75cB358380D2e3dE08A90 --value --rpc-url http://localhost:8545
INFO:Slither-read-storage:
Contract 'WETH9'
WETH9.balanceOf with type mapping(address => uint256) is located at slot: 3

INFO:Slither-read-storage:
Key: 0x000000000004444c5dc75cB358380D2e3dE08A90
Name: balanceOf
Type: uint256
Slot: 11839838417408005300668405460519842744078024714876931848523103724423050260794

INFO:Slither-read-storage:
Value: 22412870153270317898
```