### PR TITLE
Add Function module to detect functions returning msg.sender directly or via alias 

### DIFF
--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -217,6 +217,7 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
         self._solidity_signature: Optional[str] = None
         self._signature_str: Optional[str] = None
         self._canonical_name: Optional[str] = None
+        self._is_returning_msg_sender: Optional[bool] = None
         self._is_protected: Optional[bool] = None
 
         self.compilation_unit: "SlitherCompilationUnit" = compilation_unit
@@ -1528,6 +1529,83 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
     ) -> Tuple[str, str, str, List[str], List[str], List[str], List[str], List[str]]:
         pass
 
+    def is_returning_msg_sender(self) -> bool:
+        """
+            Determine if the function returns `msg.sender` directly or through aliased address variables.
+
+            This includes:
+            - Functions that explicitly returns `msg.sender`
+            - Functions that returns a variable which was directly or transitively assigned from `msg.sender`
+
+            Covers:
+                - Direct returns: 
+                    ```
+                    return msg.sender
+                    ```
+                - Aliased returns like:
+                    ```
+                    address a = msg.sender;
+                    return a;
+                    ```
+                - Reassignments or address conversions:
+                    ```
+                    address a = msg.sender;
+                    address b = address(uint160(a));
+                    return b;
+                    ```
+            Does not cover : 
+                - Returns via internal function calls, even if those functions return `msg.sender`: 
+                    ```
+                    function _getUser() internal view returns (address) {
+                            return _msgSender(); // _msgSender() returns msg.sender
+                    }
+                    ```
+
+        Returns
+            (bool)
+        """
+        from slither.core.solidity_types import ElementaryType
+        from slither.slithir.operations import Return, Assignment
+
+        if self._is_returning_msg_sender is None:
+
+            # Skip analysis if function doesn't return or doesn't return an address.
+            if not self.returns or not all(ret.type == ElementaryType('address') for ret in self.returns):
+                self._is_returning_msg_sender = False
+                return False
+    
+            return_vars = []
+            assignment_map = {}
+
+            for node in self.nodes:
+                for ir in node.irs:
+                    # Direct return of msg.sender
+                    if isinstance(ir, Return) :
+                        ir_return_vars =  [i.name for i in ir.values if hasattr(i, 'name')]
+                        if 'msg.sender' in ir_return_vars:
+                            self._is_returning_msg_sender = True
+                            return True
+                        return_vars.extend(ir_return_vars)
+
+                    # Track assignments where an address-typed variable is assigned from another variable.
+                    # This helps trace msg.sender aliases through reassignments.
+                    if isinstance(ir, Assignment) and ir.lvalue.type==ElementaryType('address'):
+                        if hasattr(ir.lvalue, 'name') and hasattr(ir.rvalue, 'name'):
+                            if ir.rvalue.name in assignment_map:
+                                assignment_map[ir.lvalue.name] = assignment_map[ir.rvalue.name]
+                            else:
+                                assignment_map[ir.lvalue.name] = ir.rvalue.name
+
+            for var in return_vars:
+                if var not in assignment_map:
+                    continue
+                var = assignment_map[var]
+                if var == 'msg.sender':
+                    self._is_returning_msg_sender = True
+                    return True 
+            self._is_returning_msg_sender = False
+        return self._is_returning_msg_sender
+    
     def is_protected(self) -> bool:
         """
             Determine if the function is protected using a check on msg.sender

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -1547,12 +1547,7 @@ class Function(SourceMapping, metaclass=ABCMeta):  # pylint: disable=too-many-pu
                     address a = msg.sender;
                     return a;
                     ```
-                - Reassignments or address conversions:
-                    ```
-                    address a = msg.sender;
-                    address b = address(uint160(a));
-                    return b;
-                    ```
+                    
             Does not cover : 
                 - Returns via internal function calls, even if those functions return `msg.sender`: 
                     ```


### PR DESCRIPTION
## Summary
This PR introduces a new method` is_returning_msg_sender()` in the `Function` class, enabling detection of Solidity functions that return `msg.sender`, either directly or through variable aliasing.

---

## Motivation
In many smart contract patterns, `msg.sender` is returned through internal functions, often after assignment to local variables or via wrapper functions like `_msgSender()`. Detecting such patterns is crucial for accurate static analysis—particularly when assessing function protection or authorization flows.

This utility provides foundational support for enhancing other modules involving `msg.sender` (in future PRs ).

---

## What’s Covered
The newly added method `Function.is_returning_msg_sender()` returns `True` if:
- The function **directly returns `msg.sender`**
- The function **returns a variable that was directly or transitively assigned from `msg.sender`**

### Examples:
- Direct return : 
```solidity
function _msgSender() internal view returns (address) {
    return msg.sender;
}
```
- Transitive Aliasing:
```solidity
function _myMsgSender() internal view returns (address) {
    address a = msg.sender;
    address b = a;
    return b;
}
```

## What's not Covered 
- Returns via internal function calls, even if those functions return `msg.sender`: 
```solidity
function _getUser() internal view returns (address) {
        return _msgSender();  // _msgSender() returns msg.sender
}
```
Support for such recursive or wrapper logic will be addressed in a future update.

