### PR TITLE
Add TypeAliasTopLevel support to `read_storage`

### DIFF
--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -13,7 +13,13 @@ from web3.exceptions import ExtraDataLengthError
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from slither.core.declarations import Contract, Structure
-from slither.core.solidity_types import ArrayType, ElementaryType, MappingType, UserDefinedType, TypeAliasTopLevel
+from slither.core.solidity_types import (
+    ArrayType,
+    ElementaryType,
+    MappingType,
+    UserDefinedType,
+    TypeAliasTopLevel,
+)
 from slither.core.solidity_types.type import Type
 from slither.core.cfg.node import NodeType
 from slither.core.variables.state_variable import StateVariable

--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -13,7 +13,7 @@ from web3.exceptions import ExtraDataLengthError
 from web3.middleware import ExtraDataToPOAMiddleware
 
 from slither.core.declarations import Contract, Structure
-from slither.core.solidity_types import ArrayType, ElementaryType, MappingType, UserDefinedType
+from slither.core.solidity_types import ArrayType, ElementaryType, MappingType, UserDefinedType, TypeAliasTopLevel
 from slither.core.solidity_types.type import Type
 from slither.core.cfg.node import NodeType
 from slither.core.variables.state_variable import StateVariable
@@ -581,8 +581,12 @@ class SlitherReadStorage:
         size = 0
         for var in elems:
             var_type = var.type
-            if isinstance(var_type, ElementaryType):
-                size = var_type.size
+            is_type_alias = isinstance(var_type, TypeAliasTopLevel)
+            if isinstance(var_type, ElementaryType) or is_type_alias:
+                if is_type_alias:
+                    size, _ = var_type.storage_size
+                else:
+                    size = var_type.size
                 if size > (256 - offset):
                     slot += 1
                     offset = 0

--- a/tests/tools/read-storage/test_data/typealiastest.sol
+++ b/tests/tools/read-storage/test_data/typealiastest.sol
@@ -1,0 +1,8 @@
+type MyUint64 is uint64;
+contract C {
+    struct S {
+        MyUint64 y;
+        MyUint64 z;
+    }
+    S s;
+}

--- a/tests/tools/read-storage/test_read_storage.py
+++ b/tests/tools/read-storage/test_read_storage.py
@@ -42,7 +42,10 @@ def deploy_contract(w3, ganache, contract_bin, contract_abi) -> Contract:
 # pylint: disable=too-many-locals
 @pytest.mark.parametrize(
     "test_contract, storage_file",
-    [("StorageLayout", "storage_layout"), ("UnstructuredStorageLayout", "unstructured_storage")],
+    [
+        ("StorageLayout", "storage_layout"),
+        ("UnstructuredStorageLayout", "unstructured_storage"),
+    ],
 )
 @pytest.mark.usefixtures("web3", "ganache")
 def test_read_storage(test_contract, storage_file, web3, ganache, solc_binary_path) -> None:
@@ -91,9 +94,9 @@ def test_read_storage(test_contract, storage_file, web3, ganache, solc_binary_pa
 
     assert not diff
 
+
 def test_type_alias() -> None:
-    """verify support for TypeAliasTop
-    """
+    """verify support for TypeAliasTop"""
     slither = Slither(Path(TEST_DATA_DIR, "typealiastest.sol").as_posix())
     c = slither.get_contract_from_name("C")
     srs = SlitherReadStorage(c, 20)

--- a/tests/tools/read-storage/test_read_storage.py
+++ b/tests/tools/read-storage/test_read_storage.py
@@ -90,3 +90,12 @@ def test_read_storage(test_contract, storage_file, web3, ganache, solc_binary_pa
                 f.write(str(change.t2))
 
     assert not diff
+
+def test_type_alias() -> None:
+    """verify support for TypeAliasTop
+    """
+    slither = Slither(Path(TEST_DATA_DIR, "typealiastest.sol").as_posix())
+    c = slither.get_contract_from_name("C")
+    srs = SlitherReadStorage(c, 20)
+    srs.get_all_storage_variables()
+    srs.get_storage_layout()


### PR DESCRIPTION
This PR addresses Issue #2522.

I use pre-existing fields of `TypeAliasTopLevel` to handle using `read_storage` on aliased `ElementaryType` instances, e.g.,
```
type MyUint64 is uint64;
contract C {
    struct S {
        MyUint64 y;
        MyUint64 z;
    }
    S s;
}
```
AFAICT, this doesn't cover user defined types, but it seems like the above reproducer can be addressed by attributes of the `TypeAliasTopLevel` class.

I couldn't get the test I added to run on my local machine, so I'll wait for the CI to run/if anyone has suggestions for changing things.