### PR TITLE
Mutation cleanup

### DIFF
--- a/docs/src/tools/Mutator.md
+++ b/docs/src/tools/Mutator.md
@@ -12,6 +12,8 @@ You can provide flags to `forge` as part of the `--test-cmd` parameter or target
 
 `slither-mutate src/core/MyContract.sol --test-cmd='forge test --match-contract="MyContract"'`
 
+If a `timout` flag is not provided, slither-mutate will default to using a value that's double the runtime of it's initial test cmd execution. Make sure you run `forge clean` or similar beforehand to ensure cache usage doesn't cause a timeout that's too short to be used; this could lead to false-negatives.
+
 ### CLI Interface
 
 ```shell
@@ -30,7 +32,7 @@ options:
   --test-dir TEST_DIR   Tests directory
   --ignore-dirs IGNORE_DIRS
                         Directories to ignore
-  --timeout TIMEOUT     Set timeout for test command (by default 30 seconds)
+  --timeout TIMEOUT     Set timeout for test command (by default 2x the initial test runtime)
   --output-dir OUTPUT_DIR
                         Name of output directory (by default 'mutation_campaign')
   -v, --verbose         log mutants that are caught, uncaught, and fail to compile

--- a/slither/tools/mutator/__main__.py
+++ b/slither/tools/mutator/__main__.py
@@ -344,7 +344,7 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
         if total_mutant_counts[0] > 0:
             logger.info(
                 magenta(
-                    f"Revert mutants: {uncaught_mutant_counts[0]} uncaught of {total_mutant_counts[0]} ({100 * uncaught_mutant_counts[0]/total_mutant_counts[0]}%)"
+                    f"Revert mutants: {uncaught_mutant_counts[0]} uncaught of {total_mutant_counts[0]} ({round(100 * (total_mutant_counts[0] - uncaught_mutant_counts[0])/total_mutant_counts[0], 1)}% caught)"
                 )
             )
         else:
@@ -353,7 +353,7 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
         if total_mutant_counts[1] > 0:
             logger.info(
                 magenta(
-                    f"Comment mutants: {uncaught_mutant_counts[1]} uncaught of {total_mutant_counts[1]} ({100 * uncaught_mutant_counts[1]/total_mutant_counts[1]}%)"
+                    f"Comment mutants: {uncaught_mutant_counts[1]} uncaught of {total_mutant_counts[1]} ({round(100 * (total_mutant_counts[1] - uncaught_mutant_counts[1])/total_mutant_counts[1], 1)}% caught)"
                 )
             )
         else:
@@ -362,7 +362,7 @@ def main() -> None:  # pylint: disable=too-many-statements,too-many-branches,too
         if total_mutant_counts[2] > 0:
             logger.info(
                 magenta(
-                    f"Tweak mutants: {uncaught_mutant_counts[2]} uncaught of {total_mutant_counts[2]} ({100 * uncaught_mutant_counts[2]/total_mutant_counts[2]}%)\n"
+                    f"Tweak mutants: {uncaught_mutant_counts[2]} uncaught of {total_mutant_counts[2]} ({round(100 * (total_mutant_counts[2] - uncaught_mutant_counts[2])/total_mutant_counts[2], 1)}% caught)\n"
                 )
             )
         else:

--- a/slither/tools/mutator/utils/testing_generated_mutant.py
+++ b/slither/tools/mutator/utils/testing_generated_mutant.py
@@ -40,10 +40,6 @@ def run_test_cmd(
     elif "hardhat test" in cmd or "truffle test" in cmd and "--bail" not in cmd:
         cmd += " --bail"
 
-    if timeout is None and "hardhat" not in cmd:  # hardhat doesn't support --force flag on tests
-        # if no timeout, ensure all contracts are recompiled w/out using any cache
-        cmd += " --force"
-
     try:
         result = subprocess.run(
             cmd,


### PR DESCRIPTION
2 tweaks:
- adjust logs so they report % caught instead of % uncaught (so 100% is good and 0% is bad, instead of vice versa)
- remove hacky & unreliable compilation flag, document that users should mutate from a clean repo instead