### PR TITLE
Fix #2747: Deduplicate functions in get_msg_sender_checks to avoid repeated msg.sender condition nodes

### DIFF
--- a/slither/printers/functions/authorization.py
+++ b/slither/printers/functions/authorization.py
@@ -18,7 +18,7 @@ class PrinterWrittenVariablesAndAuthorization(AbstractPrinter):
 
     @staticmethod
     def get_msg_sender_checks(function: Function) -> List[str]:
-        all_functions = (
+        all_functions = set(
             [
                 ir.function
                 for ir in function.all_internal_calls()


### PR DESCRIPTION
Fix: Deduplicate functions in get_msg_sender_checks to avoid repeated msg.sender condition nodes (#2747)

✅ Applied Fix (safe & immediate):
- Wraps the combined function list in a `set()` to deduplicate `Function` instances.
- Ensures complete analysis while avoiding repeated conditions in output.

⚠️ Alternative (riskier but potentially optimal):
- modifier functions are being included both via internal calls and explicitly in function.modifiers.
- Removing explicit `function.modifiers` in `all_functions` could also prevent duplicates,
  but risks missing edge cases where a modifier is attached but not present in internal calls.

The current fix ensures correctness, safety, and consistent analysis output.