### PR TITLE
Fix trimmed network string

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -298,7 +298,7 @@ def parse_args(
     usage += "\t- file.sol // a Solidity file\n"
     usage += "\t- project_directory // a project directory. See https://github.com/crytic/crytic-compile/#crytic-compile for the supported platforms\n"
     usage += "\t- 0x.. // a contract on mainnet\n"
-    usage += f"\t- NETWORK:0x.. // a contract on a different network. Supported networks: {','.join(x[:-1] for x in SUPPORTED_NETWORK)}\n"
+    usage += f"\t- NETWORK:0x.. // a contract on a different network. Supported networks: {','.join(x for x in SUPPORTED_NETWORK)}\n"
 
     parser = argparse.ArgumentParser(
         description="For usage information, see https://github.com/crytic/slither/wiki/Usage",


### PR DESCRIPTION
Current output lists networks with the last character chopped off which looks very funny:
```
usage: slither target [flag]

target can be:
	- file.sol // a Solidity file
	- project_directory // a project directory. See https://github.com/crytic/crytic-compile/#crytic-compile for the supported platforms
	- 0x.. // a contract on mainnet
	- NETWORK:0x.. // a contract on a different network. Supported networks: mainne,sepoli,holesk,bs,testnet.bs,pol,amoy.pol,polyz,cardona.polyz,bas,sepolia.bas,arb,nova.arb,sepolia.arb,line,sepolia.line,ft,testnet.ft,blas,sepolia.blas,opti,sepolia.opti,ava,testnet.ava,btt,testnet.btt,cel,alfajores.cel,crono,fra,holesky.fra,gn,krom,sepolia.krom,mantl,sepolia.mantl,moonbea,moonrive,moonbas,opbn,testnet.opbn,scrol,sepolia.scrol,taik,hekla.taik,wemi,testnet.wemi,era.zksyn,sepoliaera.zksyn,xa,sepolia.xa,xd,testnet.xd,apechai,curtis.apechai,worl,sepolia.worl,sopho,testnet.sopho,soni,testnet.soni,unichai,sepolia.unichai,abstrac,sepolia.abstrac,berachai
```