### PR TITLE
Adapt uschunt for compatibility with Slither 0.11.3

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Dict, Callable, Tuple, TYPE_CHECKING, Union, 
 from crytic_compile.platform import Type as PlatformType
 
 from slither.core.cfg.scope import Scope
+from slither.core.solidity_types.type import Type
 from slither.core.source_mapping.source_mapping import SourceMapping
 from slither.utils.using_for import USING_FOR, merge_using_for
 from slither.core.declarations.function import Function, FunctionType, FunctionLanguage
@@ -20,6 +21,7 @@ from slither.utils.erc import (
     ERC1820_signatures,
     ERC777_signatures,
     ERC1155_signatures,
+    ERC1967_signatures,
     ERC2612_signatures,
     ERC1363_signatures,
     ERC4524_signatures,
@@ -99,6 +101,17 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
 
         self._is_upgradeable: Optional[bool] = None
         self._is_upgradeable_proxy: Optional[bool] = None
+        self._is_upgradeable_proxy_confirmed: Optional[bool] = None
+        self._is_proxy: Optional[bool] = None
+        self._is_admin_only_proxy: Optional[bool] = None
+        self._delegate_variable: Optional["Variable"] = None
+        self._delegate_contract: Optional["Contract"] = None
+        self._proxy_impl_setter: Optional["Function"] = None
+        self._proxy_impl_getter: Optional["Function"] = None
+        self._proxy_impl_slot: Optional["Variable"] = None
+        self._uses_call_not_delegatecall: Optional[bool] = None
+
+        self.is_top_level = False  # heavily used, so no @property
         self._upgradeable_version: Optional[str] = None
 
         self._initial_state_variables: List["StateVariable"] = []  # ssa
@@ -890,6 +903,16 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
             None,
         )
 
+    def get_function_from_name(self, name: str) -> Optional["Function"]:
+        """
+            Return a function from a name
+        Args:
+            name (str): name of the function (not the signature)
+        Returns:
+            Function
+        """
+        return next((f for f in self.functions if f.name == name), None)
+
     def get_function_from_canonical_name(self, canonical_name: str) -> Optional["Function"]:
         """
             Return a function from a canonical name (contract.signature())
@@ -1194,6 +1217,16 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
         full_names = self.functions_signatures
         return all(s in full_names for s in ERC721_signatures)
 
+    def is_erc1967(self) -> bool:
+        """
+            Check if the contract is an erc1967 proxy
+
+            Note: it does not check for correct return values
+        :return: Returns a true if the contract is an erc1967 proxy
+        """
+        full_names = self.functions_signatures
+        return all(s in full_names for s in ERC1967_signatures)
+        
     def is_erc777(self) -> bool:
         """
             Check if the contract is an erc777
@@ -1366,6 +1399,8 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
     def is_upgradeable(self) -> bool:
         if self._is_upgradeable is None:
             self._is_upgradeable = False
+            if self.is_upgradeable_proxy:
+                return False
             initializable = self.file_scope.get_contract_from_name("Initializable")
             if initializable:
                 if initializable in self.inheritance:
@@ -1390,27 +1425,1822 @@ class Contract(SourceMapping):  # pylint: disable=too-many-public-methods
 
     @property
     def is_upgradeable_proxy(self) -> bool:
+        """
+        Determines if a proxy contract can be upgraded, i.e. if there's an implementation address setter for upgrading
+
+        :return: True if an implementation setter is found, or if the implementation getter suggests upgradeability
+        """
         from slither.core.cfg.node import NodeType
-        from slither.slithir.operations import LowLevelCall
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.variables.structure_variable import StructureVariable
+        from slither.core.declarations.function_contract import FunctionContract
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.solidity_types.user_defined_type import UserDefinedType
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.literal import Literal
 
         if self._is_upgradeable_proxy is None:
             self._is_upgradeable_proxy = False
-            if "Proxy" in self.name:
-                self._is_upgradeable_proxy = True
-                return True
-            for f in self.functions:
-                if f.is_fallback:
-                    for node in f.all_nodes():
-                        for ir in node.irs:
-                            if isinstance(ir, LowLevelCall) and ir.function_name == "delegatecall":
+            self._is_upgradeable_proxy_confirmed = False
+            # calling self.is_proxy returns True or False, and should also set self._delegates_to in the process
+            if self.is_proxy and self._delegate_variable is not None:
+                
+                # if the destination is a constant or immutable, return false
+                if self._delegate_variable.is_constant or self._delegate_variable.is_immutable:
+                    if self._proxy_impl_slot is None or self._proxy_impl_slot != self._delegate_variable:
+                        self._is_upgradeable_proxy = False
+                        return False
+                # if the destination is hard-coded, return false
+                if isinstance(self._delegate_variable.expression, Literal) and \
+                        self._delegate_variable != self._proxy_impl_slot:
+                    self._is_upgradeable_proxy = False
+                    return False
+
+                # self._delegate_variable should ideally be a StateVariable,
+                # but it may be a LocalVariable if cross-contract analysis failed to find its source
+                if isinstance(self._delegate_variable, LocalVariable):
+                    if self.handle_local_delegate_from_call_exp():
+                        return self._is_upgradeable_proxy
+
+                # Now find setter in the contract. If we succeed, then the contract is upgradeable.
+                # It is possible for self._proxy_impl_setter to already be found by this point.
+                if self._proxy_impl_setter is None:
+                    # Case: delegate is StateVariable declared in a different contract
+                    if isinstance(self._delegate_variable, StateVariable) and self._delegate_variable.contract != self:
+                        self.handle_delegate_state_var_different_contract()
+                    # Case: delegate is LocalVariable in a function declared in a different contract
+                    elif isinstance(self._delegate_variable, LocalVariable) and\
+                            isinstance(self._delegate_variable.function, FunctionContract) and\
+                            self._delegate_variable.function.contract != self:
+                        self.handle_delegate_local_var_different_contract()
+                    # Default case: look for setter in this contract
+                    if self._proxy_impl_setter is None:
+                        (self._proxy_impl_setter,
+                         self._delegate_variable) = self.find_setter_in_contract(self, self._delegate_variable,
+                                                                                 self._proxy_impl_slot)
+                if self._proxy_impl_setter is not None:
+                    # Setter is found, and upgradeability confirmed
+                    self._is_upgradeable_proxy = True
+                    self._is_upgradeable_proxy_confirmed = True
+                
+                # then find getter
+                if self._proxy_impl_getter is None:
+                    if isinstance(self._delegate_variable, StateVariable) and self._delegate_variable.contract != self:
+                        self._proxy_impl_getter = self.find_getter_in_contract(self._delegate_variable.contract,
+                                                                               self._delegate_variable)
+                    if self._proxy_impl_getter is None:
+                        self._proxy_impl_getter = self.find_getter_in_contract(self, self._delegate_variable)
+                
+                # if both setter and getter can be found, then return true
+                # Otherwise, at least the getter's return is non-constant
+                if self._proxy_impl_getter is not None:
+                    if self._proxy_impl_setter is not None:
+                        self._is_upgradeable_proxy = True
+                        self._is_upgradeable_proxy_confirmed = True
+                    else:
+                        self._is_upgradeable_proxy = self.getter_return_is_non_constant()
+                    return self._is_upgradeable_proxy
+                else:
+                    if self.handle_missing_getter():
+                        return self._is_upgradeable_proxy
+        return self._is_upgradeable_proxy
+
+    @property
+    def is_proxy(self) -> bool:
+        """
+        Checks for 'delegatecall' in the fallback function CFG, setting self._is_proxy = True if found.
+        Also tries to set self._delegates_to: Variable in the process.
+
+        :return: True if 'delegatecall' is found in fallback function, otherwise False
+        """
+        from slither.core.cfg.node import NodeType
+
+        if self._is_proxy is None:
+            self._is_proxy = False
+
+            if self.fallback_function is None:
+                return self._is_proxy
+
+            self._delegate_variable = None
+            for node in self.fallback_function.all_nodes():
+                # first try to find a delegetecall in non-assembly code region
+                is_proxy, self._delegate_variable = self.find_delegatecall_in_ir(node)
+                if not self._is_proxy:
+                    self._is_proxy = is_proxy
+                if self._is_proxy and self._delegate_variable is not None:
+                    break
+
+                # then try to find delegatecall in assembly region
+                if node.type == NodeType.ASSEMBLY:
+                    """
+                    Calls self.find_delegatecall_in_asm to search in an assembly CFG node.
+                    That method cannot always find the delegates_to Variable for solidity versions >= 0.6.0
+                    """
+                    if node.inline_asm:
+                        is_proxy, self._delegate_variable = self.find_delegatecall_in_asm(node.inline_asm,
+                                                                                          node.function)
+                        if not is_proxy:
+                            is_proxy, self._delegate_variable = self.find_delegatecall_in_asm(node.inline_asm,
+                                                                                              node.function,
+                                                                                              include_call=True)
+                        if not self._is_proxy:
+                            self._is_proxy = is_proxy
+                        if self._is_proxy and (self._delegate_variable is not None
+                                               or self._proxy_impl_slot is not None):
+                            break
+                elif node.type == NodeType.EXPRESSION:
+                    is_proxy, self._delegate_variable = self.find_delegatecall_in_exp_node(node)
+                    if not self._is_proxy:
+                        self._is_proxy = is_proxy
+                    if self._is_proxy and (self._delegate_variable is not None
+                                           or self._proxy_impl_slot is not None):
+                        break
+            if self.is_proxy and self._delegate_variable is None and self._proxy_impl_slot is not None:
+                self._delegate_variable = self._proxy_impl_slot
+        return self._is_proxy
+
+    """
+    Getters for attributes set by self.is_proxy and self.is_upgradeable_proxy
+    """
+    @property
+    def delegate_variable(self) -> Optional["Variable"]:
+        if self.is_proxy:
+            return self._delegate_variable
+        return self._delegate_variable
+
+    @property
+    def proxy_implementation_setter(self) -> Optional["FunctionContract"]:
+        if self.is_upgradeable_proxy:
+            return self._proxy_impl_setter
+        return self._proxy_impl_setter
+
+    @property
+    def proxy_implementation_getter(self) -> Optional["FunctionContract"]:
+        if self.is_upgradeable_proxy:
+            return self._proxy_impl_getter
+        return self._proxy_impl_getter
+
+    @property
+    def proxy_impl_storage_offset(self) -> Optional["Variable"]:
+        return self._proxy_impl_slot
+
+    @property
+    def is_upgradeable_proxy_confirmed(self) -> Optional[bool]:
+        if self._is_upgradeable_proxy_confirmed is None:
+            if self.is_upgradeable_proxy:
+                return self._is_upgradeable_proxy_confirmed
+        return self._is_upgradeable_proxy_confirmed
+
+    @property
+    def uses_call_not_delegatecall(self) -> bool:
+        return self._uses_call_not_delegatecall
+
+    def find_delegatecall_in_asm(
+            self,
+            inline_asm: Union[str, Dict],
+            parent_func: Function,
+            include_call=False):
+        """
+        Called by self.is_proxy to help find 'delegatecall' in an inline assembly block,
+        as well as the address Variable which the 'delegatecall' targets.
+        It is necessary to handle two separate cases, for contracts using Solidity versions
+        < 0.6.0 and >= 0.6.0, due to a change in how assembly is represented after compiling,
+        i.e. as an AST for versions >= 0.6.0 and as a simple string for earlier versions.
+
+        :param: inline_asm: The assembly code as either a string or an AST, depending on the solidity version
+        :param: parent_func: The function associated with the assembly node (maybe another function called by fallback)
+        :return: True if delegatecall is found, plus Variable delegates_to (if found)
+        """
+
+        delegates_to: Optional[Variable] = None
+        asm_split = None
+
+        if "AST" in inline_asm and isinstance(inline_asm, Dict):
+            is_proxy, dest = Contract.find_delegatecall_in_asm_ast(inline_asm, include_call)
+        else:
+            is_proxy, dest, asm_split, delegates_to = self.find_delegatecall_in_asm_str(inline_asm,
+                                                                                        parent_func,
+                                                                                        include_call)
+        if is_proxy and delegates_to is None and dest is not None:
+            """
+            Now that we extracted the name of the address variable passed as the second parameter to delegatecall, 
+            we need to find the correct Variable object to ultimately assign to self._delegates_to.
+            """
+            if "_fallback_asm" in dest:
+                dest = dest.split("_fallback_asm")[0]
+            delegates_to = self.find_delegate_variable_from_name(dest, parent_func)
+            if delegates_to is None and asm_split is not None:
+                delegates_to = self.find_delegate_sloaded_from_hardcoded_slot(asm_split, dest, parent_func)
+        return is_proxy, delegates_to
+
+    @staticmethod
+    def find_delegatecall_in_asm_ast(
+            inline_asm: Union[str, Dict],
+            include_call: bool
+    ) -> (bool, str):
+        is_proxy = False
+        dest: Optional[Union[str, dict]] = None
+
+        """
+        inline_asm is a Yul AST for Solidity versions >= 0.6.0
+        see tests/proxies/ExampleYulAST.txt for an example
+        """
+        for statement in inline_asm["AST"]["statements"]:
+            if statement["nodeType"] == "YulExpressionStatement":
+                statement = statement["expression"]
+            if statement["nodeType"] == "YulVariableDeclaration":
+                statement = statement["value"]
+            if statement["nodeType"] == "YulFunctionCall":
+                if statement["functionName"]["name"] == "delegatecall" or (include_call and
+                                                                           statement["functionName"]["name"] == "call"):
+                    is_proxy = True
+                    args = statement["arguments"]
+                    dest = args[1]
+                    if dest["nodeType"] == "YulIdentifier":
+                        dest = dest["name"]
+                    break
+        return is_proxy, dest
+
+    def find_delegatecall_in_asm_str(
+            self,
+            inline_asm: Union[str, Dict],
+            parent_func: Function,
+            include_call=False
+    ) -> (bool, str, list[str], Optional["Variable"]):
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.solidity_types.elementary_type import ElementaryType
+
+        is_proxy = False
+        delegates_to: Optional["Variable"] = None
+        """
+        inline_asm is just a string for Solidity versions < 0.6.0.
+        It contains the entire block of assembly code, so we can split it by line.
+        """
+        asm_split = inline_asm.split("\n")
+        dest: Optional[str] = None
+        for asm in asm_split:
+            if "delegatecall" in asm or (include_call and "call(" in asm):
+                if "delegatecall" not in inline_asm:
+                    self._uses_call_not_delegatecall = True
+                else:
+                    # found delegatecall somewhere in full inline_asm
+                    if "delegatecall" not in asm:
+                        continue
+                    else:
+                        self._uses_call_not_delegatecall = False
+                is_proxy = True  # Now look for the target of this delegatecall
+                params = asm.split("call(")[1].split(", ")
+                dest = params[1]
+                # Target should be 2nd parameter, but 1st param might have 2 params
+                # i.e. delegatecall(sub(gas, 10000), _dst, free_ptr, calldatasize, 0, 0)
+                if dest.startswith("sload("):
+                    # dest may not be correct, but we have found the storage slot
+                    dest = dest.replace(")", "(").split("(")[1]
+                    for v in parent_func.variables_read_or_written:
+                        if v.name == dest:
+                            if isinstance(v, LocalVariable) and v.expression is not None:
+                                e = v.expression
+                                if isinstance(e, Identifier) and isinstance(e.value, StateVariable):
+                                    v = e.value
+                                    """
+                                    Fall through, use constant storage slot as delegates_to and proxy_impl_slot
+                                    """
+                            if isinstance(v, StateVariable) and v.is_constant:
+                                # slot = str(v.expression)
+                                # delegates_to = LocalVariable()
+                                # delegates_to.set_type(ElementaryType("address"))
+                                # delegates_to.name = dest
+                                # delegates_to.set_location(slot)
+                                delegates_to = v
+                                self._proxy_impl_slot = v  # and also as proxy_impl_slot
+                if dest.endswith(")"):
+                    dest = params[2]
+                break
+        return is_proxy, dest, asm_split, delegates_to
+
+    def find_delegate_variable_from_name(
+            self,
+            dest: str,
+            parent_func: Function
+    ) -> Optional["Variable"]:
+        """
+        Called by find_delegatecall_in_asm, which can only extract the name of the destination variable, not the object.
+        Looks in every possible place for a Variable object with exactly the same name as extracted.
+        If it's a state variable, our work is done here.
+        But it may also be a local variable declared within the function, or a parameter declared in its signature.
+        In which case, we need to track it further, but at that point we can stop using names.
+
+        :param dest: The name of the delegatecall destination, as a string extracted from assembly
+        :param parent_func: The Function in which we found the ASSEMBLY Node containing delegatecall
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.variables.variable import Variable
+        from slither.core.solidity_types.elementary_type import ElementaryType
+
+        delegate = None
+        if len(dest) == 42 and dest.startswith("0x"):
+            addr = Literal(dest, ElementaryType("address"))
+            delegate = Variable()
+            delegate.expression = addr
+            delegate.type = ElementaryType("address")
+            delegate.name = dest
+            return delegate
+        for sv in self.state_variables:
+            if sv.name == dest:
+                delegate = sv
+                return delegate
+        delegate = self.find_local_delegate_from_name(dest, parent_func)
+        if delegate is not None:
+            return delegate
+        delegate = self.find_parameter_delegate_from_name(dest, parent_func)
+        if delegate is not None:
+            return delegate
+        if parent_func.contains_assembly and delegate is None:  # and self._proxy_impl_slot is not None:
+            delegate = self.find_delegate_in_asm_from_name(dest, parent_func)
+            if delegate is not None:
+                return delegate
+        return delegate
+
+    def find_local_delegate_from_name(
+            self,
+            dest: str,
+            parent_func: Function
+    ) -> Optional["Variable"]:
+        """
+        Extension of self.find_delegate_variable_by_name()
+        Used to handle searching for matching local variables and tracking them to their source.
+
+        :param dest: The name of the delegatecall destination, as a string extracted from assembly
+        :param parent_func: The Function in which we found the ASSEMBLY Node containing delegatecall
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+
+        delegate = None
+        for lv in parent_func.local_variables:
+            if delegate is not None or self._proxy_impl_slot is not None:
+                return delegate
+            if lv.name == dest:
+                # TODO: eliminate dependence on variable name for Diamond handling
+                if lv.name == "facet":
+                    delegate = lv
+                    return delegate
+                if lv.expression is not None:
+                    exp = self.unwrap_assignment_member_access(lv.expression)
+                    if isinstance(exp, IndexAccess):
+                        exp = exp.expression_left
+                        # Fall through
+                    if isinstance(exp, Identifier) and isinstance(exp.value, StateVariable):
+                        delegate = exp.value
+                        return delegate
+                    elif isinstance(exp, CallExpression):
+                        """
+                        Must be the getter, but we still need a variable
+                        """
+                        delegate = self.find_delegate_from_call_exp(exp, lv)
+                        return delegate
+                    if isinstance(exp, MemberAccess):
+                        delegate = self.find_delegate_from_member_access(exp, lv)
+                        if delegate is None:
+                            delegate = lv
+                        return delegate
+                else:
+                    # No expression found, so look for assignment operation
+                    delegate = self.find_local_variable_assignment(lv, parent_func)
+        return delegate
+
+    def find_local_variable_assignment(
+        self, lv: "LocalVariable", parent_func: Function
+    ) -> Optional["Variable"]:
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.identifier import Identifier
+
+        delegate = None
+        for node in parent_func.all_nodes():
+            if node.type in (NodeType.EXPRESSION, NodeType.VARIABLE):
+                exp = Contract.unwrap_assignment_member_access(node.expression)
+                if isinstance(exp, CallExpression):
+                    if str(exp.called) == "sload(uint256)":
+                        delegate = lv
+                        arg = exp.arguments[0]
+                        if isinstance(arg, Identifier):
+                            if (
+                                isinstance(arg.value, LocalVariable)
+                                and arg.value.expression is not None
+                                and isinstance(arg.value.expression, Identifier)
+                            ):
+                                arg = arg.value.expression
+                            if isinstance(arg.value, Variable) and arg.value.is_constant:
+                                self._proxy_impl_slot = arg.value
+                                break
+                    else:
+                        delegate = self.find_delegate_from_call_exp(exp, lv)
+        return delegate
+
+    def find_parameter_delegate_from_name(
+            self,
+            dest: str,
+            parent_func: Function
+    ) -> Optional["Variable"]:
+        """
+        Extension of self.find_delegate_variable_by_name()
+        Used to handle searching for matching parameter variables and tracking them to their source.
+
+        :param dest: The name of the delegatecall destination, as a string extracted from assembly
+        :param parent_func: The Function in which we found the ASSEMBLY Node containing delegatecall
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+
+        delegate = None
+        for idx, pv in enumerate(parent_func.parameters):
+            if pv.name == dest:
+                # delegate = pv
+                for node in self.fallback_function.all_nodes():
+                    if node.type == NodeType.EXPRESSION or node.type == NodeType.VARIABLE:
+                        exp = self.unwrap_assignment_member_access(node.expression)
+                        if isinstance(exp, CallExpression):
+                            called = exp.called
+                            if isinstance(called, MemberAccess):
+                                if str(called) == f"{parent_func.contract.name}.{parent_func.name}":
+                                    var = exp.arguments[idx]
+                                    if isinstance(var, Identifier) and isinstance(var.value, StateVariable):
+                                        delegate = var.value
+                                        break
+                            if isinstance(called, Identifier) and called.value == parent_func:
+                                arg = exp.arguments[idx]
+                                if isinstance(arg, Identifier):
+                                    v = arg.value
+                                    if isinstance(v, StateVariable):
+                                        delegate = v
+                                        break
+                                    elif isinstance(v, LocalVariable) and v.expression is not None:
+                                        delegate = v
+                                        exp = v.expression
+                                        if isinstance(exp, Identifier) and isinstance(exp.value, StateVariable):
+                                            delegate = exp.value
+                                        elif isinstance(exp, CallExpression):
+                                            called = exp.called
+                                            _delegate = self.find_delegate_from_call_exp(exp, v)
+                                            if _delegate is not None:
+                                                delegate = _delegate
+                                        break
+                                elif isinstance(arg, CallExpression):
+                                    called = exp.called
+                                    _delegate = self.find_delegate_from_call_exp(arg, pv)
+                                    if _delegate is not None:
+                                        delegate = _delegate
+                                        break
+                                elif isinstance(arg, IndexAccess):
+                                    if isinstance(arg.expression_left, Identifier):
+                                        delegate = arg.expression_left.value
+                                        delegate.expression = arg
+                                    break
+                break
+        return delegate
+
+    def find_delegate_in_asm_from_name(
+            self,
+            dest: str,
+            parent_func: Function
+    ) -> Optional["Variable"]:
+        """
+        Extension of self.find_delegate_variable_by_name()
+        Used to handle searching for matching variables loaded in assembly using sload(),
+        and determining which storage slot they are loaded from.
+
+        :param dest: The name of the delegatecall destination, as a string extracted from assembly
+        :param parent_func: The Function in which we found the ASSEMBLY Node containing delegatecall
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.solidity_types.elementary_type import ElementaryType
+        from slither.core.declarations.contract_level import ContractLevel
+        from slither.core.expressions.literal import Literal
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+
+        delegate = None
+        # If we still haven't found the delegate variable, and the function contains assembly, look for sload
+        for node in parent_func.all_nodes():
+            if node.type == NodeType.ASSEMBLY:
+                if isinstance(node.inline_asm, str):
+                    asm = node.inline_asm.split("\n")
+                    for s in asm:
+                        if f"{dest}" in s and ":=" in s:
+                            if "sload" in s:
+                                dest = s.replace(")", "(").split("(")[1]
+                                if not dest.endswith("_slot"):
+                                    slot_var = parent_func.get_local_variable_from_name(dest)
+                                    if slot_var is not None and slot_var.expression is not None:
+                                        slot_exp = slot_var.expression
+                                        if isinstance(slot_exp, Identifier) and slot_exp.value.is_constant:
+                                            self._proxy_impl_slot = slot_exp.value
+                                break
+                else:
+                    asm = node.inline_asm
+                    for statement in asm["AST"]["statements"]:
+                        if statement["nodeType"] == "YulVariableDeclaration" \
+                                and statement["variables"][0]["name"] == dest:
+                            if statement["value"]["nodeType"] == "YulFunctionCall" \
+                                    and statement["value"]["functionName"]["name"] == "and" \
+                                    and statement["value"]["arguments"][0]["nodeType"] == "YulFunctionCall" \
+                                    and statement["value"]["arguments"][0]["functionName"]["name"] == "sload":
+                                statement["value"] = statement["value"]["arguments"][0]
+                            if statement["value"]["nodeType"] == "YulFunctionCall" \
+                                    and statement["value"]["functionName"]["name"] == "sload":
+                                if statement["value"]["arguments"][0]["nodeType"] == "YulLiteral":
+                                    slot = statement["value"]["arguments"][0]["value"]
+                                    if len(slot) == 66 and slot.startswith("0x"):  # 32-bit memory address
+                                        # delegate = LocalVariable()
+                                        # delegate.set_type(ElementaryType("address"))
+                                        # delegate.name = dest
+                                        # delegate.set_location(slot)
+                                        impl_slot = StateVariable()
+                                        impl_slot.name = slot
+                                        impl_slot.is_constant = True
+                                        impl_slot.expression = Literal(slot, ElementaryType("bytes32"))
+                                        impl_slot.set_type(ElementaryType("bytes32"))
+                                        impl_slot.set_contract(node.function.contract
+                                                               if isinstance(node.function, ContractLevel)
+                                                               else self)
+                                        self._proxy_impl_slot = impl_slot
+                                        break
+                                    elif slot == "0":
+                                        delegate = self.state_variables_ordered[0]
+                                elif statement["value"]["arguments"][0]["nodeType"] == "YulIdentifier":
+                                    for sv in self.state_variables:
+                                        if sv.name == statement["value"]["arguments"][0]["name"] and sv.is_constant:
+                                            # slot = str(sv.expression)
+                                            # delegate = LocalVariable()
+                                            # delegate.set_type(ElementaryType("address"))
+                                            # delegate.name = dest
+                                            # delegate.set_location(slot)
+                                            self._proxy_impl_slot = sv
+        if delegate is None and dest.endswith("_slot"):
+            delegate = self.find_delegate_variable_from_name(dest.replace('_slot', ''), parent_func)
+        return delegate
+
+    @staticmethod
+    def unwrap_assignment_member_access(exp: "Expression"):
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.member_access import MemberAccess
+
+        if isinstance(exp, AssignmentOperation):
+            exp = exp.expression_right
+        if isinstance(exp, MemberAccess):
+            exp = exp.expression
+        return exp
+
+    @staticmethod
+    def unwrap_type_conversion(exp: "Expression"):
+        from slither.core.expressions.type_conversion import TypeConversion
+
+        while isinstance(exp, TypeConversion):
+            exp = exp.expression
+        return exp
+
+    def find_delegate_from_call_exp(self, exp, var) -> Optional["Variable"]:
+        """
+        Called by self.find_delegate_variable_from_name
+        Having found a LocalVariable matching the destination name extracted from the delegatecall,
+        we know that the value of the local variable is gotten by the given CallExpression.
+        Therefore, we are interested in tracking the origin of the value returned by the Function being called.
+        There are 2 ways to return values from a function in Solidity (though they may be mixed, leading to case 3):
+            1 - explicitly assigning values to named return variables, i.e.
+                function _implementation() internal view returns (address impl) {
+                    bytes32 slot = IMPLEMENTATION_SLOT;
+                    assembly {
+                        impl := sload(slot)
+                    }
+                }
+            2 - returning values directly using a return statement (in which case variable names may be omitted), i.e.
+                function implementation() public view returns (address) {
+                    return getAppBase(appId());
+                }
+            3 - return variable is given a name, but is not assigned a value, instead using a return statement, i.e.
+                function _implementation() internal view virtual override returns (address impl) {
+                    return ERC1967Upgrade._getImplementation();
+                }
+        Given this fact, without knowing anything about the pattern, we know that we must approach this in 1 of 2 ways:
+            1 - If the function has no RETURN node, then take the named return Variable object and look for where it is
+                assigned a value
+            2 - Otherwise, find the RETURN node at the end of the function's CFG, determine which Variable
+                object it is returning, then look for where it is assigned a value
+        For expediency, check #2 first
+
+        :param exp: a CallExpression in which we want to find the source of the return value
+        :param var: a Variable to fall back on if tracing it to it's source fails
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.tuple_expression import TupleExpression
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.literal import Literal
+        from slither.core.solidity_types.elementary_type import ElementaryType
+        from slither.core.declarations.function_contract import FunctionContract
+        from slither.analyses.data_dependency import data_dependency
+
+        delegate: Optional[Variable] = None
+        func: Optional[Function] = None
+        ret: Optional[Variable] = None
+        if isinstance(exp, CallExpression):     # Guaranteed but type checking never hurts and helps IDE w autocomplete
+            called = exp.called
+            if isinstance(called, Identifier):
+                val = called.value
+                if isinstance(val, Function):   # Identifier.value is usually a Variable but here it's always a Function
+                    func = val
+            elif isinstance(called, MemberAccess):
+                delegate = self.find_delegate_from_member_access(exp, var)
+                return delegate
+        if func is not None:
+            if len(func.all_nodes()) == 0:
+                # Sometimes Slither connects a CallExpression to an abstract function, missing the overriding function
+                func = self.get_function_from_signature(func.full_name)
+                while func is None:
+                    for c in self.inheritance:
+                        func = c.get_function_from_signature(func.full_name)
+            ret = func.returns[0]
+            # if ret.name is None or ret.name == "":
+            # Case #2/3 - need to find RETURN node and the variable returned first
+            ret_nodes = func.return_nodes()
+            if ret_nodes is not None:
+                for ret_node in ret_nodes:
+                    if ret_node is not None:
+                        rex = ret_node.expression
+                        if var.expression is None:
+                            var.expression = rex
+                        if isinstance(rex, Identifier) and isinstance(rex.value, Variable):
+                            ret = rex.value
+                            if isinstance(ret, LocalVariable):
+                                break
+                        elif isinstance(rex, CallExpression):
+                            called = rex.called
+                            if isinstance(called, MemberAccess):
+                                delegate = self.find_delegate_from_member_access(called, var)
+                            elif isinstance(called, Identifier) and isinstance(called.value, FunctionContract) \
+                                    and called.value.contract != self:
+                                delegate = called.value.contract.find_delegate_from_call_exp(rex, var)
+                            else:
+                                delegate = self.find_delegate_from_call_exp(rex, var)
+                            if delegate is None:
+                                delegate = LocalVariable()
+                                delegate.expression = rex
+                            if delegate.name is None:
+                                delegate.name = str(called)
+                            if delegate.type is None:
+                                delegate.type = ret.type
+                            args = [arg.value for arg in exp.arguments if isinstance(arg, Identifier)]
+                            for a in args:
+                                if isinstance(a, StateVariable) and str(a.type) == "bytes32" and a.is_constant:
+                                    self._proxy_impl_slot = a
+                                    if delegate.name == str(called) and delegate.expression == rex:
+                                        """ 
+                                        If we constructed a LocalVariable from scratch above, but 
+                                        then found the slot variable in the call expression arguments,
+                                        it may be better just to use the fallback variable `var` which
+                                        was assigned the value returned by the call expression.
+                                        """
+                                        delegate = var
+                                    break
+                            return delegate
+                        elif isinstance(rex, IndexAccess):
+                            left = rex.expression_left
+                            if isinstance(left, Identifier) and isinstance(left.value, StateVariable):
+                                delegate = left.value
+            if ret.name is not None and ret_nodes is None:
+                # Case #1 - return variable is named, so it's initialized in the entry point with no value assigned
+                for n in func.all_nodes():
+                    if n.type == NodeType.EXPRESSION:
+                        e = n.expression
+                        if isinstance(e, AssignmentOperation):
+                            left = e.expression_left
+                            right = e.expression_right
+                            if isinstance(left, Identifier) and left.value == ret:
+                                if isinstance(right, CallExpression):
+                                    ret.expression = right
+                                    if str(right.called) == "sload(uint256)":
+                                        arg = right.arguments[0]
+                                        if isinstance(arg, Identifier):
+                                            v = arg.value
+                                            if isinstance(v, Variable) and v.is_constant:
+                                                self._proxy_impl_slot = v
+                                                break
+                                            elif isinstance(v, LocalVariable) and v.expression is not None:
+                                                e = v.expression
+                                                if isinstance(e, Identifier) and e.value.is_constant:
+                                                    self._proxy_impl_slot = e.value
+                                                    break
+                                        elif isinstance(arg, Literal):
+                                            slot_var = StateVariable()
+                                            slot_var.name = str(arg.value)
+                                            slot_var.type = ElementaryType("bytes32")
+                                            slot_var.is_constant = True
+                                            slot_var.expression = arg
+                                            slot_var.set_contract(func.contract if isinstance(func, FunctionContract)
+                                                                  else self)
+                                            self._proxy_impl_slot = slot_var
+                                            break
+                                    elif str(right.called) == "abi.decode":
+                                        arg = right.arguments[0]
+                                        if isinstance(arg, Identifier):
+                                            v = arg.value
+                                            if v.expression is not None:
+                                                ret.expression = v.expression
+                                                delegate = ret
+                                            else:
+                                                for exp in func.expressions:
+                                                    if isinstance(exp, AssignmentOperation):
+                                                        if v.name in str(exp.expression_left):
+                                                            ret.expression = exp.expression_right
+                                                            delegate = ret
+                                                            break
+                                    else:
+                                        delegate = self.find_delegate_from_call_exp(right, ret)
+                                        right_called = right.called
+                                        if delegate is None and isinstance(right_called, MemberAccess):
+                                            member_access_exp = right_called.expression
+                                            if isinstance(member_access_exp, TypeConversion):
+                                                e = member_access_exp.expression
+                                                if isinstance(e, Identifier) and str(e.value.type) == "address":
+                                                    delegate = self.find_delegate_variable_from_name(e.value.name, func)
+            if isinstance(ret, StateVariable):
+                delegate = ret
+            elif func.contains_assembly:
+                for n in func.all_nodes():
+                    if delegate is not None or self._proxy_impl_slot is not None:
+                        break
+                    if n.type == NodeType.ASSEMBLY and isinstance(n.inline_asm, str):
+                        # only handle versions < 0.6.0 here - otherwise use EXPRESSION nodes
+                        asm_split = n.inline_asm.split("\n")
+                        for asm in asm_split:
+                            if ret.name + " := sload(" in asm:
+                                # Return value set by sload in asm: extract the name of the slot variable
+                                slot_name = asm.split("sload(")[1].split(")")[0]
+                                if slot_name.startswith("0x"):
+                                    delegate = self.find_delegate_sloaded_from_hardcoded_slot(asm_split, ret.name, func)
+                                    if delegate is not None:
+                                        break
+                                # Find the slot variable by its name
+                                for v in func.variables_read_or_written:
+                                    if v.name == slot_name:
+                                        if isinstance(v, StateVariable) and v.is_constant:
+                                            self._proxy_impl_slot = v
+                                            break
+                                        elif isinstance(v, LocalVariable) and v.expression is not None:
+                                            e = v.expression
+                                            if isinstance(e, Identifier) and e.value.is_constant:
+                                                self._proxy_impl_slot = e.value
+                                                break
+                                break
+                    elif n.type == NodeType.EXPRESSION and ret.name in str(n.expression):
+                        # handle versions >= 0.6.0: we have expression nodes for assembly expressions
+                        e = n.expression
+                        if isinstance(e, AssignmentOperation):
+                            left = e.expression_left
+                            right = e.expression_right
+                            if isinstance(left, Identifier) and left.value == ret:
+                                if isinstance(right, CallExpression) and "sload" in str(right):
+                                    arg = right.arguments[0]
+                                    if isinstance(arg, Identifier):
+                                        v = arg.value
+                                        if isinstance(v, StateVariable) and v.is_constant:
+                                            self._proxy_impl_slot = v
+                                        elif isinstance(v, LocalVariable) and v.expression is not None:
+                                            e = v.expression
+                                            if isinstance(e, Identifier) and e.value.is_constant:
+                                                self._proxy_impl_slot = e.value
+                                    break
+            elif isinstance(ret, LocalVariable):
+                if ret.expression is not None:
+                    e = ret.expression
+                    if isinstance(e, CallExpression):
+                        called = e.called
+                        if isinstance(called, Identifier):
+                            val = called.value
+                            if isinstance(val, FunctionContract):
+                                if val.contract != self:
+                                    delegate = ret
+                        elif isinstance(called, MemberAccess):
+                            if str(called) == "abi.decode":
+                                arg = e.arguments[0]
+                                if isinstance(arg, Identifier):
+                                    val = arg.value
+                                    for n in func.all_nodes():
+                                        if n.type == NodeType.EXPRESSION:
+                                            e = n.expression
+                                            if isinstance(e, AssignmentOperation):
+                                                left = e.expression_left
+                                                right = e.expression_right
+                                                if isinstance(left, Identifier) and left.value == val:
+                                                    ret.expression = right
+                                                    break
+                                                elif isinstance(left, TupleExpression):
+                                                    for v in left.expressions:
+                                                        if isinstance(v, Identifier) and v.value == val:
+                                                            ret.expression = right
+                                                            break
+                                    e = ret.expression
+                                    if isinstance(e, CallExpression) and isinstance(e.called, MemberAccess):
+                                        delegate = self.find_delegate_from_member_access(e, var)
+                            elif called.member_name == "call" or called.member_name == "staticcall":
+                                _delegate = self.find_delegate_from_member_access(e, var)
+                                if _delegate is not None:
+                                    delegate = _delegate
+                            else:
+                                _delegate = self.find_delegate_from_member_access(called, var)
+                                if _delegate is not None:
+                                    delegate = _delegate
+                    elif isinstance(e, IndexAccess):
+                        left = e.expression_left
+                        if isinstance(left, Identifier):
+                            delegate = left.value
+        return delegate
+
+    def find_delegate_from_member_access(self, exp, var) -> Optional["Variable"]:
+        """
+        Called by self.find_delegate_from_call_exp
+        Tries to find the correct delegate variable object, i.e. self._delegates_to, given
+        a Member Access expression. A Member Access expression may represent a call to a
+        function in another contract, so this method tries to find the associated contract
+        in the compilation unit, and if found, tracks down the function that was called.
+
+        :param exp: either a MemberAccess expression or a CallExpression containing a MemberAccess
+        :param var: Variable which got its value from the MemberAccess, to be used if the source can't be found
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.declarations.structure import Structure
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.solidity_types.user_defined_type import UserDefinedType
+        from slither.core.solidity_types.elementary_type import ElementaryType
+
+        delegate: Optional[Variable] = None
+        contract: Optional[Contract] = None
+        member_name = None
+        args = None
+        orig_exp = exp
+        if isinstance(exp, CallExpression) and isinstance(exp.called, MemberAccess):
+            args = exp.arguments
+            exp = exp.called
+        if isinstance(exp, MemberAccess):
+            member_name = exp.member_name
+            e = exp.expression
+            if isinstance(e, CallExpression):
+                called = e.called
+                if isinstance(called, Identifier):
+                    f = called.value
+                    if isinstance(f, Function):
+                        ret_node = f.return_node()
+                        if ret_node is not None:
+                            e = f.return_node().expression
+                        else:
+                            ret_val = f.returns[0]
+                            e = Identifier(ret_val)
+                elif isinstance(called, MemberAccess):
+                    if isinstance(var, LocalVariable):
+                        parent_func = var.function
+                        for lib_call in parent_func.all_library_calls():
+                            if f"{lib_call[0]}.{lib_call[1]}" == str(called):
+                                if len(e.arguments) > 0 and isinstance(e.arguments[0], Identifier):
+                                    val = e.arguments[0].value
+                                    if (isinstance(val, StateVariable) and val.is_constant
+                                            and str(val.type) == "bytes32"):
+                                        slot = val
+                                        delegate = slot
+                                        self._proxy_impl_slot = slot
+                                break
+            if isinstance(e, TypeConversion) or isinstance(e, Identifier):
+                ctype = e.type
+                if isinstance(e, Identifier):
+                    if isinstance(e.value, Contract):
+                        ctype = UserDefinedType(e.value)
+                    else:
+                        ctype = e.value.type
+                if isinstance(ctype, UserDefinedType) and isinstance(ctype.type, Contract) and ctype.type != self:
+                    contract = ctype.type
+                    interface = None
+                    if contract.is_interface or (contract.get_function_from_name(member_name) is not None and
+                                                 not contract.get_function_from_name(member_name).is_implemented):
+                        interface = contract
+                    for c in self.compilation_unit.contracts:
+                        if c == interface:
+                            continue
+                        if interface in c.inheritance:
+                            contract = c
+                    if contract.is_interface:
+                        for c in self.compilation_unit.contracts:
+                            if c == contract:
+                                continue
+                            for f in c.functions:
+                                if f.name == member_name and str(f.return_type) == "address":
+                                    contract = c
+                            for v in c.state_variables:
+                                if v.name == member_name and "public" in v.visibility and "address" in str(v.type):
+                                    contract = c
+                        if contract.is_interface:
+                            delegate = var
+                            return delegate
+                elif isinstance(ctype, UserDefinedType) and isinstance(ctype.type, Structure):
+                    struct = ctype.type
+                    if isinstance(struct, Structure):
+                        try:
+                            delegate = struct.elems[member_name]
+                        except:
+                            if struct.contract != self:
+                                fn = struct.contract.get_function_from_name(member_name)
+                                if fn is not None and fn.return_node() is not None:
+                                    ret_node = fn.return_node()
+                                    rex = ret_node.expression
+                                    if isinstance(rex, IndexAccess):
+                                        left = rex.expression_left
+                                        if isinstance(left, MemberAccess):
+                                            ex = left.expression
+                                            if isinstance(ex, Identifier):
+                                                v = ex.value
+                                                t = v.type
+                                                if isinstance(t, UserDefinedType) and t.type == struct:
+                                                    delegate = struct.elems[left.member_name]
+                elif isinstance(ctype, ElementaryType) and ctype.type == "address":
+                    if member_name == "call" or member_name == "staticcall":
+                        """
+                        Implementation address comes from a call to an address w/o a specified
+                        Contract type, so we must check each contract for the function called.
+                        Trying to handle the tough case of Dharma's KeyRingUpgradeBeaconProxy.
+                        """
+                        arg = orig_exp.arguments[0]
+                        if arg is None or str(arg) == "":
+                            arg = "fallback"
+                        for c in self.compilation_unit.contracts:
+                            if c == self:
+                                continue
+                            if arg == "fallback":
+                                fn = c.fallback_function
+                            else:
+                                fn = c.get_function_from_name(arg)
+                            if fn is None:
+                                continue
+                            else:
+                                if len(fn.returns) > 0:
+                                    if str(fn.returns[0].type) == "address":
+                                        ret = fn.returns[0]
+                                        """
+                                        This part doesn't apply to the FN I'm trying to solve,
+                                        so I leave it unfinished for now.
+                                        """
+                                else:
+                                    """
+                                    This bit is pretty specific to the Dharma BeaconProxy and
+                                    DharmaUpgradeBeacon, which uses its fallback as both the
+                                    setter and getter for the implementation address.
+                                    """
+                                    for node in fn.all_nodes():
+                                        if node.type == NodeType.ASSEMBLY:
+                                            inline_asm = node.inline_asm
+                                            if "sload" in inline_asm and "mstore" in inline_asm\
+                                                    and "return" in inline_asm:
+                                                self._proxy_impl_getter = fn
+                                            if "sstore" in inline_asm:
+                                                self._proxy_impl_setter = fn
+        if contract is not None:
+            for f in contract.functions:
+                if f.name == member_name:
+                    if f.is_implemented:
+                        self._proxy_impl_getter = f
+                    ret = f.returns[0]
+                    ret_node = f.return_node()
+                    if ret_node is not None:
+                        e = ret_node.expression
+                        if isinstance(e, Identifier):
+                            ret = e.value
+                        elif isinstance(e, MemberAccess):
+                            ex = e.expression
+                            if isinstance(ex, CallExpression):
+                                called = ex.called
+                                if isinstance(called, MemberAccess):
+                                    if delegate is None:
+                                        delegate: LocalVariable = LocalVariable()
+                                        delegate.expression = e
+                                        delegate.set_function(ret_node.function)
+                                    if delegate.name is None:
+                                        delegate.name = str(e)
+                                    if delegate.type is None:
+                                        delegate.type = ret.type
+                                    args = [arg.value for arg in ex.arguments if isinstance(arg, Identifier)]
+                                    for a in args:
+                                        if str(a.type) == "bytes32" and a.is_constant:
+                                            self._proxy_impl_slot = a
+                                            break
+                            elif isinstance(ex, IndexAccess):
+                                e = ex  # Fall through
+                        if isinstance(e, IndexAccess):
+                            left = e.expression_left
+                            if isinstance(left, Identifier):
+                                if isinstance(left.value, StateVariable):
+                                    delegate = left.value
+                                    break
+                                elif isinstance(left.value, LocalVariable):
+                                    delegate = self.find_delegate_variable_from_name(left.value.name, ret_node.function)
+                                    if delegate is not None:
+                                        break
+                    if isinstance(ret, StateVariable):
+                        delegate = ret
+                    elif isinstance(ret, LocalVariable):
+                        if ret.expression is None:
+                            for n in f.all_nodes():
+                                if n.type == NodeType.EXPRESSION:
+                                    e = n.expression
+                                    if isinstance(e, AssignmentOperation):
+                                        left = e.expression_left
+                                        right = e.expression_right
+                                        if isinstance(left, Identifier) and left.value == ret:
+                                            ret.expression = right
+                                elif n.type == NodeType.ASSEMBLY:
+                                    # TODO: check for assignment inside of assembly
+                                    asm = n.inline_asm
+                        if ret.expression is not None:
+                            e = ret.expression
+                            if isinstance(e, Identifier) and isinstance(e.value, StateVariable):
+                                delegate = e.value
+                            elif isinstance(e, CallExpression):
+                                delegate = contract.find_delegate_from_call_exp(e, ret)
+            if delegate is None:
+                for v in contract.state_variables:
+                    if v.name == member_name and "public" in v.visibility and "address" in str(v.type):
+                        delegate = v
+                        break
+        return delegate
+
+    def find_delegate_sloaded_from_hardcoded_slot(
+            self,
+            asm_split: List[str],
+            dest: str,
+            parent_func: Function
+    ) -> Optional["Variable"]:
+        """
+        Finally, here I am trying to handle the case where there are no variables at all in the proxy,
+        except for one defined within the assembly block itself with the slot hardcoded as seen below.
+        In such an instance, there is literally no Variable object to assign to self._delegates_to,
+        so we attempt to create a new one if appropriate
+        ex: /tests/proxies/EIP1822Token.sol
+        function() external payable {
+            assembly { // solium-disable-line
+                let logic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+                calldatacopy(0x0, 0x0, calldatasize)
+                let success := delegatecall(sub(gas, 10000), logic, 0x0, calldatasize, 0, 0)
+                ...
+            }
+        }
+
+        :param asm_split: a List of strings representing each line of assembly code
+        :param dest: the name of the delegatecall destination variable extracted from the assembly string
+        :param parent_func: the function in which this assembly is found
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.expressions.literal import Literal
+        from slither.core.declarations.contract_level import ContractLevel
+        from slither.core.solidity_types.elementary_type import ElementaryType
+
+        delegates_to = None
+        for asm in asm_split:
+            if dest in asm and "sload(" in asm:
+                slot = asm.split("sload(", 1)[1].split(")")[0]
+                if len(slot) == 66 and slot.startswith("0x"):  # 32-bit memory address
+                    # TODO: make sure we don't need to construct a LocalVariable from scratch anymore,
+                    #       now that we're allowing self._delegate_variable to equal self._proxy_impl_slot
+                    # delegates_to = LocalVariable()
+                    # delegates_to.set_type(ElementaryType("address"))
+                    # delegates_to.name = dest
+                    # delegates_to.set_location(slot)
+                    impl_slot = StateVariable()
+                    impl_slot.name = slot
+                    impl_slot.is_constant = True
+                    impl_slot.expression = Literal(slot, ElementaryType("bytes32"))
+                    impl_slot.set_type(ElementaryType("bytes32"))
+                    impl_slot.set_contract(parent_func.contract
+                                           if isinstance(parent_func, ContractLevel)
+                                           else self)
+                    self._proxy_impl_slot = impl_slot
+                    break
+                else:
+                    delegates_to = self.find_delegate_variable_from_name(slot.strip("_slot"), parent_func)
+        return delegates_to
+
+    @staticmethod
+    def find_delegatecall_in_ir(node):     # General enough to keep as is
+        """
+        Handles finding delegatecall outside an assembly block, as a LowLevelCall
+        i.e. delegate.delegatecall(msg.data)  
+        ex: tests/proxies/Delegation.sol (appears to have been written to demonstrate a vulnerability)
+
+        :param node: a CFG Node object
+        :return: boolean indicating if delegatecall was found, and the corresponding Variable object, if found
+        """
+        from slither.slithir.operations import LowLevelCall
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.declarations.contract_level import ContractLevel
+        from slither.core.declarations.function_contract import FunctionContract
+        from slither.slithir.variables.temporary import TemporaryVariable
+
+        is_proxy = False
+        delegate_to = None
+
+        for ir in node.irs:
+            if isinstance(ir, LowLevelCall):
+                if ir.function_name == "delegatecall":
+                    is_proxy = True
+                    delegate_to = ir.destination
+                    break
+        if isinstance(delegate_to, LocalVariable):
+            e = delegate_to.expression
+            if e is not None:
+                if isinstance(e, CallExpression) and isinstance(delegate_to, ContractLevel):
+                    if isinstance(delegate_to.function, ContractLevel):
+                        delegate_to = delegate_to.function.contract.find_delegate_from_call_exp(e, delegate_to)
+                elif isinstance(e, MemberAccess) and isinstance(delegate_to, ContractLevel):
+                    delegate_to = delegate_to.contract.find_delegate_from_member_access(e, delegate_to)
+        elif isinstance(delegate_to, TemporaryVariable):
+            exp = delegate_to.expression
+            if isinstance(exp, CallExpression):
+                called = exp.called
+                if isinstance(called, Identifier):
+                    func = called.value
+                    if isinstance(func, FunctionContract):
+                        if not func.is_implemented:
+                            for f in node.function.contract.functions:
+                                if f.name == func.name and f.is_implemented:
+                                    func = f
+                        delegate_to = func.contract.find_delegate_from_call_exp(exp, delegate_to)
+        return is_proxy, delegate_to
+
+    def find_delegatecall_in_exp_node(self, node):
+        """
+        For versions >= 0.6.0, in addition to Assembly nodes as seen above, it seems that 
+        Slither creates Expression nodes for expressions within an inline assembly block.
+        This is convenient, because sometimes self.find_delegatecall_in_asm fails to find 
+        the target Variable self._delegates_to, so this serves as a fallback for such cases.
+        ex: /tests/proxies/App2.sol (for comparison, /tests/proxies/App.sol is an earlier version)
+
+        :param node: a CFG Node object
+        :return: the corresponding Variable object, if found
+        """
+        from slither.core.expressions.expression import Expression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.literal import Literal
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.variables.state_variable import StateVariable
+
+        is_proxy = False
+        delegate_to = None
+        expression = node.expression
+        if isinstance(expression, Expression):
+            if isinstance(expression, AssignmentOperation):
+                """
+                Handles the common case like this: 
+                let result := delegatecall(gas, implementation, 0, calldatasize, 0, 0)
+                """
+                expression = expression.expression_right
+        if isinstance(expression, CallExpression):
+            if "delegatecall" in str(expression.called):
+                is_proxy = True
+                if len(expression.arguments) > 1:
+                    dest = expression.arguments[1]
+                    if isinstance(dest, Identifier):
+                        val = dest.value
+                        if isinstance(val, StateVariable):
+                            delegate_to = val
+                        elif isinstance(val, LocalVariable):
+                            exp = val.expression
+                            if exp is not None:
+                                if isinstance(exp, Identifier) and isinstance(exp.value, StateVariable):
+                                    delegate_to = exp.value
+                                elif isinstance(exp, CallExpression):
+                                    delegate_to = self.find_delegate_from_call_exp(exp, val)
+                                elif isinstance(exp, MemberAccess):
+                                    exp = exp.expression
+                                    if isinstance(exp, IndexAccess):
+                                        exp = exp.expression_left
+                                        if isinstance(exp, Identifier):
+                                            delegate_to = val
+                                        elif isinstance(exp, MemberAccess):
+                                            exp = exp.expression
+                                            if isinstance(exp, Identifier):
+                                                delegate_to = val
+                                elif isinstance(exp, Literal) and str(exp.type) == "address":
+                                    delegate_to = val
+                            else:
+                                delegate_to = self.find_delegate_variable_from_name(val.name, node.function)
+        return is_proxy, delegate_to
+
+    def getter_return_is_non_constant(self) -> bool:
+        """
+        If we could only find the getter, but not the setter, make sure that the getter does not return
+        a variable that can never be set (i.e. is practically constant, but not declared constant)
+        Instead we would like to see if the getter returns the result of a call to another function,
+        possibly a function in another contract.
+        ex: in /tests/proxies/APMRegistry.sol, AppProxyPinned should not be identified as upgradeable,
+            though AppProxyUpgradeable obviously should be
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.analyses.data_dependency import data_dependency
+
+        for node in self._proxy_impl_getter.all_nodes():
+            exp = node.expression
+            if node.type == NodeType.EXPRESSION and isinstance(exp, AssignmentOperation):
+                left = exp.expression_left
+                right = exp.expression_right
+                if isinstance(left, Identifier) and left.value == self._delegate_variable:
+                    if isinstance(right, Identifier) and right.value.is_constant:
+                        self._is_upgradeable_proxy = False
+                        return self._is_upgradeable_proxy
+                    elif isinstance(right, CallExpression):
+                        if "sload" in str(right):
+                            slot = right.arguments[0]
+                            if isinstance(slot, Identifier):
+                                slot = slot.value
+                                if slot.is_constant:
+                                    self._proxy_impl_slot = slot
+                                elif isinstance(slot, LocalVariable):
+                                    for v in self.variables:
+                                        if data_dependency.is_dependent(slot, v, node.function) and v.is_constant:
+                                            self._proxy_impl_slot = v
+                                            break
+                        if self._proxy_impl_slot is not None and self._proxy_impl_setter is None:
+                            for f in self.functions:
+                                if f.contains_assembly:
+                                    slot = None
+                                    for n in f.all_nodes():
+                                        if n.type == NodeType.EXPRESSION:
+                                            e = n.expression
+                                            if isinstance(e, AssignmentOperation):
+                                                l = e.expression_left
+                                                r = e.expression_right
+                                                if isinstance(r, Identifier) and r.value == self._proxy_impl_slot:
+                                                    slot = l.value
+                                            elif isinstance(e, CallExpression) and str(e.called) == "sstore":
+                                                if e.arguments[0] == slot or e.arguments[0] == self._proxy_impl_slot:
+                                                    self._proxy_impl_setter = f
+                                        elif n.type == NodeType.ASSEMBLY and n.inline_asm is not None:
+                                            if "sstore(" + str(slot) in n.inline_asm \
+                                                    or "sstore(" + str(self._proxy_impl_slot) in n.inline_asm:
+                                                self._proxy_impl_setter = f
+                        self._is_upgradeable_proxy = True
+                        return self._is_upgradeable_proxy
+                    elif isinstance(right, MemberAccess):
+                        self._is_upgradeable_proxy = True
+                        return self._is_upgradeable_proxy
+            elif node.type == NodeType.RETURN:
+                if isinstance(exp, CallExpression):
+                    self._is_upgradeable_proxy = True
+                    return self._is_upgradeable_proxy
+        return self._is_upgradeable_proxy
+
+    @staticmethod
+    def find_getter_in_contract(
+            contract: "Contract", 
+            var_to_get: Union[str, "Variable"]
+    ) -> Optional[Function]:
+        """
+        Tries to find the getter function for a given variable.
+        Static because we can use this for cross-contract implementation setters, i.e. EIP 1822 Proxy/Proxiable
+
+        :param contract: the Contract to look in
+        :param var_to_get: the Variable to look for, or at least its name as a string
+        :return: the function in contract which sets var_to_set, if found
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.identifier import Identifier
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.assignment_operation import AssignmentOperation
+        from slither.core.solidity_types.user_defined_type import UserDefinedType
+
+        getter = None
+        exp = (var_to_get.expression if isinstance(var_to_get, Variable) else None)
+        for f in contract.functions:
+            if contract._proxy_impl_getter is not None:
+                getter = contract._proxy_impl_getter
+                break
+            if len(f.all_nodes()) == 0:
+                continue
+            if f.name is not None:
+                if isinstance(exp, CallExpression) and len(f.all_nodes()) > 0:
+                    if f.name == str(exp.called) or exp in f.expressions:
+                        getter = f
+                        break
+            else:
+                continue
+            if not f.is_fallback and not f.is_constructor and not f.is_receive and "init" not in f.name.lower():
+                # if f.visibility == "internal" or f.visibility == "private":
+                #     continue
+                if len(f.returns) > 0:
+                    skip_f = False
+                    for v in f.returns:
+                        if v == var_to_get:
+                            getter = f
+                            break
+                        if (isinstance(v.type, UserDefinedType) and isinstance(v.type.type, Contract)) \
+                                or isinstance(v.type, Contract):
+                            """ Not interested in functions that return a new Contract """
+                            skip_f = True
+                    if skip_f:
+                        continue
+                    for n in f.all_nodes():
+                        if getter is not None:
+                            break
+                        if n.type == NodeType.RETURN and n.function == f:
+                            """ Not interested in RETURN nodes in functions called by f """
+                            e = n.expression
+                            if isinstance(e, MemberAccess):
+                                e = e.expression
+                                """Fall through to below"""
+                            if isinstance(e, IndexAccess):
+                                if isinstance(exp, IndexAccess):
+                                    if isinstance(e.expression_left, Identifier) and isinstance(exp.expression_left,
+                                                                                                Identifier):
+                                        if e.expression_left.value == exp.expression_left.value:
+                                            getter = f
+                                            break
+                                else:
+                                    e = e.expression_left
+                                    """Fall through to below"""
+                            if isinstance(e, Identifier) and e.value == var_to_get:
+                                getter = f
+                                break
+                        if contract.proxy_impl_storage_offset is not None and f.contains_assembly:
+                            slot = contract.proxy_impl_storage_offset
+                            if n.type == NodeType.ASSEMBLY and isinstance(n.inline_asm, str) \
+                                    and "sload(" in n.inline_asm:
+                                slot_name = n.inline_asm.split("sload(")[1].split(")")[0]
+                                if slot_name == slot.name:
+                                    getter = f
+                                    break
+                                for v in n.function.variables_read_or_written:
+                                    if v.name == slot_name and isinstance(v, LocalVariable) and v.expression is not None:
+                                        e = v.expression
+                                        if isinstance(e, Identifier) and e.value == slot:
+                                            getter = f
+                                            break
+                            elif n.type == NodeType.EXPRESSION:
+                                e = n.expression
+                                if isinstance(e, AssignmentOperation):
+                                    e = e.expression_right
+                                if isinstance(e, CallExpression) and "sload" in str(e.called):
+                                    e = e.arguments[0]
+                                    if isinstance(e, Identifier):
+                                        v = e.value
+                                        if v == slot:
+                                            getter = f
+                                            break
+                                        elif isinstance(v, LocalVariable) and v.expression is not None:
+                                            e = v.expression
+                                            if isinstance(e, Identifier) and e.value == slot:
+                                                getter = f
+                                                break
+                    if getter is not None:
+                        break
+        return getter
+
+    @staticmethod
+    def find_setter_in_contract(
+            contract: "Contract",
+            var_to_set: Union[str, "Variable"],
+            storage_slot: Optional["Variable"]
+    ) -> (Optional[Function], Union[str, "Variable"]):
+        """
+        Tries to find the setter function for a given variable.
+        Static because we can use this for cross-contract implementation setters, i.e. EIP 1822 Proxy/Proxiable
+
+        :param contract: the Contract to look in
+        :param var_to_set: the Variable to look for, or at least its name as a string
+        :param storage_slot: an optional, constant variable containing a storage offset (for setting via sstore)
+        :return: the function in contract which sets var_to_set, if found, and var_to_set, which may have been changed
+        """
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.variable import Variable
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.expression import Expression
+        from slither.core.expressions.assignment_operation import AssignmentOperation, AssignmentOperationType
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.index_access import IndexAccess
+        from slither.core.expressions.identifier import Identifier
+
+        setter = None
+        assignment = None
+        var_exp = (var_to_set.expression if isinstance(var_to_set, Variable) else None)
+        for f in contract.functions_declared + contract.functions_inherited:
+            if setter is not None:
+                break
+            if not f.is_fallback and not f.is_constructor and not f.is_receive \
+                    and "init" not in f.name.lower() and "fallback" not in f.name.lower():  # avoid _fallback()
+                if f.visibility == "internal" or f.visibility == "private":
+                    continue
+                # # Commented out because the remaining code can handle any cases this one would catch,
+                # # but we need to check for an AssignmentOperation that writes to var_to_set
+                # # in case we find that the value being written comes from a cross-contract call.
+                # for v in f.variables_written:
+                #     if isinstance(v, LocalVariable) and v in f.returns:
+                #         continue
+                #     elif isinstance(v, StateVariable):
+                #         if str(var_to_set) == v.name:
+                #             setter = f
+                #             break
+                for node in f.all_nodes():
+                    if setter is not None:
+                        break
+                    if node.type == NodeType.ASSEMBLY:
+                        inline = node.inline_asm
+                        if isinstance(inline, str):
+                            for asm in inline.split("\n"):
+                                if "sstore" in asm:
+                                    slot_name = asm.split("sstore(")[1].split(",")[0]
+                                    written_name = name = asm.split("sstore(")[1].split(",")[1].split(")")[0].strip()
+                                    if slot_name == str(storage_slot):
+                                        setter = f
+                                        break
+                                    for v in node.function.variables_read_or_written:
+                                        if v.name == slot_name:
+                                            if v in [storage_slot, var_to_set]:
+                                                setter = f
+                                            elif isinstance(v, LocalVariable):
+                                                exp = v.expression
+                                                if isinstance(exp, Identifier) and exp.value in [storage_slot,
+                                                                                                 var_to_set]:
+                                                    setter = f
+                                        elif v.name == written_name and isinstance(v, LocalVariable):
+                                            exp = v.expression
+                                            if isinstance(exp, AssignmentOperation):
+                                                assignment = exp
+                                            elif isinstance(exp, CallExpression) or isinstance(exp, MemberAccess):
+                                                v_id = Identifier(v)
+                                                assignment = AssignmentOperation(v_id, exp,
+                                                                                 AssignmentOperationType.ASSIGN)
+                                    if setter is not None:
+                                        break
+                    elif node.type == NodeType.EXPRESSION or node.type == NodeType.RETURN:
+                        exp = node.expression
+                        if isinstance(exp, CallExpression) and "sstore" in str(exp.called):
+                            slot_arg = exp.arguments[0]
+                            written_arg = exp.arguments[1]
+                            if isinstance(slot_arg, Identifier):
+                                v = slot_arg.value
+                                if v in [storage_slot, var_to_set]:
+                                    setter = f
+                                elif isinstance(v, LocalVariable):
+                                    exp = v.expression
+                                    if isinstance(exp, Identifier) and exp.value in [storage_slot, var_to_set]:
+                                        setter = f
+                            elif storage_slot is not None and str(slot_arg) == storage_slot.name:
+                                setter = f
+                            if isinstance(written_arg, Identifier) and isinstance(written_arg.value, LocalVariable):
+                                exp = written_arg.value.expression
+                                if isinstance(exp, AssignmentOperation):
+                                    assignment = exp
+                                elif isinstance(exp, CallExpression) or isinstance(exp, MemberAccess):
+                                    assignment = AssignmentOperation(written_arg, exp,
+                                                                     AssignmentOperationType.ASSIGN)
+                        elif isinstance(exp, AssignmentOperation):
+                            left = exp.expression_left
+                            if isinstance(left, MemberAccess):
+                                member_of = left.expression
+                                if isinstance(member_of, CallExpression):
+                                    if var_to_set in [arg.value for arg in member_of.arguments
+                                                      if isinstance(arg, Identifier)]:
+                                        setter = f
+                                        assignment = exp
+                                    elif str(left) == var_to_set.name:
+                                        setter = f
+                                        assignment = exp
+                            elif var_exp is not None:
+                                if var_exp == left or str(var_exp) == str(left):   # Expression.__eq__() not implemented
+                                    setter = f
+                                    assignment = exp
+                                elif isinstance(left, Identifier) and var_to_set == left.value:
+                                    setter = f
+                                    assignment = exp
+                                elif isinstance(left, IndexAccess) and isinstance(var_exp, IndexAccess):
+                                    if str(left.expression_left) == str(var_exp.expression_left):
+                                        setter = f
+                                        assignment = exp
+                            elif isinstance(left, IndexAccess):
+                                left = left.expression_left
+                                if (isinstance(left, MemberAccess) and left.member_name == var_to_set.name) \
+                                        or (isinstance(left, Identifier) and left.value == var_to_set):
+                                    setter = f
+                                    assignment = exp
+                            elif str(left) == var_to_set.name:
+                                setter = f
+                                assignment = exp
+        if setter is not None and assignment is not None:
+            """
+            Found setter in the given contract, and the AssignmentOperation doing the setting.
+            But what is the new value that is being assigned, and where does it come from?
+            Most likely it is just an address variable that comes from the setter's arguments,
+            but the right side of the AssignmentOperation could include a CallExpression, which
+            could be a cross-contract call. 
+            For example (tests/proxies/ContributionTriggerRegistry.sol):
+                function upgradeTo(uint256 _version) public {
+                    require(msg.sender == address(registry),"ERR_ONLY_REGISTRERY_CAN_CALL");
+                    _implementation = registry.getVersion(_version);
+                }
+            In this case, _implementation is a StateVariable which is inherited by the proxy,
+            and this is accessed directly (without a contract call) when delegating. 
+            Therefore it doesn't make sense to change self._delegate_variable to reference 
+            whatever gets returned by registry.getVersion(_version) instead of _implementation.
+            So, rather than check for a CallExpression here and trace it to its source if found,
+            we leave that to be done later by the ProxyFeatureExtraction class, and simply
+            update var_to_set here by giving assigning it an expression.
+            """
+            right = assignment.expression_right
+            var_to_set.expression = right
+        if setter is None and "facet" in str(var_to_set):
+            """
+            Handle the corner case for EIP-2535 Diamond proxy
+            The function diamondCut is used to add/delete/modify logic contracts (it is the setter)
+            But, this function is implemented in a facet (logic) contract itself, i.e. DiamondCutFacet
+            This facet is added by the constructor, using LibDiamond.diamondCut, and subsequent calls
+            to diamondCut are handled by the fallback(), which delegates to the DiamondCutFacet
+            ex: /tests/proxies/DiamondFactory.sol
+            """
+            constructor = contract.constructors_declared
+            if constructor is not None:
+                for n in constructor.all_nodes():
+                    if n.type == NodeType.EXPRESSION:
+                        exp = n.expression
+                        if isinstance(exp, CallExpression):
+                            # TODO: Remove dependence on function name "diamondCut"
+                            if "diamondCut" in str(exp.called):
+                                diamond_cut = exp.arguments[0]
+                                if isinstance(diamond_cut, Identifier) and "DiamondCut" in str(diamond_cut.value.type):
+                                    idiamond_cut = contract.compilation_unit.get_contract_from_name("IDiamondCut")
+                                    cut_facet = idiamond_cut
+                                    for c in contract.compilation_unit.contracts:
+                                        if c == idiamond_cut:
+                                            continue
+                                        if idiamond_cut in c.inheritance:
+                                            cut_facet = c
+                                    if cut_facet != idiamond_cut:
+                                        """ Found implementation of DiamondCutFacet """
+                                        for f in cut_facet.functions:
+                                            if f.name == "diamondCut":
+                                                setter = f
+                                                break
+                                    else:
+                                        lib_diamond = contract.compilation_unit.get_contract_from_name("LibDiamond")
+                                        setter = lib_diamond.get_function_from_name("diamondCut")
+                                        if setter is not None:
+                                            break
+                        elif isinstance(exp, AssignmentOperation):
+                            left = exp.expression_left
+                            right = exp.expression_right
+                            if isinstance(left, IndexAccess):
+                                left = left.expression_left
+                                if isinstance(left, Identifier) and str(left.value.type) == "bytes4[]":
+                                    if isinstance(right, MemberAccess) and right.member_name == "selector":
+                                        right = right.expression
+                                        if isinstance(right, MemberAccess):
+                                            member_name = right.member_name
+                                            member_of = right.expression
+                                            if isinstance(member_of, Identifier):
+                                                value = member_of.value
+                                                if isinstance(value, Contract):
+                                                    setter = value.get_function_from_name(member_name)
+                                                    break
+        return setter, var_to_set
+
+    def handle_local_delegate_from_call_exp(self) -> bool:
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.expressions.type_conversion import TypeConversion
+        from slither.core.expressions.call_expression import CallExpression
+        from slither.core.solidity_types.user_defined_type import UserDefinedType
+        from slither.core.expressions.member_access import MemberAccess
+        from slither.core.expressions.identifier import Identifier
+
+        if isinstance(self._delegate_variable, LocalVariable):
+            call = self._delegate_variable.expression
+            if isinstance(call, CallExpression):
+                call = call.called
+                if isinstance(call, MemberAccess):
+                    e = call.expression
+                    if isinstance(e, CallExpression) and isinstance(e.called, Identifier):
+                        f = e.called.value
+                        if isinstance(f, Function):
+                            ret_node = f.return_node()
+                            if ret_node is not None:
+                                e = f.return_node().expression
+                            else:
+                                ret_val = f.returns[0]
+                                e = Identifier(ret_val)
+                    if isinstance(e, TypeConversion) or isinstance(e, Identifier):
+                        ctype = e.type
+                        if isinstance(e, Identifier):
+                            if isinstance(e.value, Contract):
+                                ctype = UserDefinedType(e.value)
+                            else:
+                                ctype = e.value.type
+                        if isinstance(ctype, UserDefinedType) and isinstance(ctype.type,
+                                                                             Contract) and ctype.type != self:
+                            contract = ctype.type
+                            if contract.is_interface:
+                                # call destination to retrieve delegate target is hidden in an interface,
+                                # cannot use cross-contract analysis to confirm upgradeability
                                 self._is_upgradeable_proxy = True
+                                self._is_upgradeable_proxy_confirmed = False
+        return self._is_upgradeable_proxy
+
+    def handle_delegate_state_var_different_contract(self):
+        # Whenever we call find_setter_in_contract, we should also update _delegate_variable, in case
+        # find_setter_in_contract found an AssignmentOperation and updated _delegate_variable.expression
+        (self._proxy_impl_setter,
+         self._delegate_variable) = self.find_setter_in_contract(self._delegate_variable.contract,
+                                                                 self._delegate_variable,
+                                                                 self._proxy_impl_slot)
+        if self._proxy_impl_setter is None:
+            # Failed to find setter in self._delegate_variable.contract, so look in self
+            (self._proxy_impl_setter,
+             self._delegate_variable) = self.find_setter_in_contract(self, self._delegate_variable,
+                                                                     self._proxy_impl_slot)
+            if self._proxy_impl_setter is None:
+                # Failed to find setter in self, so scan the rest of the compilation unit contracts
+                for c in self.compilation_unit.contracts:
+                    if c == self or c == self._delegate_variable.contract or self in c.inheritance:
+                        continue
+                    if self._proxy_impl_setter is not None:
+                        break
+                    if self._delegate_variable.contract in c.inheritance:
+                        (self._proxy_impl_setter,
+                         self._delegate_variable) = self.find_setter_in_contract(c, self._delegate_variable,
+                                                                                 self._proxy_impl_slot)
+
+    def handle_delegate_local_var_different_contract(self):
+        (self._proxy_impl_setter,
+         self._delegate_variable) = self.find_setter_in_contract(self._delegate_variable.function.contract,
+                                                                 self._delegate_variable, self._proxy_impl_slot)
+        if self._proxy_impl_setter is None:
+            for c in self.compilation_unit.contracts:
+                if c == self or c == self._delegate_variable.function.contract or self in c.inheritance:
+                    continue
+                if self._delegate_variable.function.contract in c.inheritance:
+                    (self._proxy_impl_setter,
+                     self._delegate_variable) = self.find_setter_in_contract(c, self._delegate_variable,
+                                                                             self._proxy_impl_slot)
+
+    def handle_missing_getter(self) -> bool:
+        from slither.core.cfg.node import NodeType
+        from slither.core.variables.state_variable import StateVariable
+        from slither.core.variables.local_variable import LocalVariable
+        from slither.core.variables.structure_variable import StructureVariable
+        from slither.core.declarations.function_contract import FunctionContract
+
+        delegate_contract = None
+        if isinstance(self._delegate_variable, StateVariable) and self._delegate_variable.contract != self:
+            delegate_contract = self._delegate_variable.contract
+        elif isinstance(self._delegate_variable, LocalVariable) and \
+                isinstance(self._delegate_variable.function, FunctionContract) and \
+                self._delegate_variable.function.contract != self:
+            delegate_contract = self._delegate_variable.function.contract
+        elif isinstance(self._delegate_variable, StructureVariable) and \
+                isinstance(self._delegate_variable.structure, StructureContract) and \
+                self._delegate_variable.structure.contract != self:
+            delegate_contract = self._delegate_variable.structure.contract
+        if delegate_contract is not None:
+            for c in self.compilation_unit.contracts:
+                if delegate_contract in c.inheritance and c != self and self not in c.inheritance:
+                    self._proxy_impl_getter = self.find_getter_in_contract(c, self._delegate_variable)
+                    if self._proxy_impl_setter is None:
+                        (self._proxy_impl_setter,
+                         self._delegate_variable) = self.find_setter_in_contract(c, self._delegate_variable, None)
+                    if self._proxy_impl_setter is not None:
+                        self._is_upgradeable_proxy = True
+                        self._is_upgradeable_proxy_confirmed = True
+                        return self._is_upgradeable_proxy
+                    elif self._proxy_impl_getter is not None:
+                        self._is_upgradeable_proxy = self.getter_return_is_non_constant()
+                        return self._is_upgradeable_proxy
+        """
+        Handle the case where the delegate address is a state variable which is also declared in the
+        implementation contract at the same position in storage, in which case the setter may be
+        located in the implementation contract, though we have no other clues that this may be the case.
+        """
+        if isinstance(self._delegate_variable, StateVariable):
+            index = -1
+            for idx, var in enumerate(self.state_variables_ordered):
+                if var == self._delegate_variable:
+                    index = idx
+                    break
+            if index >= 0:
+                for c in self.compilation_unit.contracts:
+                    if len(c.state_variables_ordered) < index + 1 or c == self:
+                        continue
+                    var = c.state_variables_ordered[index]
+                    if var.name != self._delegate_variable.name and self._delegate_variable == self._proxy_impl_slot:
+                        var = c.get_state_variable_from_name(self._delegate_variable.name)
+                    if var is not None:
+                        if var.name == self._delegate_variable.name and var.type == self._delegate_variable.type:
+                            self._proxy_impl_getter = self.find_getter_in_contract(c, var)
+                            if self._proxy_impl_setter is None:
+                                (self._proxy_impl_setter,
+                                 self._delegate_variable) = self.find_setter_in_contract(c, var, None)
+                            if self._proxy_impl_setter is not None:
+                                self._is_upgradeable_proxy = True
+                                self._is_upgradeable_proxy_confirmed = True
                                 return self._is_upgradeable_proxy
-                        if node.type == NodeType.ASSEMBLY:
-                            inline_asm = node.inline_asm
-                            if inline_asm:
-                                if "delegatecall" in inline_asm:
-                                    self._is_upgradeable_proxy = True
-                                    return self._is_upgradeable_proxy
+                            elif self._proxy_impl_getter is not None:
+                                return c.getter_return_is_non_constant()
+        """
+        Handle the case, as in EIP 1822, where the Proxy has no implementation getter because it is
+        loaded explicitly from a hard-coded slot within the fallback itself.
+        We assume in this case that, if the Proxy needs to load the implementation address from storage slot
+        then the address must not be constant - otherwise why not use a constant address
+        This is only necessary if the Proxy also doesn't have an implementation setter, because it is
+        located in another contract. The assumption is only necessary if we do not search cross-contracts.
+        """
+        if self._proxy_impl_slot is not None or self._delegate_variable.expression is not None:
+            for c in self.compilation_unit.contracts:
+                if c != self and self not in c.inheritance:
+                    self._proxy_impl_getter = self.find_getter_in_contract(c, self._delegate_variable)
+                    if self._proxy_impl_setter is None:
+                        (self._proxy_impl_setter,
+                         self._delegate_variable) = self.find_setter_in_contract(c, self._delegate_variable,
+                                                                                 self._proxy_impl_slot)
+                    if self._proxy_impl_setter is not None:
+                        self._is_upgradeable_proxy = True
+                        self._is_upgradeable_proxy_confirmed = True
+                        return self._is_upgradeable_proxy
+                    elif self._proxy_impl_getter is not None:
+                        return c.getter_return_is_non_constant()
+        else:
+            for n in self.fallback_function.all_nodes():
+                if n.type == NodeType.ASSEMBLY:
+                    inline_asm = n.inline_asm
+                    if inline_asm and "sload" in str(inline_asm):  # and self._delegates_to.name in inline_asm:
+                        self._is_upgradeable_proxy = True
         return self._is_upgradeable_proxy
 
     @is_upgradeable_proxy.setter

--- a/slither/detectors/all_detectors.py
+++ b/slither/detectors/all_detectors.py
@@ -106,3 +106,5 @@ from .functions.pyth_deprecated_functions import PythDeprecatedFunctions
 from .functions.optimism_deprecation import OptimismDeprecation
 
 # from .statements.unused_import import UnusedImport
+from .proxy.proxy_standards import ProxyStandards, ProxyFeatures
+from .proxy.proxy_patterns import ProxyPatterns

--- a/slither/detectors/proxy/proxy_features.py
+++ b/slither/detectors/proxy/proxy_features.py
@@ -1,0 +1,1563 @@
+from abc import ABC
+
+from inspect import currentframe, getframeinfo
+from symtable import Function
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from typing import Optional, List, Dict, Set, Callable, Tuple, TYPE_CHECKING, Union
+from slither.core.cfg.node import Node, NodeType
+from slither.core.declarations.contract import Contract
+from slither.core.compilation_unit import SlitherCompilationUnit
+from slither.core.declarations.structure import Structure
+from slither.core.declarations.structure_contract import StructureContract
+from slither.core.declarations.solidity_variables import SolidityVariable, SolidityFunction
+from slither.core.variables.variable import Variable
+from slither.core.variables.state_variable import StateVariable
+from slither.core.variables.local_variable import LocalVariable
+from slither.core.variables.structure_variable import StructureVariable
+from slither.core.expressions.identifier import Identifier
+from slither.core.expressions.literal import Literal
+from slither.core.declarations.function_contract import FunctionContract
+from slither.core.expressions.expression import Expression
+from slither.core.expressions.tuple_expression import TupleExpression
+from slither.core.expressions.literal import Literal
+from slither.core.expressions.call_expression import CallExpression
+from slither.core.expressions.type_conversion import TypeConversion
+from slither.core.expressions.assignment_operation import AssignmentOperation
+from slither.core.expressions.conditional_expression import ConditionalExpression
+from slither.core.expressions.binary_operation import BinaryOperation, BinaryOperationType
+from slither.core.expressions.member_access import MemberAccess
+from slither.core.expressions.index_access import IndexAccess
+from slither.core.solidity_types.mapping_type import MappingType, Type
+from slither.core.solidity_types.user_defined_type import UserDefinedType
+from slither.core.solidity_types.elementary_type import ElementaryType
+from slither.slithir.variables.temporary import TemporaryVariable
+from slither.utils.function import get_function_id
+import slither.analyses.data_dependency.data_dependency as data_dependency
+
+
+class ProxyFeatureExtraction:
+    """
+    Wrapper class for extracting proxy features from a Contract object.
+    Not a detector, but used exclusively by ProxyPatterns detector.
+    """
+
+    def __init__(self, contract: "Contract", compilation_unit: "SlitherCompilationUnit"):
+        self.contract: Contract = contract
+        self.compilation_unit: SlitherCompilationUnit = compilation_unit
+        self._is_admin_only_proxy: Optional[bool] = None
+        self._impl_address_variable: Optional["Variable"] = contract.delegate_variable
+        self._impl_address_location: Optional["Contract"] = None
+        self._proxy_only_contains_fallback: Optional[bool] = None
+        self._has_time_delay: Optional[dict] = None
+
+    ###################################################################################
+    ###################################################################################
+    # region general properties
+    ###################################################################################
+    ###################################################################################
+
+    @property
+    def is_proxy(self) -> bool:
+        return self.contract.is_proxy
+
+    @property
+    def is_upgradeable_proxy(self) -> bool:
+        return self.contract.is_upgradeable_proxy
+
+    @property
+    def is_upgradeable_proxy_confirmed(self) -> bool:
+        return self.contract.is_upgradeable_proxy_confirmed
+
+    @property
+    def impl_address_variable(self) -> Optional["Variable"]:
+        if self._impl_address_variable is None:
+            self._impl_address_variable = self.contract.delegate_variable
+        return self._impl_address_variable
+
+    @property
+    def impl_address_location(self) -> Optional["Contract"]:
+        """
+        Determine which contract the implementation address variable is declared in.
+
+        :return: For state variables, just return the StateVariable.contract.
+                 For local variables, return LocalVariable.function.contract
+                  or self.contract if that contract is inherited by self.contract.
+                 For structure variables, return StructureVariable.structure.contract.
+        """
+        if self._impl_address_location is None:
+            if isinstance(self._impl_address_variable, StateVariable):
+                self._impl_address_location = self._impl_address_variable.contract
+            elif isinstance(self._impl_address_variable, LocalVariable):
+                function = self._impl_address_variable.function
+                if function is None:
+                    self._impl_address_location = self.contract
+                if isinstance(function, FunctionContract):
+                    self._impl_address_location = function.contract
+                    if self._impl_address_location in self.contract.inheritance:
+                        self._impl_address_location = self.contract
+            elif isinstance(self._impl_address_variable, StructureVariable):
+                struct = self._impl_address_variable.structure
+                if isinstance(struct, StructureContract):
+                    self._impl_address_location = struct.contract
+            # dependencies = data_dependency.get_dependencies_recursive(self._impl_address_variable,
+            #                                                           self._impl_address_location)
+        return self._impl_address_location
+
+    def is_impl_address_also_declared_in_logic(self) -> (int, Optional[Contract]):
+        """
+        If the implementation address variable is a StateVariable declared in the proxy,
+        but the implementation setter is not declared in the proxy, then we need to determine
+        if the implementation contract declares the same variable in the same slot.
+
+        :return: The index indicating the position of the variable declaration, i.e. slot 0,
+                 and the Contract in which the variable (and its setter) is also declared,
+                 or else return -1 and None if this is not the case.
+        """
+        ret_index = -1
+        ret_contract = None
+        if isinstance(self._impl_address_variable, StateVariable):
+            delegate = self._impl_address_variable
+            setter = self.contract.proxy_implementation_setter
+            if setter is not None and setter.contract != self.contract:
+                ret_contract = setter.contract
+                index = -1
+                for idx, var in enumerate(self.contract.state_variables_ordered):
+                    if var == delegate:
+                        index = idx
+                        break
+                if index >= 0 and len(ret_contract.state_variables_ordered) >= index + 1:
+                    var = ret_contract.state_variables_ordered[index]
+                    if var is not None:
+                        if var.name == delegate.name and var.type == delegate.type:
+                            ret_index = index
+        return ret_index, ret_contract
+
+    def find_slot_in_setter_asm(self) -> Optional[str]:
+        slot = None
+        setter = self.contract.proxy_implementation_setter
+        if setter is not None:
+            for node in setter.all_nodes():
+                if node.type == NodeType.ASSEMBLY and node.inline_asm is not None:
+                    inline_asm = node.inline_asm
+                    if "AST" in inline_asm and isinstance(inline_asm, Dict):
+                        for statement in inline_asm["AST"]["statements"]:
+                            if statement["nodeType"] == "YulExpressionStatement":
+                                statement = statement["expression"]
+                            if statement["nodeType"] == "YulVariableDeclaration":
+                                statement = statement["value"]
+                            if statement["nodeType"] == "YulFunctionCall":
+                                if statement["functionName"]["name"] == "sstore":
+                                    slot = statement["arguments"][0]
+                    else:
+                        asm_split = inline_asm.split("\n")
+                        for asm in asm_split:
+                            if "sstore" in asm:
+                                params = asm.split("(")[1].strip(")").split(", ")
+                                slot = params[0]
+                    if slot is not None:
+                        sv = self.contract.get_state_variable_from_name(slot)
+                        if sv is None:
+                            lv = node.function.get_local_variable_from_name(slot)
+                            if lv is not None and lv.expression is not None and isinstance(lv.expression,
+                                                                                           Identifier):
+                                if isinstance(lv.expression.value, StateVariable):
+                                    sv = lv.expression.value
+                        if sv is not None and sv.expression is not None:
+                            slot = str(sv.expression)
+                        break
+        return slot
+
+    def all_mappings(self) -> Optional[List["MappingType"]]:
+        """
+        :return: List of all MappingType state variables found in the contract, or None if empty
+        """
+        mappings = []
+        for v in self.contract.state_variables:
+            if isinstance(v.type, MappingType):
+                mappings.append(v.type)
+        if len(mappings) == 0:
+            return None
+        return mappings
+
+    def is_eternal_storage(self) -> bool:
+        """
+        Contracts using Eternal Storage must contain the following mappings:
+            mapping(bytes32 => uint256) internal uintStorage;
+            mapping(bytes32 => string) internal stringStorage;
+            mapping(bytes32 => address) internal addressStorage;
+            mapping(bytes32 => bytes) internal bytesStorage;
+            mapping(bytes32 => bool) internal boolStorage;
+            mapping(bytes32 => int256) internal intStorage;
+        Note: the implementation address variable may be stored separately.
+
+        :return: True if all of the above mappings are present, otherwise False.
+        """
+        mappings = self.all_mappings()
+        types = ["uint256", "string", "address", "bytes", "bool", "int256"]
+        if mappings is not None:
+            maps_to = [str(m.type_to) for m in mappings]
+            return all([t in maps_to for t in types])
+        return False
+
+    def find_impl_slot_from_sload(self) -> str:
+        """
+        Given the implementation address variable (which should be a LocalVariable
+        if loaded from a storage slot), searches the CFG of the fallback function
+        to extract the value of the storage slot it is loaded from (using sload).
+
+        :return: A string, which should be the 32-byte storage slot location.
+        """
+        fallback = self.contract.fallback_function
+        delegate = self.contract.delegate_variable
+        if delegate == self.contract.proxy_impl_storage_offset:
+            return str(delegate.expression)
+        slot = None
+        """
+        Use slither.analysis.data_dependency to expedite analysis if possible.
+        """
+        for sv in self.contract.state_variables:
+            if data_dependency.is_dependent(delegate, sv, self.contract):
+                # print(f"{delegate} is dependent on {sv}")
+                if str(sv.type) == "bytes32" and sv.is_constant:
+                    getter = self.contract.proxy_implementation_getter
+                    if getter is not None and getter.contains_assembly and getter.is_reading(sv):
+                        asm_nodes = [node for node in getter.all_nodes()
+                                     if node.type == NodeType.ASSEMBLY and node.inline_asm is not None]
+                        for node in asm_nodes:
+                            if "sload" in node.inline_asm:
+                                return str(sv.expression)
+        """
+        Check if the slot was found during the initial execution of Contract.is_upgradeable_proxy().
+        Comment out to ensure the rest of the code here works without it.
+        """
+        slot = self.contract.proxy_impl_storage_offset
+        if slot is not None:
+            if len(slot.name) == 66 and slot.name.startswith("0x"):
+                return slot.name
+            else:
+                return str(slot.expression)
+        if delegate.expression is not None:
+            """
+            Means the variable was assigned a value when it was first declared. 
+            """
+            exp = delegate.expression
+            # print(f"Expression for {delegate}: {exp}")
+            if isinstance(exp, Identifier):
+                v = self.unwrap_identifiers(self.impl_address_location, exp)
+                if v.expression is not None:
+                    exp = v.expression
+                # else:
+                    # print(f"{v}.expression is None")
+            if isinstance(exp, MemberAccess):
+                # print(f"MemberAccess: {exp.expression}")
+                exp = exp.expression
+            if isinstance(exp, CallExpression):
+                # print(f"Called: {exp.called}")
+                # if str(exp.called).startswith("sload"):
+                if len(exp.arguments) > 0:
+                    arg = exp.arguments[0]
+                    if len(str(arg)) == 66 and str(arg).startswith("0x"):
+                        return str(arg)
+                    elif isinstance(arg, Identifier):
+                        v = self.unwrap_identifiers(self.impl_address_location, arg)
+                        if v.expression is not None:
+                            exp = v.expression
+                            if v.is_constant:
+                                return str(v.expression)
+                            elif str(v.type) == "bytes32":
+                                return str(v)
+                            elif isinstance(exp, Literal):
+                                return str(exp)
+                        # else:
+                        #     print(f"{v}.expression is None")
+                    # else:
+                    #     print(f"CallExpression argument {arg} is not an Identifier")
+        else:
+            """
+            Means the variable was declared before it was assigned a value.
+            i.e., if the return value was given a name in the function signature.
+            In this case we must search for where it was assigned a value. 
+            """
+            # print(f"Expression for {delegate} is None")
+            func = self.contract.proxy_implementation_getter
+            if func is None:
+                func = fallback
+            for node in func.all_nodes():
+                if node.type == NodeType.VARIABLE:
+                    if node.variable_declaration != delegate:
+                        continue
+                    exp = node.variable_declaration.expression
+                    # print(f"find_impl_slot_from_sload: VARIABLE node: {exp}")
+                    if exp is not None and isinstance(exp, Identifier):
+                        slot = str(exp.value.expression)
+                        return slot
+                elif node.type == NodeType.EXPRESSION:
+                    exp = node.expression
+                    # print(f"find_impl_slot_from_sload: EXPRESSION node: {exp}")
+                    if isinstance(exp, AssignmentOperation):
+                        left = exp.expression_left
+                        right = exp.expression_right
+                        if isinstance(left, Identifier) and left.value == delegate:
+                            if isinstance(right, CallExpression) and str(right.called) == "sload":
+                                slot = right.arguments[0]
+                elif node.type == NodeType.ASSEMBLY:
+                    # print(f"find_impl_slot_from_sload: ASSEMBLY node: {node.inline_asm}")
+                    if "AST" in node.inline_asm and isinstance(node.inline_asm, Dict):
+                        for statement in node.inline_asm["AST"]["statements"]:
+                            if statement["nodeType"] == "YulExpressionStatement":
+                                statement = statement["expression"]
+                            if statement["nodeType"] == "YulVariableDeclaration":
+                                if statement["variables"][0]["name"] != delegate.name:
+                                    continue
+                                statement = statement["value"]
+                            if statement["nodeType"] == "YulAssignment":
+                                if statement["variableNames"][0]["name"] != delegate.name:
+                                    continue
+                                statement = statement["value"]
+                            if statement["nodeType"] == "YulFunctionCall":
+                                if statement["functionName"]["name"] == "sload":
+                                    slot = statement["arguments"][0]["name"]
+                    else:
+                        asm_split = node.inline_asm.split("\n")
+                        for asm in asm_split:
+                            # print(f"checking assembly line: {asm}")
+                            if "sload" in asm and str(delegate) in asm:
+                                slot = asm.split("(")[1].strip(")")
+                if slot is not None and len(str(slot)) != 66:
+                    sv = self.contract.get_state_variable_from_name(slot)
+                    if sv is None:
+                        lv = node.function.get_local_variable_from_name(slot)
+                        if lv is not None and lv.expression is not None:
+                            exp = lv.expression
+                            while isinstance(exp, Identifier) and isinstance(exp.value, LocalVariable):
+                                exp = exp.value.expression
+                            if isinstance(exp, Identifier) and isinstance(exp.value, StateVariable):
+                                sv = exp.value
+                    if sv is not None and sv.expression is not None and (sv.is_constant or str(sv.type) == "bytes32"):
+                        slot = str(sv.expression)
+                        break
+                    # elif sv is not None and sv.expression is None:
+                    #     print(f"{sv} is missing an expression")
+                    # else:
+                    #     print(f"Could not find StateVariable from {slot}")
+                elif slot is not None:
+                    break
+        return slot
+
+    def proxy_only_contains_fallback(self) -> bool:
+        """
+        Determine whether the proxy contract contains any external/public functions
+        besides the fallback, not including the constructor or receive function.
+
+        :return: False if any other external/public function is found, or if the
+                 fallback function is missing, otherwise True
+        """
+        if self._proxy_only_contains_fallback is None:
+            self._proxy_only_contains_fallback = False
+            for function in self.contract.functions:
+                if function.is_fallback:
+                    # print(f"Found {function.name}")
+                    self._proxy_only_contains_fallback = True
+                elif function.visibility in ["external", "public"]:
+                    # print(f"Found {function.visibility} function: {function.name}")
+                    if function.is_receive or function.is_constructor:
+                        continue
+                    self._proxy_only_contains_fallback = False
+                    return self._proxy_only_contains_fallback
+        return self._proxy_only_contains_fallback
+
+    def has_transparent_admin_checks(self) -> (bool, str):
+        """
+        Determine whether all external functions (besides fallback() and receive())
+        are only callable by a specific address, and whether the fallback and receive
+        functions are only callable by addresses other than the same specific address,
+        i.e., whether this proxy uses the Transparent Proxy pattern.
+
+        :return: True if the above conditions are met, otherwise False
+        """
+        admin_str = None
+        checks = []
+        has_external_functions = False
+        for function in self.contract.functions:
+            if not function.is_fallback and not function.is_constructor and not function.is_receive:
+                """
+                Check for 'msg.sender ==' comparison in all external/public functions 
+                besides fallback, receive and constructor
+                """
+                comparator = "=="
+            elif not function.is_constructor:
+                """
+                Check for 'msg.sender !=' comparison in fallback and receive functions
+                """
+                comparator = "!="
+            else:
+                """
+                Skip the constructor
+                """
+                continue
+            if function.visibility in ["external", "public"]:
+                has_external_functions = True
+                if not function.is_protected():
+                    return False, None
+                check, admin_str = self.is_function_protected_with_comparator(function, comparator, admin_str)
+                checks.append(check)
+        return (all(checks) and has_external_functions), admin_str
+
+    def impl_address_from_contract_call(self) -> (bool, Optional[Expression], Optional[Type]):
+        """
+        Determine whether the proxy contract retrieves the address of the
+        implementation contract by calling a function in a third contract,
+        i.e. from a Beacon or Registry contract.
+
+        Note: Because the initial execution of contract.is_upgradeable_proxy()
+              performs cross-contract analysis to trace this contract call,
+              if successful, impl_address_variable will be a StateVariable
+              declared in said third contract. But what we really want is a
+              LocalVariable which gets its value from a CallExpression, which
+              is what we'd have if the initial cross-contract analysis failed.
+
+        :return: True if cross-contract call was found, as well as the actual
+                 CallExpression and the Type of the contract being called.
+                 Otherwise, returns (False, None, None).
+        """
+        delegate = self.impl_address_variable
+        e = delegate.expression
+        # print(f"impl_address_from_contract_call: {e}")
+        ret_exp = None
+        c_type = None
+        is_cross_contract = False
+        if isinstance(delegate, StateVariable) and delegate.contract != self.contract:
+            # print(f"impl_address_from_contract_call: StateVariable {delegate}")
+            """
+            This indicates that cross-contract analysis during the initial execution of
+            contract.is_upgradeable_proxy() was able to identify the variable which is
+            returned by the cross-contract call. In this case, in order to return the
+            CallExpression which returned this value, we need to re-find it first.
+            """
+            getter = self.contract.proxy_implementation_getter
+            # print(f"impl_address_from_contract_call: getter is {getter}")
+            if getter is None and delegate.visibility in ["public", "external"]:
+                getter = delegate
+            elif getter is not None:
+                # print(f"getter.full_name = {getter.full_name}")
+
+                for call in self.contract.all_library_calls:
+                    print(str(call))
+
+                for call in self.contract.all_library_calls:
+                    # print(f"library call: {c.name}.{f.name}")
+                    if call.function and isinstance(call.function, Function):
+                        function_name = call.function.canonical_name
+                        if function_name == getter.canonical_name:
+                            # print(f"Found {getter} in {self.contract.name}.all_library_calls")
+                            return is_cross_contract, ret_exp, c_type
+            for node in self.contract.fallback_function.all_nodes():
+                exp = node.expression
+                if isinstance(exp, AssignmentOperation):
+                    exp = exp.expression_right
+                    """Fall through to below"""
+                if isinstance(exp, CallExpression):
+                    # print(f"impl_address_from_contract_call: CallExpression {exp}")
+                    called = exp.called
+                    if isinstance(called, Identifier):
+                        f = called.value
+                        if isinstance(f, FunctionContract) and f == getter \
+                                and f.contract != self.contract and f.contract not in self.contract.inheritance:
+                            e = exp
+                            # print(f"found CallExpression calling getter in another contract: {e}")
+                            break
+                        elif len(exp.arguments) > 0:
+                            for arg in exp.arguments:
+                                # print(f"impl_address_from_contract_call: arg is {arg}")
+                                if isinstance(arg, CallExpression):
+                                    # print(f"impl_address_from_contract_call: CallExpression {arg}")
+                                    exp = arg
+                                    called = arg.called
+                                    break
+                    if isinstance(called, MemberAccess) and called.member_name == getter.name:
+                        e = exp
+                        # print(f"found MemberAccess calling getter in another contract: {e}")
+                        break
+        while isinstance(e, CallExpression):
+            """
+            Unwrap the (possibly nested) function calls until a MemberAccess is found.
+            An example of why this is necessary (from tests/proxies/APMRegistry.sol):
+                function () payable public {
+                    address target = getCode();
+                    require(target != 0); // if app code hasn't been set yet, don't call
+                    delegatedFwd(target, msg.data);
+                }
+                function getCode() public view returns (address) {
+                    return getAppBase(appId);
+                }
+                function getAppBase(bytes32 _appId) internal view returns (address) {
+                    return kernel.getApp(keccak256(APP_BASES_NAMESPACE, _appId));
+                }
+            """
+            called = e.called
+            # print(f"called: {called}")
+            if isinstance(called, Identifier):
+                f = called.value
+                if isinstance(f, FunctionContract) and f.return_node() is not None:
+                    e = f.return_node().expression
+                    # print(f"{called} returns {e}")
+
+                elif isinstance(f, SolidityFunction):
+                    break
+                else:
+                    e = f.expression
+            elif isinstance(called, MemberAccess):
+                ret_exp = e
+                e = called
+                # print(f"found MemberAccess: {e}")
+            else:
+                # print(f"{called} is not Identifier or MemberAccess")
+                break
+        if isinstance(e, MemberAccess):
+            e = e.expression
+            if isinstance(e, CallExpression) and isinstance(e.called, Identifier):
+                f = e.called.value
+                if isinstance(f, FunctionContract):
+                    ret_node = f.return_node()
+                    if ret_node is not None:
+                        e = f.return_node().expression
+                    else:
+                        ret_val = f.returns[0]
+                        e = Identifier(ret_val)
+            if isinstance(e, TypeConversion) or isinstance(e, Identifier):
+                c_type = e.type
+                if isinstance(e, Identifier):
+                    # print(f"Identifier: {e}")
+                    if isinstance(e.value, Contract):
+                        # print(f"value is Contract: {e.value}")
+                        c_type = UserDefinedType(e.value)
+                    else:
+                        c_type = e.value.type
+                        # if isinstance(e.value, StateVariable):
+                        #     print(f"value is StateVariable: {e.value}\nType: {c_type}")
+                elif isinstance(e, TypeConversion):
+                    # print(f"TypeConversion: {e}")
+                    exp = e.expression
+                    if isinstance(exp, Literal) and not isinstance(ret_exp, CallExpression):
+                        ret_exp = exp
+                if isinstance(c_type, UserDefinedType) and isinstance(c_type.type,
+                                                                      Contract) and c_type.type != self:
+                    is_cross_contract = True
+                    if c_type.type.is_interface or (getter is not None and c_type.type != getter.contract):
+                        for c in self.compilation_unit.contracts:
+                            if c_type.type in c.inheritance:
+                                c_type = UserDefinedType(c)
+                elif str(c_type) == "address":
+                    is_cross_contract = True
+                    getter = self.contract.proxy_implementation_getter
+                    if getter is not None and getter.contract != self.contract:
+                        c_type = UserDefinedType(getter.contract)
+        return is_cross_contract, ret_exp, c_type
+
+    def find_registry_address_source(self, call: CallExpression) -> Optional[Variable]:
+        """
+        Determine the source of the address of the third contract from which the proxy retrieves
+        its implementation address, i.e., where the Registry/Beacon address is stored.
+
+        :param call: The CallExpression returned by impl_address_from_contract_call()
+        """
+        # print(f"find_registry_address_source: {call}")
+        exp = call.called
+        value = None
+        if isinstance(exp, MemberAccess):
+            # print(f"MemberAccess: {exp}")
+            exp = exp.expression
+            """fall-through to below"""
+        if isinstance(exp, TypeConversion):
+            # print(f"TypeConversion: {exp}")
+            exp = exp.expression
+            """fall-through to below"""
+        if isinstance(exp, CallExpression):
+            # print(f"CallExpression: {exp}")
+            exp = exp.called
+            """fall-through to below"""
+        if isinstance(exp, Identifier):
+            # print(f"Identifier: {exp}")
+            value = exp.value
+            if isinstance(value, LocalVariable):
+                func = value.function
+                if isinstance(func, FunctionContract):
+                    dependencies = data_dependency.get_dependencies_recursive(value, func.contract)
+                    # print(f"dependencies for {value} in context {func.contract}: "
+                    #       f"{[str(dep) for dep in dependencies]}")
+                    for dep in dependencies:
+                        if isinstance(dep, TemporaryVariable):
+                            dep_exp = dep.expression
+                            # print(f"TemporaryVariable expression: {dep_exp}")
+                            if isinstance(dep_exp, CallExpression) and isinstance(dep_exp.called, Identifier):
+                                value = dep_exp.called.value
+                        elif isinstance(dep, StateVariable) and str(dep.type) == "bytes32":
+                            value = dep
+                            break
+            if isinstance(value, FunctionContract):
+                func = value
+                if len(func.returns) > 0:
+                    value = func.returns[0]
+                    ret_node = func.return_node()
+                    if ret_node is not None and (value.name is None or value.name == ""):
+                        """
+                        If return value is unnamed, check return node expression
+                        """
+                        exp = ret_node.expression
+                        if exp is not None:
+                            if isinstance(exp, CallExpression):
+                                """recursive call with new expression"""
+                                return self.find_registry_address_source(exp)
+                            if isinstance(exp, Identifier):
+                                value = exp.value
+                    elif value.name is not None and value.name != "":
+                        """
+                        If return value is named, find where it is assigned a value
+                        """
+                        for node in func.all_nodes():
+                            if node.type == NodeType.EXPRESSION:
+                                exp = node.expression
+                                # print(f"EXPRESSION node: {exp}")
+                                if isinstance(exp, AssignmentOperation):
+                                    left = exp.expression_left
+                                    right = exp.expression_right
+                                    if isinstance(left, Identifier) and left.value == value:
+                                        if isinstance(right, CallExpression):
+                                            # print(f"Called: {right.called}")
+                                            if str(right.called).startswith("sload"):
+                                                exp = right.arguments[0]
+                                                if isinstance(exp, Identifier):
+                                                    value = exp.value
+                                                if isinstance(value, LocalVariable):
+                                                    exp = value.expression
+                                                    if isinstance(exp, Identifier):
+                                                        value = exp.value
+                                            else:
+                                                return self.find_registry_address_source(right)
+                                        if isinstance(right, Identifier):
+                                            value = right.value
+                                            break
+                            elif node.type == NodeType.ASSEMBLY:
+                                if "AST" not in node.inline_asm and not isinstance(node.inline_asm, Dict):
+                                    asm_split = node.inline_asm.split("\n")
+                                    for asm in asm_split:
+                                        # print(f"checking assembly line: {asm}")
+                                        if "sload" in asm and value.name in asm:
+                                            slot = asm.split("(")[1].strip(")")
+                                            value = self.contract.get_state_variable_from_name(slot)
+                                            if value is None:
+                                                lv = node.function.get_local_variable_from_name(slot)
+                                                if lv is not None and lv.expression is not None:
+                                                    exp = lv.expression
+                                                    if isinstance(exp, Identifier) and isinstance(exp.value,
+                                                                                                  StateVariable):
+                                                        value = exp.value
+        return value
+
+    def is_mapping_from_msg_sig(self, mapping: Variable) -> bool:
+        """
+        Determine whether the given variable is a mapping with function signatures as keys
+
+        :param mapping: Should be a Variable with mapping.type == MappingType
+        :return: True if a matching IndexAccess expression is found using msg.sig as the key, otherwise False
+        """
+        ret = False
+        m_type = mapping.type
+        if isinstance(m_type, MappingType):
+            if str(m_type.type_from) != "bytes4":
+                return False
+            for node in self.contract.fallback_function.all_nodes():
+                if node.type == NodeType.EXPRESSION or node.type == NodeType.VARIABLE:
+                    if node.expression is None:
+                        continue
+                    exp = node.expression
+                    if isinstance(exp, AssignmentOperation):
+                        exp = exp.expression_right
+                    while isinstance(exp, TypeConversion):
+                        exp = exp.expression
+                    if isinstance(exp, MemberAccess):
+                        exp = exp.expression
+                    if isinstance(exp, IndexAccess):
+                        if mapping.name in str(exp.expression_left) and str(exp.expression_right) == "msg.sig":
+                            ret = True
+        return ret
+
+    def has_compatibility_checks(self) -> (bool, List[Tuple[FunctionContract, Optional[Expression], bool]]):
+        """
+        For every function that can update the implementation address,
+        determines whether it contains a compatibility check expression.
+
+        Examples of compatibility checks:
+        for ERC-1967, require that the new implementation is a contract:
+            require(OpenZeppelinUpgradesAddress.isContract(newImplementation),
+                           "Cannot set a proxy implementation to a non-contract address");
+        for EIP-1822 (UUPS), require the new implementation uses the correct slot:
+            require(bytes32(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+                           == Proxiable(newAddress).proxiableUUID(), "Not compatible");
+
+        :return: True if all update functions have checks,
+                 plus a list of each Function and check Expression
+        """
+        all_checks = []
+        func_exp_list: List[Tuple[FunctionContract, Optional[Expression], bool]] = []
+        delegate = self.impl_address_variable
+        writing_funcs = self.functions_writing_to_delegate(delegate, self.contract)
+        setter = self.contract.proxy_implementation_setter
+        getter = self.contract.proxy_implementation_getter
+        dependencies = list(data_dependency.get_dependencies_recursive(delegate, self.contract))
+        if setter is not None and setter.contract != self.contract:
+            dependencies += list(data_dependency.get_dependencies_recursive(delegate, setter.contract))
+        elif getter is not None and getter.contract != self.contract:
+            dependencies += list(data_dependency.get_dependencies_recursive(delegate, getter.contract))
+        dependencies = set(dependencies)
+        # print(f"has_compatibility_checks: dependencies: {[str(dep) for dep in dependencies]}")
+        for dep in dependencies:
+            if isinstance(dep, StateVariable):
+                writing_funcs += self.functions_writing_to_delegate(dep, dep.contract)
+        for (func, var_written) in writing_funcs:
+            if isinstance(func, FunctionContract):
+                if func.visibility in ["internal", "private"] and func != setter:
+                    # print(f"has_compatibility_checks: skipping {func.visibility} function {func}")
+                    continue
+                # else:
+                #     print(f"has_compatibility_checks: checking {func.visibility} function {func}")
+                check_exp = None
+                has_check = False
+                for node in func.all_nodes():
+                    exp = node.expression
+                    """
+                    Search each upgrade function's expressions for a condition that will 
+                    revert if the new implementation is not compatible with the proxy.
+                    """
+                    if isinstance(exp, CallExpression):
+                        called = exp.called
+                        if isinstance(called, Identifier):
+                            """
+                            For some early versions of Solidity, like 0.4.21, Slither wraps
+                            SolidityFunctions in an Identifier when found in a CallExpression.
+                            i.e., exp.called.value is the SolidityFunction object.
+                            For later versions, exp.called is the SolidityFunction.
+                            """
+                            called = called.value
+                        if isinstance(called, SolidityFunction):
+                            """
+                            Only CallExpressions we care about here are require and assert
+                            """
+                            if called.name in ["require(bool)", "require(bool,string)", "assert(bool)"]:
+                                # print(exp)
+                                condition = exp.arguments[0]
+                                # print(f"has_compatibility_checks: condition {condition}")
+                                """
+                                The static helper method check_condition_from_expression will return an
+                                Expression object if exp is a compatibility check, and will append any
+                                newly found checks to the list of (function, compatibility check) pairs.
+                                """
+                                check_, func_exp_list = self.check_condition_from_expression(
+                                    condition, func, var_written, func_exp_list, exp
+                                )
+                                """
+                                Since there may be more than one valid compatibility check in the same function,
+                                it is possible for the call above to return a check expression the first time,
+                                setting has_check = True, and then return None after checking another expression
+                                in the same function. Therefore, we do not want to overwrite check_exp above 
+                                if the subsequent call to check_condition_from_expression returned None.
+                                """
+                                if check_ is not None:
+                                    check_exp = check_
+                                    has_check = True
+                    # elif isinstance(exp, ConditionalExpression):
+                    #     """
+                    #     Even when there is clearly an if-else block in the source code, Function.all_expressions()
+                    #     never seems to contain any ConditionalExpression objects. Rather, only the condition itself,
+                    #     often a BinaryOperation or an Identifier for a boolean variable, and the expressions within
+                    #     the `then` and `else` blocks appear in the list of all expressions. Therefore we need to use
+                    #     Function.all_nodes() instead to find the IF nodes in the CFG. Unfortunately we cannot use
+                    #     all_nodes() instead of all_expressions() for the section above, because all_nodes() does not
+                    #     handle Solidity function CallExpressions correctly.
+                    #     """
+                    #     print(f"has_compatibility_checks: ConditionalExpression {exp}")
+                    elif isinstance(exp, AssignmentOperation):
+                        """
+                        Need to check for incorrect compatibility check where the variable written is a Contract type,
+                        as in the following example from PurgeableSynth.sol:
+                            function setTarget(Proxyable _target)
+                                external
+                                onlyOwner
+                            {
+                                target = _target;
+                                emit TargetUpdated(_target);
+                            }
+                        After compilation and deployment, the EVM converts the function's ABI to `setTarget(address)` and
+                        does not perform any type checking to ensure the address given is actually a Proxyable contract,
+                        even though the function signature in Solidity gives the impression that it would check the type.
+                        """
+                        left = exp.expression_left
+                        right = exp.expression_right
+                        if isinstance(left, Identifier) and isinstance(right, Identifier) \
+                                and left.value == delegate and right.value == var_written:
+                            if isinstance(var_written, LocalVariable) and isinstance(func, FunctionContract):
+                                var_type = var_written.type
+                                if isinstance(var_type, UserDefinedType):
+                                    # print(f"has_compatibility_checks: {var_written}"
+                                    #       f" is UserDefinedType: {var_type}")
+                                    var_type = var_type.type
+                                if isinstance(var_type, Contract):
+                                    # print(f"has_compatibility_checks: {var_written}"
+                                    #       f" is Contract type: {var_type}")
+                                    if var_written in func.parameters:
+                                        check_exp = exp
+                                        has_check = True
+                                        is_check_correct = False
+                                        func_exp_list.append((func, check_exp, is_check_correct))
+                    elif node.type == NodeType.IF:
+                        # print(f"has_compatibility_checks: IF node exp = {exp}")
+                        """
+                        Found an IF node, so check if it can lead to a revert.
+                        Node.sons only gives us the immediate children of the IF node,
+                        i.e., the first node in the `then` block and the `else` block.
+                        """
+                        # TODO: It may be better to implement a recursive getter for Node children.
+                        # TODO: Use Dominators / Control Dependency Graph instead
+                        if any(["revert(" in str(son.expression) for son in node.sons if son.expression is not None]):
+                            # print("has_compatibility_checks: IF node can lead to revert"
+                            #       f" {[str(son.expression) for son in node.sons if son.expression is not None]}")
+                            """
+                            Unfortunately the IF Node does not contain a ConditionalExpression
+                            already, so we must construct one using the CFG info from the Node. 
+                            """
+                            if len(node.sons) > 1:
+                                # print("has_compatibility_checks: IF node can lead to revert"
+                                #       f" {[str(son.expression) for son in node.sons if son.expression is not None]}")
+                                son0 = node.sons[0]
+                                while son0.expression is None and son0.sons[0] is not None:
+                                    son0 = son0.sons[0]
+                                son1 = node.sons[1]
+                                while son1.expression is None and son1.sons[0] is not None:
+                                    son1 = son1.sons[0]
+                                conditional_exp = ConditionalExpression(exp, son0.expression, son1.expression)
+                            else:
+                                conditional_exp = ConditionalExpression(exp, node.sons[0].expression)
+                            # print(f"has_compatibility_checks: ConditionalExpression {conditional_exp}")
+                            """
+                            The static helper method check_condition_from_expression will return an
+                            Expression object if exp is a compatibility check, and will append any
+                            newly found checks to the list of (function, compatibility check) pairs.
+                            """
+                            check_, func_exp_list = self.check_condition_from_expression(
+                                exp, func, var_written, func_exp_list, conditional_exp
+                            )
+                            """
+                            Since there may be more than one valid compatibility check in the same function,
+                            it is possible for the call above to return a check expression the first time,
+                            setting has_check = True, and then return None after checking another expression
+                            in the same function. Therefore, we do not want to overwrite check_exp above 
+                            if the subsequent call to check_condition_from_expression returned None.
+                            """
+                            if check_ is not None:
+                                check_exp = check_
+                                has_check = True
+                if check_exp is None:
+                    """ Didn't find check in this function """
+                    func_exp_list.append((func, None, False))
+            all_checks.append(has_check)
+        return all(all_checks), func_exp_list
+
+    def functions_writing_to_delegate(
+            self,
+            delegate: Variable,
+            contract: Contract
+    ) -> List[Tuple[FunctionContract, LocalVariable]]:
+        """
+        Contract.get_functions_writing_to_variable doesn't always work for us,
+        for instance when a function writes to a storage slot in assembly.
+        So this helper method finds all functions writing to the delegate variable.
+
+        :param delegate: The Variable we are interested in
+        :param contract: The Contract in which to search
+        :return: List of FunctionContract objects and the values they write to delegate
+        """
+        setters = []
+        setter = self.contract.proxy_implementation_setter
+        slot = self.contract.proxy_impl_storage_offset
+        to_search = contract.functions
+        # print(f"functions_writing_to_variable: {delegate}")
+        if setter is not None and setter.contract != contract:
+            """
+            If the implementation setter was found in a different contract, 
+            then we must also search all of the functions in that contract.
+            """
+            to_search += setter.contract.functions
+        for func in set(to_search):
+            if isinstance(delegate, LocalVariable) and delegate.function == func:
+                """
+                If the implementation address variable extracted during the initial analysis
+                is a LocalVariable, then the function in which it was declared is likely the 
+                implementation getter, which we are not interested in.
+                """
+                continue
+            value_written = None
+            # print(f"functions_writing_to_variable: checking function {func.contract.name}.{func}"
+            #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+            if func.is_writing(delegate) and delegate not in func.returns:
+                """
+                Function.is_writing only works in the simplest cases, i.e., when writing to
+                a typical StateVariable or LocalVariable. This does not work for patterns
+                like Unstructured Storage or Diamond Storage.
+                We still need to search the Expressions in func.expressions in order to 
+                find the AssignmentOperation and extract the value being written.
+                """
+                for exp in func.expressions:
+                    # print(f"functions_writing_to_variable: exp = {exp}"
+                    #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                    if isinstance(exp, AssignmentOperation):
+                        # print(f"functions_writing_to_variable: AssignmentOperation: {exp}"
+                        #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                        left = exp.expression_left
+                        right = exp.expression_right
+                        if isinstance(left, IndexAccess):
+                            """
+                            If the delegate variable is a mapping, then we expect an IndexAccess
+                            """
+                            # print(f"functions_writing_to_variable: IndexAccess: {left}"
+                            #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                            left = left.expression_left
+                        if isinstance(left, Identifier) and left.value == delegate:
+                            # print(f"functions_writing_to_variable: Identifier: {left}"
+                            #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                            value_written = self.get_value_assigned(exp)
+                if value_written is not None:
+                    setters.append([func, value_written])
+                    # print(f"functions_writing_to_variable: {func} writes {value_written} to {delegate}"
+                    #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+            elif slot is not None:
+                """
+                If the implementation address storage slot was detected during the initial analysis,
+                then we need to search the CFG to find where the slot is used to store a new value.
+                """
+                for node in func.all_nodes():
+                    if node.type == NodeType.ASSEMBLY:
+                        """
+                        Only search an ASSEMBLY Node if the Solidity version is < 0.6.0, because
+                        in that case the assembly code is not also captured in EXPRESSION Nodes.
+                        We can tell if it is < 0.6.0 if node.inline_asm is a string, not a Dict. 
+                        """
+                        if isinstance(node.inline_asm, str) and "sstore" in node.inline_asm:
+                            asm_split = node.inline_asm.split("\n")
+                            """
+                            Only bother extracting the sstore if the function is actually using
+                            the implementation slot. Without the line below, this would return any
+                            function that uses sstore, even if it is using the admin or beacon slot.
+                            """
+                            if node.function.is_reading(slot) or slot.name in node.inline_asm:
+                                for asm in asm_split:
+                                    if "sstore" in asm:
+                                        # print(f"functions_writing_to_variable: found sstore:\n{asm}\n"
+                                        #       f"(proxy_features line:{getframeinfo(currentframe()).lineno})")
+                                        val_str = asm.split("sstore")[1].split(",")[1].split(")")[0].strip()
+                                        # print(val_str)
+                                        value_written = node.function.get_local_variable_from_name(val_str)
+                                        setters.append([func, value_written])
+                                        # print(f"functions_writing_to_variable: {func} writes {value_written}"
+                                        #       f" to {slot} w/ sstore"
+                                        #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                                        break
+                    elif node.type == NodeType.EXPRESSION:
+                        exp = node.expression
+                        """
+                        Only bother extracting the sstore if the function is actually using
+                        the implementation slot. Without the line below, this would return any
+                        function that uses sstore, even if it is using the admin or beacon slot.
+                        """
+                        if node.function.is_reading(slot) or slot.name in str(exp):
+                            if isinstance(exp, AssignmentOperation):
+                                left = exp.expression_left
+                                if (str(left) == delegate.name
+                                        or (isinstance(left, MemberAccess)
+                                            and isinstance(left.expression, CallExpression)
+                                            and slot.name in [arg.value.name for arg in left.expression.arguments
+                                                              if isinstance(arg, Identifier)])):
+                                    """
+                                    This case handles the recent versions of ERC-1967 which use the StorageSlot library.
+                                    In this case, when extracting the implementation variable during initial analysis,
+                                    we encounter the following return statement in the getter:
+                                        return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+                                    Due to the complexity of unraveling this expression, we default to returning a new
+                                    LocalVariable containing this expression. So in the setter, we expect to find the
+                                    following AssignmentOperation:
+                                        StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation; 
+                                    """
+                                    if "sload" in str(exp.expression_right):
+                                        continue
+                                    value_written = self.get_value_assigned(exp)
+                                    setters.append([func, value_written])
+                                    # print(f"functions_writing_to_variable: {func} writes {value_written} to {delegate}"
+                                    #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                                    break
+                            elif isinstance(exp, CallExpression) and str(exp.called).startswith("sstore"):
+                                value_written = self.get_value_assigned(exp)
+                                setters.append([func, value_written])
+                                # print(f"functions_writing_to_variable: {func} writes {value_written} to {slot}"
+                                #       f" using sstore (proxy_features line:{getframeinfo(currentframe()).lineno})")
+            else:
+                for exp in func.all_expressions():
+                    if isinstance(exp, AssignmentOperation):
+                        left = exp.expression_left
+                        right = exp.expression_right
+                        if str(left) == delegate.name:
+                            value_written = self.get_value_assigned(exp)
+                            if value_written is None:
+                                dependencies = data_dependency.get_dependencies_recursive(delegate, func.contract)
+                                value_written = next((dep for dep in dependencies
+                                                      if isinstance(dep, Variable)
+                                                      and dep.expression == right))
+                            setters.append([func, value_written])
+                            # print(f"functions_writing_to_variable: {func} writes {value_written} to {delegate}"
+                            #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                            break
+                        elif delegate.expression is not None:
+                            d_exp = delegate.expression
+                            """
+                            Code below is necessary in some cases, such as when the delegate is a 
+                            LocalVariable with a complicated expression which we were unable to trace
+                            to its source. 
+                            i.e., for Diamonds this is the value of `delegate`:
+                                address facet = ds.selectorToFacetAndPosition[msg.sig].facetAddress;
+                            and this is the expression where it is ultimately set, in LibDiamond.addFunction:
+                                ds.selectorToFacetAndPosition[_selector].facetAddress = _facetAddress;
+                            """
+                            if isinstance(d_exp, MemberAccess) and isinstance(left, MemberAccess) \
+                                    and d_exp.member_name == left.member_name:
+                                member_exp = left
+                                d_exp = d_exp.expression
+                                left = left.expression
+                                if isinstance(d_exp, IndexAccess) and isinstance(left, IndexAccess):
+                                    d_exp = d_exp.expression_left
+                                    left = left.expression_left
+                                    if str(d_exp) == str(left):
+                                        value_written = self.get_value_assigned(exp)
+                                        setters.append([func, value_written])
+                                        # print(f"functions_writing_to_variable: {func} writes {value_written}"
+                                        #       f" to {member_exp}"
+                                        #       f" (proxy_features line:{getframeinfo(currentframe()).lineno})")
+                                        break
+        return setters
+
+    def find_diamond_loupe_functions(self) -> Optional[List[Tuple[str, Union[str, "Contract"]]]]:
+        """
+        For EIP-2535 Diamonds, determine if all four Loupe functions are
+        included in any of the "Facet" contracts in the compilation unit.
+        These functions are required to be compliant with the standard, and
+        it is not sufficient to only include the interface w/o implementations.
+
+        :return: List of (function signature, Contract) pairs indicating
+                 which contract contains each of the Loupe functions.
+        """
+        loupe_facets = []
+        loupe_sigs = [
+            "facets() returns(IDiamondLoupe.Facet[])",
+            "facetAddresses() returns(address[])",
+            "facetAddress(bytes4) returns(address)",
+            "facetFunctionSelectors(address) returns(bytes4[])"
+        ]
+        for c in self.compilation_unit.contracts:
+            if c == self.contract or c.is_interface:
+                continue
+            # print(f"Looking for Loupe functions in {c}")
+            for f in c.functions:
+                # print(f.signature_str)
+                if f.signature_str in loupe_sigs:
+                    loupe_sigs.remove(f.signature_str)
+                    loupe_facets.append((f.signature_str, c))
+        if len(loupe_sigs) > 0:
+            for sig in loupe_sigs:
+                loupe_facets.append((sig, "missing"))
+        return loupe_facets
+
+    def can_toggle_delegatecall_on_off(self) -> Tuple[bool, Optional[Expression], Optional[bool], Optional["Node"]]:
+        can_toggle = False
+        dominators: Optional[Set[Node]] = None
+        delegatecall_node: Optional[Node] = None
+        alternate_node: Optional[Node] = None
+        condition: Optional[Expression] = None
+        delegatecall_condition: Optional[bool] = None
+        for node in self.contract.fallback_function.all_nodes():
+            if node.type == NodeType.ASSEMBLY and isinstance(node.inline_asm, str):
+                if "delegatecall" in node.inline_asm:
+                    # print(f"can_toggle_delegatecall_on_off: found delegatecall in ASSEMBLY node: {node.inline_asm}")
+                    dominators = node.dominators
+                    delegatecall_node = node
+                    break
+            elif node.type == NodeType.EXPRESSION:
+                exp = node.expression
+                if isinstance(exp, AssignmentOperation):
+                    exp = exp.expression_right
+                if isinstance(exp, CallExpression) and "delegatecall" in str(exp.called):
+                    # print(f"can_toggle_delegatecall_on_off: found delegatecall in EXPRESSION node: {node.inline_asm}")
+                    dominators = node.dominators
+                    delegatecall_node = node
+                    break
+        if dominators is not None:
+            dom_node = None
+            for node in dominators:
+                # print(f"can_toggle_delegatecall_on_off:\n"
+                #       f" dominator node type: {node.type}\n"
+                #       f" dominator expression: {node.expression}")
+                # if node.is_conditional(include_loop=False) and all([call not in str(node.expression)
+                #                                                     for call in ["require", "assert"]]):
+                if node.type == NodeType.IF:
+                    condition = node.expression
+                    dom_node = node
+                    can_toggle = True
+                    break
+            if dom_node is not None:
+                successors = dom_node.dominator_successors_recursive
+                # if len(successors) > 0:
+                #     print(f"can_toggle_delegatecall_on_off: successors:")
+                for successor in successors:
+                    # print(f" NodeType: {successor.type}"
+                    #       f"  expression: "
+                    #       f"{successor.inline_asm if successor.inline_asm is not None else successor.expression}")
+                    if successor == delegatecall_node:
+                        if successor == dom_node.son_true or dom_node.son_true in successor.dominators:
+                            # print(f"can_toggle_delegatecall_on_off: delegatecall_condition = True")
+                            delegatecall_condition = True
+                        elif successor == dom_node.son_false or dom_node.son_false in successor.dominators:
+                            # print(f"can_toggle_delegatecall_on_off: delegatecall_condition = False")
+                            delegatecall_condition = False
+                if delegatecall_condition is not None:
+                    for successor in successors:
+                        if successor == delegatecall_node:
+                            continue
+                        elif ((not delegatecall_condition and (successor == dom_node.son_true or
+                                                               dom_node.son_true in successor.dominators))
+                              or (delegatecall_condition and (successor == dom_node.son_false or
+                                                              dom_node.son_false in successor.dominators))):
+                            alternate_node = successor
+                            if alternate_node.type in [NodeType.ASSEMBLY, NodeType.PLACEHOLDER] \
+                                    or " call(" in str(alternate_node.expression):
+                                break
+        return can_toggle, condition, delegatecall_condition, alternate_node
+
+    def has_time_delay(self) -> dict:
+        if self._has_time_delay is None:
+            self._has_time_delay = {"has_delay": False}
+            delegate = self._impl_address_variable
+            setter = self.contract.proxy_implementation_setter
+            condition: Optional[Expression] = None
+            if setter is not None:
+                for node in setter.all_nodes():
+                    if node.expression is not None:
+                        exp = node.expression
+                        # print(f"has_time_delay: (node.type) {node.type}\n(Expression) {exp}")
+                        if isinstance(exp, CallExpression):
+                            # print(f"has_time_delay: (node.type) {node.type}\n(CallExpression) {exp}")
+                            if str(exp.called) in ["require(bool)", "require(bool,string)", "assert(bool)"]:
+                                condition = exp.arguments[0]
+                        elif node.type == NodeType.IF:
+                            condition = exp
+                    if "now" in str(condition) and delegate in [n.expression.expression_left.value
+                                                                for n in node.dominator_successors_recursive
+                                                                if isinstance(n.expression, AssignmentOperation) and
+                                                                isinstance(n.expression.expression_left, Identifier)]:
+                        # print(f"has_time_delay: found condition using `now`: {condition}")
+                        self._has_time_delay["has_delay"] = True
+                        self._has_time_delay["upgrade_condition"] = str(condition)
+                        break
+                if isinstance(condition, BinaryOperation) and str(condition.type) in ["<", ">", "<=", ">="]:
+                    left = condition.expression_left
+                    right = condition.expression_right
+                    delay_duration = None
+                    if "now" in str(left):
+                        compare_to_exp = right
+                        now_exp = left
+                    else:
+                        compare_to_exp = left
+                        now_exp = right
+                    if isinstance(compare_to_exp, BinaryOperation) and str(compare_to_exp.type) == "+":
+                        # print(f"has_time_delay: comparing (BinaryOperation) {compare_to_exp} to {now_exp}")
+                        compare_to_exp, delay_duration = self.delay_duration_from_binary_operation(compare_to_exp)
+                    if isinstance(compare_to_exp, Identifier):
+                        # print(f"has_time_delay: comparing (Identifier) {compare_to_exp} to {now_exp}")
+                        compare_to_var = compare_to_exp.value
+                        self._has_time_delay["timestamp_variable"] = compare_to_var.name
+                        timestamp_setters = self.contract.get_functions_writing_to_variable(compare_to_var)
+                        self._has_time_delay["timestamp_setters"] = [func.canonical_name for func in timestamp_setters]
+                        if delay_duration is None:
+                            for func in timestamp_setters:
+                                assignment = next((exp for exp in func.expressions
+                                                   if isinstance(exp, AssignmentOperation)
+                                                   and isinstance(exp.expression_left, Identifier)
+                                                   and exp.expression_left.value == compare_to_var
+                                                   and "now" in str(exp.expression_right)), None)
+                                if assignment is not None:
+                                    right = assignment.expression_right
+                                    # print(f"has_time_delay: function {func} assigns {right} to {compare_to_var}")
+                                    if isinstance(right, BinaryOperation) and str(right.type) == "+":
+                                        # print(f"has_time_delay: assigned (BinaryOperation) {right}")
+                                        compare_to_exp, delay_duration = self.delay_duration_from_binary_operation(right)
+                                        if delay_duration is not None:
+                                            break
+                    if delay_duration is not None:
+                        # print(f"has_time_delay: time delay = {delay_duration}")
+                        self._has_time_delay["delay_duration"] = delay_duration
+        return self._has_time_delay
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Static methods
+    ###################################################################################
+    ###################################################################################
+
+    @staticmethod
+    def delay_duration_from_binary_operation(
+            compare_to_exp: Expression
+    ) -> Tuple[Expression, Optional[str]]:
+        delay_duration = None
+        if isinstance(compare_to_exp, BinaryOperation):
+            # print(f"delay_duration_from_binary_operation: (BinaryOperation) {compare_to_exp}")
+            left = compare_to_exp.expression_left
+            right = compare_to_exp.expression_right
+            if isinstance(right, Literal):
+                # print(f"delay_duration_from_binary_operation: right side (Literal) {right.value}")
+                delay_duration = right.value
+                if right.subdenomination is not None:
+                    delay_duration = f"{delay_duration} {right.subdenomination}"
+                if isinstance(left, Identifier):
+                    compare_to_exp = left
+            elif isinstance(left, Literal):
+                delay_duration = left.value
+                if left.subdenomination is not None:
+                    delay_duration = f"{delay_duration} {left.subdenomination}"
+                if isinstance(right, Identifier):
+                    compare_to_exp = right
+        return compare_to_exp, delay_duration
+
+    @staticmethod
+    def is_function_protected_with_comparator(
+            function: FunctionContract,
+            comparator: str,
+            admin_str: Optional[str]
+    ) -> Tuple[bool, Optional[str]]:
+        check = False
+
+        # print(f"Checking {function.visibility} function {function}")
+        for exp in function.all_expressions():
+            """
+            function.all_expressions() is a recursive getter which includes
+            expressions from all functions/modifiers called in given function.
+            """
+            # if ('msg.sender ' + comparator) in str(exp):
+            #     print(f"Found 'msg.sender {comparator}' in expression: {exp}")
+            if "require" in str(exp) or "assert" in str(exp):
+                """
+                'require' and 'assert' are Solidity functions which always
+                take a boolean expression as the first argument.
+                """
+                if isinstance(exp, CallExpression) and len(exp.arguments) > 0:
+                    exp = exp.arguments[0]
+            if isinstance(exp, Identifier):
+                value = ProxyFeatureExtraction.unwrap_identifiers(function.contract, exp)
+                if value is None:
+                    continue
+                exp = value.expression
+            if isinstance(exp, BinaryOperation) and str(exp.type) == comparator:
+                """
+                For this method to return true, we must find a comparison expression,
+                i.e., a BinaryOperation, with 'msg.sender' on one side and the
+                admin_exp on the other side, where admin_exp must be the same in all.
+                """
+                if str(exp.expression_left) == "msg.sender":
+                    exp = exp.expression_right
+                elif str(exp.expression_right) == "msg.sender":
+                    exp = exp.expression_left
+                else:
+                    continue
+                if admin_str is None:
+                    admin_str = str(exp)
+                    check = True
+                    break
+                elif str(exp) == admin_str:
+                    check = True
+                    break
+        return check, admin_str
+
+    @staticmethod
+    def unwrap_identifiers(
+            contract: Contract,
+            exp: Identifier
+    ) -> Optional[Variable]:
+        """
+        Given an Identifier expression, which is essentially a wrapper for a Variable (or
+        sometimes a Function or Contract) object, unwrap it to find the `source` of its value.
+
+        For example, in the expression ``bytes32 slot = IMPLEMENTATION_SLOT`` we have an Identifier
+        on either side of the assignment expression. If we passed the left side into this method
+        as ``exp``, the first Variable found in ``exp.value`` is the LocalVariable ``slot``. Because
+        it is assigned a value in the same line as its declaration, ``exp.value.expression`` is
+        the right side of the assignment, which in this case is also an Identifier for the
+        StateVariable ``IMPLEMENTATION_SLOT``. But once ``exp`` has been updated to this Identifier,
+        then ``exp.value.expression`` is no longer an Identifier, because ``IMPLEMENTATION_SLOT``
+        was assigned a value as a Literal expression, namely the 32 byte storage slot.
+
+        Note: This method does not unwrap CallExpressions to find a value's source in another function.
+        For example, given the left side of the expression ``address impl = implementation()``,
+        ``exp.value`` is the LocalVariable ``impl`` and ``exp.value.expression`` is a CallExpression.
+        Tracing this CallExpression to find its return value should be done elsewhere.
+
+        :param contract: The Contract in which the expression is found.
+        :param exp: The Identifier expression to unwrap.
+        :return: The unwrapped Variable object.
+        """
+        ret_val = None
+        while isinstance(exp, Identifier):
+            val = exp.value
+            if isinstance(val, SolidityVariable):
+                """
+                The SolidityVariable class does not inherit Variable, 
+                so we cannot immediately set exp = val.expression.
+                If the name ends with _slot or _offset, it indicates
+                a property of the StateVariable with the same name,
+                minus the suffix. The _ here is like dot notation.
+                (i.e. delegate_slot = the slot where delegate is stored)
+                """
+                if val.name.endswith("_slot") or val.name.endswith("_offset"):
+                    val = contract.get_state_variable_from_name(val.state_variable)
+                else:
+                    return ret_val
+            ret_val = val
+            exp = ret_val.expression
+        return ret_val
+
+    @staticmethod
+    def check_condition_from_expression(
+            condition: Expression,
+            in_function: FunctionContract,
+            var_written: LocalVariable,
+            func_exp_list: List[Tuple[FunctionContract, Expression, bool]],
+            original: Optional[Union[CallExpression, ConditionalExpression]]
+    ) -> Tuple[Optional[Expression], List[Tuple[FunctionContract, Optional[Expression], bool]]]:
+        """
+        Helper method specifically intended for use by ``ProxyFeatureExtraction.has_compatibility_checks()``,
+        which requires two separate loops to find Solidity function calls and if statements, but which needs
+        to perform the same analysis on each condition regardless of which loop finds it.
+
+        Checks whether the condition depends in any way on the same variable that is being written to the
+        implementation address variable in a function found by ``Contract.functions_writing_to_delegate()``.
+
+        :param condition: An Expression, extracted either from an if statement condition or from the first
+            argument in a call to one of the Solidity functions ``require(bool)``, ``require(bool,string)``
+            or ``assert(bool)``.
+        :param in_function: The FunctionContract in which this expression was found.
+        :param var_written: The LocalVariable being written to the implementation address variable,
+            found by ``Contract.functions_writing_to_delegate()``.
+        :param func_exp_list: The list of (FunctionContract, Expression) pairs found so far, where Expression
+            is a compatibility check found in the FunctionContract, to which to append any newly found checks.
+        :param original: The Expression in which the condition expression was found, i.e., a CallExpression
+            for require and assert, or a ConditionalExpression in the case of an if condition.
+        :return: The full expression in which the compatibility check was found, or None if not found,
+            as well as the original list of (FunctionContract, Expression) pairs with any newly found checks
+            appended to it.
+        """
+        check_exp = None
+        if var_written is None or (var_written.name not in str(condition)
+                                   and not isinstance(condition, Identifier)
+                                   and not any([var_written.name in str(call)
+                                                for call in in_function.modifier_calls_as_expressions])):
+            """
+            The boolean result of the condition should depend on the new implementation address value.
+            But we need to be careful not to skip cases where the condition is in a modifier.
+            """
+            return check_exp, func_exp_list
+        elif isinstance(condition, Identifier):
+            # print(f"check_condition_from_expression: Identifier {condition}")
+            if condition.value.expression is not None:
+                # print(f"check_condition_from_expression: Identifier.value.expression "
+                #       f"{condition.value.expression}")
+                condition = condition.value.expression
+            else:
+                for e in in_function.all_expressions():
+                    if isinstance(e, AssignmentOperation) and \
+                            str(condition) in str(e.expression_left):
+                        condition = e.expression_right
+                        break
+        # elif len(in_function.modifier_calls_as_expressions) > 0:
+        #     print(f"check_condition_from_expression: modifier calls: "
+        #           f"{[str(call) for call in in_function.modifier_calls_as_expressions]}")
+        call_func = None
+        if isinstance(condition, CallExpression):
+            """
+            i.e., OpenZeppelinUpgradesAddress.isContract(newImplementation)
+            Probably need to search this function for the condition it returns.
+            What we really want is the BinaryExpression I think.
+            """
+            called = condition.called
+            if isinstance(called, MemberAccess):
+                member_of = called.expression
+                if isinstance(member_of, Identifier) and isinstance(member_of.value, Contract):
+                    call_func = member_of.value.get_function_from_name(called.member_name)
+                elif isinstance(member_of, Identifier) and member_of.value == var_written:
+                    if isinstance(original, CallExpression):
+                        args = [condition]
+                        if len(original.arguments) > 1:
+                            args.append(original.arguments[1])
+                        check_exp = CallExpression(original.called, args, original.type_call)
+                        func_exp_list.append((in_function, check_exp, True))
+            elif isinstance(called, Identifier) and isinstance(called.value, FunctionContract):
+                call_func = called.value
+            if isinstance(call_func, FunctionContract) \
+                    and "bool" in [str(_type) for _type in call_func.return_type]:
+                if call_func.return_node() is not None:
+                    ret_exp = call_func.return_node().expression
+                    if isinstance(ret_exp, Identifier) and ret_exp.value.expression is not None:
+                        ret_exp = ret_exp.value.expression
+                    if isinstance(ret_exp, BinaryOperation):
+                        condition = ret_exp
+        if isinstance(condition, BinaryOperation):
+            """
+            If either side of the BinaryOperation is a local variable, use the
+            expression assigned to it to replace the variable's Identifier.
+            i.e., if we have the following:
+            function isContract(address account) internal view returns (bool) {
+                uint256 size;
+                assembly { size := extcodesize(account) }
+                return size > 0;
+            }
+            then we want the final condition expression to be:
+                extcodesize(account) > 0
+            """
+            left = condition.expression_left
+            right = condition.expression_right
+            if isinstance(left, Identifier):
+                if left.value.expression is not None:
+                    condition = BinaryOperation(left.value.expression, right, condition.type)
+                elif isinstance(left.value, LocalVariable) and isinstance(call_func, FunctionContract):
+                    for e in call_func.all_expressions():
+                        if isinstance(e, AssignmentOperation) and str(e.expression_left) == str(left):
+                            condition = BinaryOperation(e.expression_right, right, condition.type)
+            elif isinstance(right, Identifier):
+                if right.value.expression is not None:
+                    condition = BinaryOperation(left, right.value.expression, condition.type)
+                elif isinstance(right.value, LocalVariable) and isinstance(call_func, FunctionContract):
+                    for e in call_func.all_expressions():
+                        if isinstance(e, AssignmentOperation) and str(e.expression_left) == str(right):
+                            condition = BinaryOperation(left, e.expression_right, condition.type)
+            # print(f"check_condition_from_expression: condition {condition}")
+            if isinstance(original, CallExpression) and call_func is not None:
+                args = [condition]
+                if len(original.arguments) > 1:
+                    args.append(original.arguments[1])
+                check_exp = CallExpression(original.called, args, original.type_call)
+            elif isinstance(original, ConditionalExpression) and call_func is not None:
+                check_exp = ConditionalExpression(condition,
+                                                  original.then_expression,
+                                                  original.else_expression)
+            else:
+                check_exp = original
+            # print(f"Appending to list: {check_exp} at line ")
+            if not (in_function, check_exp, True) in func_exp_list:
+                func_exp_list.append((in_function, check_exp, True))
+        return check_exp, func_exp_list
+
+    @staticmethod
+    def get_value_assigned(exp: Expression) -> Optional[Variable]:
+        # print(f"get_value_assigned: {exp}")
+        value = None
+        id_exp = None
+        if isinstance(exp, AssignmentOperation):
+            id_exp = exp.expression_right
+        elif isinstance(exp, CallExpression) and str(exp.called).startswith("sstore"):
+            id_exp = exp.arguments[1]
+        while isinstance(id_exp, Identifier):
+            value = id_exp.value
+            if isinstance(value, Variable):
+                id_exp = value.expression
+            else:
+                break
+        return value
+
+    @staticmethod
+    def find_slot_string_from_assert(
+            proxy: Contract,
+            slot: StateVariable
+    ):
+        slot_string = None
+        assert_exp = None
+        minus = 0
+        if proxy.constructor is not None:
+            for exp in proxy.constructor.all_expressions():
+                if isinstance(exp, CallExpression) and str(exp.called) == "assert(bool)" and slot.name in str(exp):
+                    # print(f"Found assert statement in constructor:\n{str(exp)}")
+                    assert_exp = exp
+                    arg = exp.arguments[0]
+                    if isinstance(arg, BinaryOperation) and str(arg.type) == "==" and arg.expression_left.value == slot:
+                        e = arg.expression_right
+                        # print("BinaryOperation ==")
+                        if isinstance(e, TypeConversion) and str(e.type) == "bytes32":
+                            # print(f"TypeConversion bytes32: {str(e)}")
+                            e = e.expression
+                        if isinstance(e, BinaryOperation) and str(e.type) == "-":
+                            # print(f"BinaryOperation -: {str(e)}")
+                            if isinstance(e.expression_right, Literal):
+                                # print(f"Minus: {str(e.expression_right.value)}")
+                                minus = int(e.expression_right.value)
+                                e = e.expression_left
+                        if isinstance(e, TypeConversion) and str(e.type) == "uint256":
+                            # print(f"TypeConversion uint256: {str(e)}")
+                            e = e.expression
+                        if isinstance(e, CallExpression) and "keccak256(" in str(e.called):
+                            # print(f"CallExpression keccak256: {str(e)}")
+                            arg = e.arguments[0]
+                            if isinstance(arg, Literal):
+                                if str(arg.type) == "string":
+                                    slot_string = arg.value
+                                    break
+        return slot_string, assert_exp, minus
+
+    @staticmethod
+    def find_mapping_in_var_exp(
+            delegate: Variable,
+            proxy: Contract
+    ) -> (Optional["Variable"], Optional["IndexAccess"]):
+        mapping = None
+        exp = None
+        e = delegate.expression
+        if e is not None:
+            # print(f"find_mapping_in_var_exp: {delegate} expression is {e}")
+            while isinstance(e, TypeConversion) or isinstance(e, MemberAccess):
+                e = e.expression
+            if isinstance(e, IndexAccess):
+                # print(f"find_mapping_in_var_exp: found IndexAccess: {e}")
+                exp = e
+                left = e.expression_left
+                if isinstance(left, MemberAccess):
+                    # print(f"find_mapping_in_var_exp: found MemberAccess: {left}")
+                    e = left.expression
+                    member = left.member_name
+                    if isinstance(e, Identifier):
+                        # print(f"find_mapping_in_var_exp: found Identifier: {e}")
+                        v = e.value
+                        if isinstance(v.type, UserDefinedType):
+                            user_type: UserDefinedType = v.type
+                            # print(f"find_mapping_in_var_exp: found UserDefinedType: {user_type}")
+                            if isinstance(user_type.type, Structure):
+                                struct: Structure = user_type.type
+                                # print(f"find_mapping_in_var_exp: found Structure: {struct.name}")
+                                if isinstance(struct.elems[member].type, MappingType):
+                                    # print(f"find_mapping_in_var_exp: found mapping in struct: "
+                                    #       f"{struct.elems[member].type} {struct.elems[member].name}")
+                                    mapping = struct.elems[member]
+                elif isinstance(left, Identifier):
+                    v = left.value
+                    if isinstance(v.type, MappingType):
+                        mapping = v
+        elif isinstance(delegate.type, MappingType):
+            mapping = delegate
+            for e in proxy.fallback_function.variables_read_as_expression:
+                if isinstance(e, IndexAccess) and isinstance(e.expression_left, Identifier):
+                    if e.expression_left.value == mapping:
+                        exp = e
+                        break
+        return mapping, exp
+
+    # endregion

--- a/slither/detectors/proxy/proxy_patterns.py
+++ b/slither/detectors/proxy/proxy_patterns.py
@@ -1,0 +1,1152 @@
+from abc import ABC
+
+# import sha3
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification, SupportedOutput, Output
+from slither.detectors.proxy.proxy_features import ProxyFeatureExtraction
+from slither.utils.proxy_output import ProxyOutput
+from typing import Optional, List, Dict, Callable, Tuple, TYPE_CHECKING, Union
+from slither.core.cfg.node import NodeType
+from slither.core.declarations.contract import Contract
+from slither.core.declarations.structure import Structure
+from slither.core.declarations.structure_contract import StructureContract
+from slither.core.declarations.modifier import Modifier
+from slither.core.variables.variable import Variable
+from slither.core.variables.state_variable import StateVariable
+from slither.core.variables.local_variable import LocalVariable
+from slither.core.variables.structure_variable import StructureVariable
+from slither.core.expressions.identifier import Identifier
+from slither.core.expressions.literal import Literal
+from slither.core.declarations.function_contract import FunctionContract
+from slither.core.expressions.call_expression import CallExpression
+from slither.core.expressions.type_conversion import TypeConversion
+from slither.core.expressions.assignment_operation import AssignmentOperation
+from slither.core.expressions.binary_operation import BinaryOperation
+from slither.core.expressions.member_access import MemberAccess
+from slither.core.expressions.index_access import IndexAccess
+from slither.core.solidity_types.mapping_type import MappingType
+from slither.core.solidity_types.user_defined_type import UserDefinedType
+from slither.core.solidity_types.elementary_type import ElementaryType
+from slither.utils.erc import (
+    ERC20_all_signatures,
+    ERC165_signatures,
+    ERC721_all_signatures,
+    ERC897_signatures,
+    ERC1155_all_signatures
+)
+
+
+class ProxyPatterns(AbstractDetector, ABC):
+    ARGUMENT = "proxy-patterns"
+    IMPACT = DetectorClassification.INFORMATIONAL
+    CONFIDENCE = DetectorClassification.MEDIUM
+
+    HELP = "Proxy contract does not conform to any known standard"
+    WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#proxy-patterns"
+    WIKI_TITLE = "Proxy Patterns"
+
+    # region wiki_description
+    WIKI_DESCRIPTION = """
+Determine whether an upgradeable proxy contract conforms to any known proxy standards, i.e. OpenZeppelin, UUPS, Diamond 
+Multi-Facet Proxy, etc.
+"""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """
+```solidity
+contract Proxy{
+    address logicAddress;
+
+    function() payable {
+        logicAddress.delegatecall(msg.data)
+    }
+}
+
+contract Logic{
+    uint variable1;
+}
+```
+The new version, `V2` does not contain `variable1`. 
+If a new variable is added in an update of `V2`, this variable will hold the latest value of `variable2` and
+will be corrupted.
+"""
+    # endregion wiki_exploit_scenario
+
+    # region wiki_recommendation
+    WIKI_RECOMMENDATION = """
+It is better to use one of the common standards for upgradeable proxy contracts. Consider EIP-1967, EIP-1822, EIP-2523, 
+or one of the proxy patterns developed by OpenZeppelin.
+"""
+
+    # endregion wiki_recommendation
+
+    # region custom generate_result
+    STANDARD_JSON = False
+
+    """
+    Override AbstractDetector.generate_result to define our own json output format
+    """
+
+    def generate_result(
+            self,
+            info: Union[str, List[Union[str, SupportedOutput]]],
+            additional_fields: Optional[Dict] = None,
+    ) -> ProxyOutput:
+        contracts = [i for i in info if isinstance(i, Contract)]
+        if len(contracts) > 0:
+            contract = contracts[0]
+        else:
+            contract = None
+        output = ProxyOutput(
+            contract,
+            info,
+            additional_fields,
+            standard_format=self.STANDARD_JSON,
+            markdown_root=self.slither.markdown_root,
+        )
+
+        return output
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Detect Mappings
+    ###################################################################################
+    ###################################################################################
+
+    @staticmethod
+    def detect_mappings(proxy_features: ProxyFeatureExtraction, delegate: Variable):
+        # results = []
+        info = []
+        features: Dict = {}
+        proxy = proxy_features.contract
+        """
+        Check mapping types, i.e. delegate.type_from and delegate.type_to
+        """
+        if proxy_features.is_eternal_storage():
+            features["eternal_storage"] = True
+            info += [
+                " uses Eternal Storage\n"
+            ]
+            # json = self.generate_result(info)
+            # results.append(json)
+        if isinstance(delegate.type, MappingType):
+            if f"{delegate.type.type_from}" == "bytes4":  # and f"{delegate.type.type_to}" == "address":
+                """
+                Check to confirm that `msg.sig` is used as the key in the mapping
+                """
+                if proxy_features.is_mapping_from_msg_sig(delegate):
+                    features["impl_mapping_from_msg_sig"] = True
+                    info += [
+                        delegate.name,
+                        " maps function signatures to addresses, suggesting multiple implementations.\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+                    """
+                    Check if the mapping is stored in a struct, i.e. DiamondStorage for EIP-2535
+                    """
+                    if isinstance(delegate, StructureVariable):
+                        struct = delegate.structure
+                        if struct.name == "DiamondStorage":
+                            features["diamond_storage"] = True
+                            if struct.canonical_name == "LibDiamond.DiamondStorage":
+                                features["diamond_storage_location"] = "LibDiamond (" + str(struct.source_mapping) + ")"
+                                features["eip_2535"] = True
+                                info += [
+                                    delegate.name,
+                                    " is stored in the structure specified by EIP-2535: ",
+                                    struct.canonical_name,
+                                    "\n"
+                                ]
+                                # json = self.generate_result(info)
+                                # results.append(json)
+                            elif isinstance(struct, StructureContract):
+                                features["diamond_storage_location"] = struct.contract.name + " (" + \
+                                                                       str(struct.source_mapping) + ")"
+                                features["eip_2535"] = "true (non-standard)"
+                                info += [
+                                    delegate.name,
+                                    " is stored in the structure specified by EIP-2535 but not the one in LibDiamond: ",
+                                    struct.canonical_name,
+                                    "\n"
+                                ]
+                                # json = self.generate_result(info)
+                                # results.append(json)
+                            """
+                            Search for the Loupe functions required by EIP-2535.
+                            """
+                            loupe_facets = proxy_features.find_diamond_loupe_functions()
+                            features["diamond_loupe_facets"] = {}
+                            for sig, facet in loupe_facets:
+                                features["diamond_loupe_facets"][sig] = str(facet)
+                            if len(loupe_facets) == 4:
+                                info += [
+                                    f"Loupe functions located in {', '.join(set(str(c) for f, c in loupe_facets))}\n"
+                                ]
+                                # json = self.generate_result(info)
+                                # results.append(json)
+                        else:
+                            features["eip_2535"] = False
+                            if len(struct.elems) > 1:
+                                features["diamond_storage"] = True
+                            else:
+                                features["diamond_storage"] = False
+                            info += [
+                                delegate.name,
+                                " is stored in a structure: ",
+                                struct.canonical_name,
+                                ", consistent with Diamond Storage but not EIP-2535\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                    else:
+                        """
+                        Mapping not stored in a struct
+                        """
+                        features["eip_2535"] = False
+                        features["eip_1538"] = True
+                else:
+                    features["impl_mapping_from_msg_sig"] = "maybe"
+                    info += [
+                        delegate.name,
+                        " probably maps function signatures to addresses, but detector could not find `msg.sig` use.\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+            else:
+                features["impl_mapping_from_msg_sig"] = False
+                info += [
+                    delegate.name,
+                    " is a mapping of type ",
+                    str(delegate.type),
+                    "\n"
+                ]
+                # json = self.generate_result(info)
+                # results.append(json)
+        return info, features
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Detect Storage Slot
+    ###################################################################################
+    ###################################################################################
+
+    @staticmethod
+    def detect_storage_slot(proxy_features: ProxyFeatureExtraction):
+        # results = []
+        info = []
+        features: Dict = {}
+        proxy = proxy_features.contract
+        slot = proxy_features.find_impl_slot_from_sload()
+        if slot is not None:
+            features["unstructured_storage"] = True
+            info += [
+                " uses Unstructured Storage\n"
+            ]
+            # json = self.generate_result(info)
+            # results.append(json)
+            setter = proxy.proxy_implementation_setter
+            if setter is None:
+                """
+                Use the getter instead
+                """
+                setter = proxy.proxy_implementation_getter
+            if setter is None or setter.contract == proxy or setter.contract in proxy.inheritance:
+                if slot == "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" or \
+                        slot == "bytes32(uint256(keccak256(bytes)(eip1967.proxy.implementation)) - 1)":
+                    features["eip_1967"] = True
+                    info += [
+                        " implements EIP-1967\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+                else:
+                    features["eip_1967"] = False
+                    info += [
+                        " uses non-standard slot: ",
+                        slot, "\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+            elif setter.contract != proxy and proxy_features.proxy_only_contains_fallback():
+                if slot == "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" or \
+                        slot == "bytes32(uint256(keccak256(bytes)(eip1967.proxy.implementation)) - 1)":
+                    features["eip_1967"] = True
+                    features["eip_1822"] = True
+                    info += [
+                        " implements EIP-1822 using slot from ERC-1967"
+                        " (i.e. OpenZeppelin UUPS)\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+
+                elif slot == "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7":
+                    features["eip_1967"] = False
+                    features["eip_1822"] = True
+                    info += [
+                        " implements EIP-1822 (UUPS) with slot = keccak256('PROXIABLE')\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+                else:
+                    features["eip_1967"] = False
+                    features["eip_1822"] = False
+                    info += [
+                        " uses non-standard slot: ",
+                        slot, "\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+        return info, features
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Detect Cross-Contract Call
+    ###################################################################################
+    ###################################################################################
+
+    @staticmethod
+    def detect_cross_contract_call(proxy_features: ProxyFeatureExtraction):
+        # results = []
+        info = []
+        features: Dict = {}
+        proxy = proxy_features.contract
+        delegate = proxy_features.impl_address_variable
+        is_cross_contract, call_exp, contract_type = proxy_features.impl_address_from_contract_call()
+        if is_cross_contract:
+            """
+            is_cross_contract is a boolean returned by proxy_features.impl_address_from_contract_call()
+            which indicates whether or not a cross contract call was found.
+            call_exp is the CallExpression that was found, contract_type is the type of the contract called.
+            """
+            features["impl_address_from_contract_call"] = str(call_exp)
+            info += [
+                delegate,
+                " gets value from a cross-contract call: ",
+                str(call_exp),
+                "\n"
+            ]
+            # json = self.generate_result(info)
+            # results.append(json)
+            if isinstance(call_exp, CallExpression) and isinstance(contract_type, UserDefinedType):
+                """
+                We use the presence or absence of arguments in the CallExpression
+                to classify the contract as a Registry or a Beacon.
+                A Beacon should have no arguments, while a Registry should have at least one.
+                Alternatively, if the delegate variable is a mapping in the called contract, it is a Registry.
+                """
+                if (len(call_exp.arguments) > 0 and str(call_exp.arguments[0]) != "") or \
+                        (isinstance(delegate.type, MappingType) and
+                         proxy_features.impl_address_location == contract_type.type):
+                    rorb = "Registry"
+                else:
+                    rorb = "Beacon"
+                features[rorb.lower()] = contract_type.type.name
+                info += [
+                    contract_type.type.name,
+                    f" appears to be a {rorb} contract for the proxy\n"
+                ]
+                # json = self.generate_result(info)
+                # results.append(json)
+                """
+                Check where the Registry/Beacon address comes from, 
+                i.e. from a storage slot or a state variable
+                """
+                source = proxy_features.find_registry_address_source(call_exp)
+                if source is not None:
+                    if isinstance(source, Variable) and source.is_constant and str(source.type) == "bytes32":
+                        features[f"{rorb.lower()}_source_type"] = "bytes32 constant storage slot"
+                        features[f"{rorb.lower()}_source_slot"] = str(source.expression)
+                        info += [
+                            "The address of ",
+                            contract_type.type.name,
+                            " is loaded from storage slot ",
+                            source.name,
+                            " = ",
+                            str(source.expression),
+                            "\n"
+                        ]
+                    elif isinstance(source, StateVariable):
+                        features[f"{rorb.lower()}_source_type"] = str(source.type)
+                        features[f"{rorb.lower()}_source_variable"] = source.canonical_name
+                        info += [
+                            "The address of ",
+                            contract_type.type.name,
+                            " is stored as a state variable: ",
+                            source.canonical_name,
+                            "\n"
+                        ]
+                        if source.is_constant:
+                            features[f"{rorb.lower()}_source_constant"] = True
+                            info += [
+                                source.name,
+                                f" is constant, so the {rorb} address cannot be upgraded.\n"
+                            ]
+                        else:
+                            features[f"{rorb.lower()}_source_constant"] = False
+                            setters = proxy.get_functions_writing_to_variable(source)
+                            setters = [setter.canonical_name for setter in setters if not setter.is_constructor]
+                            if len(setters) > 0:
+                                features[f"{rorb.lower()}_source_setters"] = ", ".join(setters)
+                                info += [
+                                    source.name,
+                                    " can be updated by the following function(s): ",
+                                    str(setters),
+                                    "\n"
+                                ]
+                            else:
+                                features[f"{rorb.lower()}_source_setters"] = "none found"
+                                info += [
+                                    "Could not find setter for ",
+                                    source.name,
+                                    "\n"
+                                ]
+                    else:
+                        features[f"{rorb.lower()}_source_type"] = str(source.type)
+                        features[f"{rorb.lower()}_source_variable"] = str(source)
+                        info += [
+                            "The address of ",
+                            contract_type.type.name,
+                            " comes from the value of ",
+                            source,
+                            "\n"
+                        ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+        return info, features
+
+    # endregion
+    ###################################################################################
+    ###################################################################################
+    # region Main _detect
+    ###################################################################################
+    ###################################################################################
+
+    def _detect(self):
+        results = []
+        for contract in self.contracts:
+            info = []
+            features: Dict = {}
+            proxy_features = ProxyFeatureExtraction(contract, self.compilation_unit)
+            ###################################################################################
+            ###################################################################################
+            # region Upgradeable Proxy
+            ###################################################################################
+            ###################################################################################
+            if proxy_features.is_upgradeable_proxy:
+                proxy = contract
+                delegate = proxy_features.impl_address_variable
+                info += [proxy,
+                         " may be" if not proxy_features.is_upgradeable_proxy_confirmed else " is",
+                         " an upgradeable proxy.\n"]
+                if contract.is_upgradeable_proxy_confirmed:
+                    features["upgradeable"] = True
+                else:
+                    features["upgradeable"] = "maybe"
+                if contract.uses_call_not_delegatecall:
+                    features["uses_call_instead_of_delegatecall"] = True
+                    info += f"{proxy.name} uses `call` instead of `delegatecall`\n"
+                """
+                Output the delegate variable and its setter and getter
+                """
+                if isinstance(delegate, (StateVariable, LocalVariable, StructureVariable)):
+                    features["impl_address_variable"] = delegate.canonical_name
+                else:
+                    features["impl_address_variable"] = delegate.name
+                if proxy.proxy_implementation_setter is not None:
+                    features["impl_address_setter"] = proxy.proxy_implementation_setter.canonical_name
+                else:
+                    features["impl_address_setter"] = "not found"
+                if proxy.proxy_implementation_getter is not None:
+                    features["impl_address_getter"] = proxy.proxy_implementation_getter.canonical_name
+                else:
+                    features["impl_address_getter"] = "not found"
+                # json = self.generate_result(info)
+                # results.append(json)
+                """
+                Check location of implementation address, i.e. contract.delegate_variable.
+                Could be located in proxy contract or in a different contract.
+                """
+                # endregion
+                ###################################################################################
+                ###################################################################################
+                # region Delegate Variable Located in Proxy Contract
+                ###################################################################################
+                ###################################################################################
+                if proxy_features.impl_address_location == proxy:
+                    """
+                    Check the scope of the implementation address variable,
+                    i.e., StateVariable or LocalVariable.
+                    """
+                    info += [
+                        delegate.name,
+                        " is declared in the proxy.\n"
+                    ]
+                    features["impl_address_location"] = proxy.name + " (" + str(proxy.source_mapping) + ")"
+                    # json = self.generate_result(info)
+                    # results.append(json)
+
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region State Variable
+                    ###################################################################################
+                    ###################################################################################
+                    if isinstance(delegate, StateVariable):
+                        """
+                        Check the type of the state variable, i.e. an address, a mapping, or something else
+                        """
+                        features["impl_address_scope"] = "StateVariable"
+                        if f"{delegate.type}" == "address":
+                            info += [
+                                delegate.name,
+                                " is an address state variable\n"
+                            ]
+                            features["impl_address_type"] = "address"
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                            """
+                            Check if the implementation address setter is in the proxy contract. 
+                            """
+                            # if proxy.proxy_implementation_setter is not None:
+                            #     if proxy.proxy_implementation_setter.contract == proxy:
+                            #         info += [
+                            #             "Implementation setter ",
+                            #             proxy.proxy_implementation_setter,
+                            #             " was found in the proxy contract.\n"
+                            #         ]
+                            #     else:
+                            #         info += [
+                            #             "Implementation setter ",
+                            #             proxy.proxy_implementation_setter,
+                            #             " was found in another contract: ",
+                            #             proxy.proxy_implementation_setter.contract,
+                            #             "\n"
+                            #         ]
+                            #     json = self.generate_result(info)
+                            #     results.append(json)
+                            """
+                            Check if logic contract has same variable declared in same slot, i.e. Singleton/MasterCopy
+                            """
+                            idx, logic = proxy_features.is_impl_address_also_declared_in_logic()
+                            if idx >= 0 and logic is not None:
+                                features["impl_address_also_declared_in"] = str(logic.source_mapping)
+                                features["impl_address_slot"] = str(idx)
+                                features["master_copy_coupling"] = True
+                                info += [
+                                    delegate.name,
+                                    " is declared in both the proxy and logic contract (",
+                                    logic.name,
+                                    f") in storage slot {idx}.\n"
+                                ]
+                                # json = self.generate_result(info)
+                                # results.append(json)
+                            elif logic is None:
+                                features["master_copy_coupling"] = "missing implementation source"
+                        elif f"{delegate.type}" == "bytes32" and delegate.is_constant:
+                            # info += self.detect_storage_slot(proxy_features)
+                            features["impl_address_type"] = "bytes32 constant storage slot"
+                            features["impl_address_slot"] = str(delegate.expression)
+                            slot_info, slot_features = self.detect_storage_slot(proxy_features)
+                            if len(slot_info) > 0:
+                                info += slot_info
+                                for key in slot_features.keys():
+                                    features[key] = slot_features[key]
+                        elif isinstance(delegate.type, MappingType):
+                            """
+                            Check for mapping results after the else block below, because we want 
+                            to check for Eternal Storage regardless of the delegate variable type.
+                            i.e. the implementation address may be stored as a StateVariable, but
+                            the proxy could still use mappings to store all other variables.
+                            """
+                            info += [
+                                delegate.name,
+                                " is a mapping of type ",
+                                str(delegate.type),
+                                "\n"
+                            ]
+                            features["impl_address_type"] = str(delegate.type)
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        else:
+                            """
+                            Do something else? 
+                            Print result for debugging
+                            """
+                            info += [
+                                delegate.name,
+                                " is a state variable of type ",
+                                str(delegate.type),
+                                "\n"
+                            ]
+                            features["impl_address_type"] = str(delegate.type)
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        """
+                        Check for mappings regardless of delegate.type, 
+                        in case EternalStorage is used for variables other than the implementation address.
+                        """
+                        # info += self.detect_mappings(proxy_features, delegate)
+                        map_info, map_features = self.detect_mappings(proxy_features, delegate)
+                        if len(map_info) > 0:
+                            info += map_info
+                            for key in map_features.keys():
+                                features[key] = map_features[key]
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region Local Variable
+                    ###################################################################################
+                    ###################################################################################
+                    elif isinstance(delegate, LocalVariable):
+                        """
+                        Check where the local variable gets the value of the implementation address from, i.e., 
+                        is it loaded from a storage slot, or by a call to a different contract, or something else?
+                        """
+
+                        mapping, exp = ProxyFeatureExtraction.find_mapping_in_var_exp(delegate, proxy)
+                        # slot_results = self.detect_storage_slot(proxy_features)
+                        if mapping is not None:
+                            if isinstance(mapping, StateVariable):
+                                features["impl_address_variable"] = f"{mapping.canonical_name}"
+                                features["impl_address_scope"] = "StateVariable"
+                            elif isinstance(mapping, StructureVariable):
+                                features["impl_address_variable"] = f"{mapping.structure.canonical_name}.{mapping.name}"
+                                features["impl_address_scope"] = "StructureVariable"
+                            features["impl_address_type"] = str(mapping.type)
+                            # info += self.detect_mappings(proxy_features, mapping)
+                            map_info, map_features = self.detect_mappings(proxy_features, mapping)
+                            if len(map_info) > 0:
+                                info += map_info
+                                for key in map_features.keys():
+                                    features[key] = map_features[key]
+                        else:
+                            features["impl_address_scope"] = "LocalVariable"
+                            features["impl_address_type"] = str(delegate.type)
+                            slot_info, slot_features = self.detect_storage_slot(proxy_features)
+                            if len(slot_info) > 0:
+                                info += slot_info
+                                for key in slot_features.keys():
+                                    features[key] = slot_features[key]
+                        """
+                        Check for call to a different contract in delegate.expression
+                        """
+                        # info += self.detect_cross_contract_call(proxy_features)
+                        (cross_contract_info,
+                         cross_contract_features) = self.detect_cross_contract_call(proxy_features)
+                        info += cross_contract_info
+                        for key in cross_contract_features.keys():
+                            features[key] = cross_contract_features[key]
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region Structure Variable
+                    ###################################################################################
+                    ###################################################################################
+                    elif isinstance(delegate, StructureVariable):
+                        """
+                        Check the type of the structure variable, i.e. an address, a mapping, or something else
+                        """
+                        struct = delegate.structure
+                        features["impl_address_scope"] = "StructureVariable"
+                        features["impl_address_in_struct"] = struct.canonical_name
+                        if f"{delegate.type}" == "address":
+                            features["impl_address_type"] = "address"
+                            info += [
+                                delegate.name,
+                                " is an address stored in a structure: ",
+                                struct.canonical_name,
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        elif isinstance(delegate.type, MappingType):
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a mapping found in a structure: ",
+                                struct.canonical_name,
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                            # info += self.detect_mappings(proxy_features, delegate)
+                            map_info, map_features = self.detect_mappings(proxy_features, delegate)
+                            if len(map_info) > 0:
+                                info += map_info
+                                for key in map_features.keys():
+                                    features[key] = map_features[key]
+                        else:
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a structure variable of type ",
+                                str(delegate.type),
+                                " which is unexpected!\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                    # endregion
+                    else:
+                        """
+                        Should not be reachable, but print a result for debugging
+                        """
+                        info += [
+                            delegate,
+                            " is not a StateVariable, LocalVariable, or StructureVariable."
+                            " This should not be possible!\n"
+                        ]
+                        # json = self.generate_result(info)
+                        # results.append(json)
+                # endregion
+                ###################################################################################
+                ###################################################################################
+                # region Delegate Variable Located in Different Contract
+                ###################################################################################
+                ###################################################################################
+                else:  # Location of delegate is in a different contract
+                    info += [
+                        delegate.name,
+                        " was found in a different contract.\n"
+                    ]
+                    features["impl_address_location"] = (proxy_features.impl_address_location.name + " (" +
+                                                         str(proxy_features.impl_address_location.source_mapping) + ")")
+                    # json = self.generate_result(info)
+                    # results.append(json)
+                    """
+                    Check the scope of the implementation address variable,
+                    i.e., StateVariable or LocalVariable.
+                    """
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region State Variable
+                    ###################################################################################
+                    ###################################################################################
+                    if isinstance(delegate, StateVariable):
+                        """
+                        Check the type of the state variable, i.e. an address, a mapping, or something else
+                        """
+                        features["impl_address_scope"] = "StateVariable"
+                        if f"{delegate.type}" == "address":
+                            features["impl_address_type"] = "address"
+                            info += [
+                                delegate.name,
+                                " is an address state variable.\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        elif f"{delegate.type}" == "bytes32" and delegate.is_constant:
+                            features["impl_address_type"] = "bytes32 constant storage slot"
+                            features["impl_address_slot"] = str(delegate.expression)
+                            # info += self.detect_storage_slot(proxy_features)
+                            slot_info, slot_features = self.detect_storage_slot(proxy_features)
+                            if len(slot_info) > 0:
+                                info += slot_info
+                                for key in slot_features.keys():
+                                    features[key] = slot_features[key]
+                        elif isinstance(delegate.type, MappingType):
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a mapping of type ",
+                                str(delegate.type),
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        else:
+                            """
+                            Unexpected variable type
+                            Print result for debugging
+                            """
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a state variable of type ",
+                                str(delegate.type),
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        # info += self.detect_mappings(proxy_features, delegate)
+                        map_info, map_features = self.detect_mappings(proxy_features, delegate)
+                        if len(map_info) > 0:
+                            info += map_info
+                            for key in map_features.keys():
+                                features[key] = map_features[key]
+                        """
+                        Check if proxy contract makes a call to impl_address_location contract to retrieve delegate
+                        """
+                        # info += self.detect_cross_contract_call(proxy_features)
+                        cross_contract_info, cross_contract_features = self.detect_cross_contract_call(proxy_features)
+                        info += cross_contract_info
+                        for key in cross_contract_features.keys():
+                            features[key] = cross_contract_features[key]
+                        """
+                        Check if impl_address_location contract is inherited by any contract besides current proxy
+                        """
+                        for c in self.contracts:
+                            if c == proxy or c == proxy_features.impl_address_location:
+                                continue
+                            if proxy_features.impl_address_location in proxy.inheritance and \
+                                    proxy_features.impl_address_location in c.inheritance and \
+                                    proxy not in c.inheritance and c not in proxy.inheritance:
+                                features["inherited_storage"] = True
+                                info += [
+                                    " uses Inherited Storage\n"
+                                ]
+                                # json = self.generate_result(info)
+                                # results.append(json)
+                                break
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region Local Variable
+                    ###################################################################################
+                    ###################################################################################
+                    elif isinstance(delegate, LocalVariable):
+                        """
+                        Check where the local variable gets the value of the implementation address from, i.e., 
+                        is it loaded from a storage slot, or by a call to a different contract, or something else?
+                        """
+                        features["impl_address_scope"] = "LocalVariable"
+                        features["impl_address_type"] = str(delegate.type)
+                        mapping, exp = ProxyFeatureExtraction.find_mapping_in_var_exp(delegate,
+                                                                                      delegate.function.contract)
+                        # info += self.detect_storage_slot(proxy_features)
+                        slot_info, slot_features = self.detect_storage_slot(proxy_features)
+                        if mapping is not None:
+                            features["impl_address_scope"] = "StateVariable"
+                            features["impl_address_type"] = str(mapping.type)
+                            # info += self.detect_mappings(proxy_features, mapping)
+                            map_info, map_features = self.detect_mappings(proxy_features, delegate)
+                            if len(map_info) > 0:
+                                info += map_info
+                                for key in map_features.keys():
+                                    features[key] = map_features[key]
+                        elif len(slot_info) > 0:
+                            info += slot_info
+                            for key in slot_features.keys():
+                                features[key] = slot_features[key]
+                        else:
+                            """
+                            Check for call to a different contract in delegate.expression
+                            """
+                            # info += self.detect_cross_contract_call(proxy_features)
+                            (cross_contract_info,
+                             cross_contract_features) = self.detect_cross_contract_call(proxy_features)
+                            info += cross_contract_info
+                            for key in cross_contract_features.keys():
+                                features[key] = cross_contract_features[key]
+
+                    # endregion
+                    ###################################################################################
+                    ###################################################################################
+                    # region Structure Variable
+                    ###################################################################################
+                    ###################################################################################
+                    elif isinstance(delegate, StructureVariable):
+                        """
+                        Check the type of the structure variable, i.e. an address, a mapping, or something else
+                        """
+                        struct = delegate.structure
+                        features["impl_address_scope"] = "StructureVariable"
+                        features["impl_address_in_struct"] = struct.canonical_name
+                        if f"{delegate.type}" == "address":
+                            features["impl_address_type"] = "address"
+                            info += [
+                                delegate.name,
+                                " is an address stored in a structure: ",
+                                struct.canonical_name,
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                        elif isinstance(delegate.type, MappingType):
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a mapping found in a structure: ",
+                                struct.canonical_name,
+                                "\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+                            # info += self.detect_mappings(proxy_features, delegate)
+                            map_info, map_features = self.detect_mappings(proxy_features, delegate)
+                            if len(map_info) > 0:
+                                info += map_info
+                                for key in map_features.keys():
+                                    features[key] = map_features[key]
+                        else:
+                            """
+                            Unexpected variable type
+                            Print result for debugging
+                            """
+                            features["impl_address_type"] = str(delegate.type)
+                            info += [
+                                delegate.name,
+                                " is a structure variable of type ",
+                                str(delegate.type),
+                                " which is unexpected!\n"
+                            ]
+                            # json = self.generate_result(info)
+                            # results.append(json)
+
+                    # endregion
+                    else:
+                        """
+                        Should not be reachable, but print a result for debugging
+                        """
+                        info += [
+                            delegate.name,
+                            " is not a StateVariable, a LocalVariable, or a StructureVariable."
+                            " This should not be possible!\n"
+                        ]
+                        # json = self.generate_result(info)
+                        # results.append(json)
+
+                # endregion
+                ###################################################################################
+                ###################################################################################
+                # region Transparent Proxy
+                ###################################################################################
+                ###################################################################################
+
+                """
+                Check if the proxy is transparent, i.e., if all external functions other than
+                the fallback and receive are only callable by a specific address, and whether 
+                the fallback and receive functions are only callable by addresses other than 
+                the same specific address
+                """
+                is_transparent, admin_str = proxy_features.has_transparent_admin_checks()
+                if is_transparent:
+                    features["transparent"] = True
+                    features["external_functions_require_specific_sender"] = True
+                    features["fallback_receive_not_callable_by_specific_sender"] = True
+                    info += [
+                        " uses Transparent Proxy pattern\n"
+                    ]
+                    # json = self.generate_result(info)
+                    # results.append(json)
+                else:
+                    features["transparent"] = False
+                    features["external_functions_require_specific_sender"] = (all(
+                        [proxy_features.is_function_protected_with_comparator(fn, "==", admin_str)
+                         for fn in proxy.functions if fn.visibility in ["external", "public"]
+                         and not fn.is_fallback and not fn.is_receive and not fn.is_constructor]
+                    ) and admin_str is not None and not proxy_features.proxy_only_contains_fallback())
+                    features["fallback_receive_not_callable_by_specific_sender"] = (all(
+                        [proxy_features.is_function_protected_with_comparator(fn, "!=", admin_str)
+                         for fn in proxy.functions if fn.is_fallback or fn.is_receive]
+                    ) and admin_str is not None)
+
+                # endregion
+                ###################################################################################
+                ###################################################################################
+                # region Compatibility Checks
+                ###################################################################################
+                ###################################################################################
+
+                """
+                Check if all functions that can update the implementation have compatibility checks
+                """
+                has_checks, func_exp_list = proxy_features.has_compatibility_checks()
+                features["compatibility_checks"] = {"has_all_checks": has_checks, "functions": {}}
+                # info = []
+                if not has_checks:
+                    funcs_missing_check = [func for func, check, correct in func_exp_list if check is None]
+                    funcs_with_check = [(func, check) for func, check, correct in func_exp_list if check is not None]
+                    for func in funcs_missing_check:
+                        features["compatibility_checks"]["functions"][func.canonical_name] = "missing"
+                        info += [
+                            "Missing compatibility check in ",
+                            func.canonical_name, "\n"
+                        ]
+                    for func, check in funcs_with_check:
+                        features["compatibility_checks"]["functions"][func.canonical_name] = str(check)
+                        info += [
+                            "Found compatibility check in ",
+                            func.canonical_name,
+                            "\n"
+                        ]
+                elif len(func_exp_list) == 0:
+                    features["compatibility_checks"]["functions"] = "no setters found"
+                    info += ["No setter functions found to search for compatibility checks.\n"]
+                else:
+                    info += ["Found compatibility checks in all upgrade functions.\n"]
+                    for func, exp, is_correct in func_exp_list:
+                        if not is_correct:
+                            info += [f"Incorrect compatibility check in {func}: {exp}\n"]
+                        features["compatibility_checks"]["functions"][func.canonical_name] = {"check": str(exp),
+                                                                                              "is_correct": is_correct}
+                # if len(info) > 0:
+                # json = self.generate_result(info)
+                # results.append(json)
+
+                # endregion
+                ###################################################################################
+                ###################################################################################
+                # region Anti-Pattern Features
+                ###################################################################################
+                ###################################################################################
+
+                """
+                Check whether upgradeability can be removed 
+                i.e., if setter is in another contract, which can be updated to remove the setter
+                """
+                setter = proxy.proxy_implementation_setter
+                if setter is not None and setter.contract != proxy and setter.contract not in proxy.inheritance:
+                    features["can_remove_upgradeability"] = True
+                    """
+                    If a beacon or registry was detected earlier, check if its address can be updated
+                    """
+                    if "beacon_source_constant" in features.keys():
+                        if features["beacon_source_constant"]:
+                            features["can_remove_upgradeability"] = False
+                        elif not features["beacon_source_constant"]:
+                            features["can_remove_upgradeability"] = True
+                    elif "registry_source_constant" in features.keys():
+                        if features["registry_source_constant"]:
+                            features["can_remove_upgradeability"] = False
+                        elif not features["registry_source_constant"]:
+                            features["can_remove_upgradeability"] = True
+                    if features["can_remove_upgradeability"]:
+                        if "eip_2535" in features.keys():
+                            features["how_to_remove_upgradeability"] = f"remove {setter.contract.name} facet"
+                            info += [f"To remove upgradeability, delete the {setter.contract.name} facet\n"]
+                        else:
+                            features["how_to_remove_upgradeability"] = f"remove {setter.name} from {setter.contract}"
+                            info += [f"To remove upgradeability, delete {setter.name} from {setter.contract}\n"]
+                else:
+                    features["can_remove_upgradeability"] = False
+
+                """
+                Check whether the proxy can toggle using delegatecall on and off
+                """
+                can_toggle_delegatecall, condition, delegate_condition, alt_node \
+                    = proxy_features.can_toggle_delegatecall_on_off()
+                if can_toggle_delegatecall:
+                    info += [f"Can toggle delegatecall on/off: condition: {condition}\n"]
+                    features["can_toggle_delegatecall"] = True
+                    toggle_condition = str(condition)
+                    if not delegate_condition:  # condition must equate to False for using delegatecall
+                        if "==" in toggle_condition:
+                            toggle_condition = toggle_condition.replace("==", "!=")
+                        else:
+                            toggle_condition = "!" + toggle_condition
+                    features["toggle_delegatecall_condition"] = toggle_condition
+                    if alt_node.type == NodeType.PLACEHOLDER and isinstance(alt_node.function, Modifier):
+                        features["toggle_alternative_logic"] = "placeholder for function with modifier"
+                        features["toggle_modifier"] = alt_node.function.name
+                    elif alt_node.type == NodeType.ASSEMBLY and " call" in alt_node.inline_asm:
+                        features["toggle_alternative_logic"] = "uses call instead of delegatecall"
+                    else:
+                        alt_logic = str(alt_node.expression) if alt_node.expression is not None else "None"
+                        features["toggle_alternative_logic"] = alt_logic
+                    if isinstance(condition, Identifier):
+                        condition_var = condition.value
+                        funcs_writing_condition = proxy.get_functions_writing_to_variable(condition_var)
+                        features["toggle_setters"] = [func.name for func in funcs_writing_condition]
+                    elif isinstance(condition, BinaryOperation) \
+                            and delegate in [exp.value for exp in condition.expressions if isinstance(exp, Identifier)]:
+                        features["toggle_setters"] = [proxy.proxy_implementation_setter.name]
+
+                """
+                Check whether there are any immutable external/public functions (besides fallback/receive) 
+                and see if they contain delegatecall
+                """
+                if not proxy_features.proxy_only_contains_fallback():
+                    features["immutable_functions"] = {}
+                    funcs_containing_delegatecall = []
+                    for function in proxy.functions:
+                        if function.visibility in ["external", "public"]:
+                            if function.is_receive or function.is_fallback or function.is_constructor:
+                                continue
+                            if function.contains_assembly or any([modifier.contains_assembly
+                                                                  for modifier in function.modifiers]):
+                                asm_nodes = function.assembly_nodes
+                                for node in asm_nodes:
+                                    if node.inline_asm is not None and "delegatecall" in node.inline_asm:
+                                        funcs_containing_delegatecall.append(function.full_name)
+                                        features["immutable_functions"]["containing_delegatecall"] \
+                                            = funcs_containing_delegatecall
+                                        break
+                    """
+                    Check if the proxy contains any known ERC functions (if it contains external functions)
+                    """
+                    ERC721 = list(set(ERC721_all_signatures).difference(ERC20_all_signatures + ERC165_signatures))
+                    ERC1155 = list(set(ERC1155_all_signatures).difference(ERC20_all_signatures + ERC165_signatures))
+                    all_erc_sigs = ERC20_all_signatures + ERC165_signatures + ERC721 + ERC897_signatures + ERC1155
+                    if any(function.full_name in all_erc_sigs
+                           for function in proxy.functions if function.name != "implementation"):
+                        if any(function.full_name in ERC20_all_signatures for function in proxy.functions):
+                            erc20_functions = []
+                            for sig in ERC20_all_signatures:
+                                if proxy.get_function_from_signature(sig) is not None:
+                                    erc20_functions.append(sig)
+                            features["immutable_functions"]["erc20"] = erc20_functions
+                        if any(function.full_name in ERC165_signatures for function in proxy.functions):
+                            erc165_functions = []
+                            for sig in ERC165_signatures:
+                                if proxy.get_function_from_signature(sig) is not None:
+                                    erc165_functions.append(sig)
+                            features["immutable_functions"]["erc165"] = erc165_functions
+                        if any(function.full_name in ERC721 for function in proxy.functions):
+                            erc721_functions = []
+                            for sig in ERC721_all_signatures:
+                                if proxy.get_function_from_signature(sig) is not None:
+                                    erc721_functions.append(sig)
+                            features["immutable_functions"]["erc721"] = erc721_functions
+                        if any(function.full_name in ERC1155 for function in proxy.functions):
+                            erc1155_functions = []
+                            for sig in ERC1155_all_signatures:
+                                if proxy.get_function_from_signature(sig) is not None:
+                                    erc1155_functions.append(sig)
+                            features["immutable_functions"]["erc1155"] = erc1155_functions
+                        # for ERC-897: DelegateProxy, only care if `proxyType()` is present, since
+                        # `implementation()` is found in so many proxies which don't use EIP-897
+                        if all(function.full_name in ERC897_signatures for function in proxy.functions):
+                            features["immutable_functions"]["erc897"] = ERC897_signatures
+                    """
+                    Add remaining public/external functions not covered above
+                    """
+                    other_functions = [function.full_name for function in proxy.functions
+                                       if function.visibility in ["external", "public"]
+                                       and function.full_name not in str(features["immutable_functions"])
+                                       and not (function.is_constructor or function.is_fallback or function.is_receive)]
+                    if len(other_functions) > 0:
+                        features["immutable_functions"]["other"] = other_functions
+
+                """
+                TODO: Check whether upgrading has a time-delay
+                """
+                has_time_delay = proxy_features.has_time_delay()
+                if has_time_delay["has_delay"]:
+                    features["time_delay"] = has_time_delay
+
+                # endregion
+            ###################################################################################
+            ###################################################################################
+            # region Non-Upgradeable Proxy
+            ###################################################################################
+            ###################################################################################
+
+            elif contract.is_proxy:
+                """
+                Contract is either a non-upgradeable proxy, or upgradeability could not be determined
+                """
+                info += [contract, " is a proxy, but doesn't seem upgradeable.\n"]
+                features["upgradeable"] = False
+
+            # endregion
+            else:
+                continue
+            json = self.generate_result(info, features)
+            results.append(json)
+        return results
+    # endregion

--- a/slither/detectors/proxy/proxy_standards.py
+++ b/slither/detectors/proxy/proxy_standards.py
@@ -1,0 +1,703 @@
+from abc import ABC
+
+import hashlib
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+from typing import Optional, List, Dict, Callable, Tuple, TYPE_CHECKING, Union
+from slither.core.cfg.node import NodeType
+from slither.core.declarations.contract import Contract
+from slither.core.declarations.structure import Structure
+from slither.core.variables.variable import Variable
+from slither.core.variables.state_variable import StateVariable
+from slither.core.variables.local_variable import LocalVariable
+from slither.core.variables.structure_variable import StructureVariable
+from slither.core.expressions.identifier import Identifier
+from slither.core.expressions.literal import Literal
+from slither.core.declarations.function_contract import FunctionContract
+from slither.core.expressions.expression import Expression
+from slither.core.expressions.call_expression import CallExpression
+from slither.core.expressions.type_conversion import TypeConversion
+from slither.core.expressions.assignment_operation import AssignmentOperation
+from slither.core.expressions.binary_operation import BinaryOperation
+from slither.core.expressions.member_access import MemberAccess
+from slither.core.expressions.index_access import IndexAccess
+from slither.core.solidity_types.mapping_type import MappingType
+from slither.core.solidity_types.user_defined_type import UserDefinedType
+from slither.core.solidity_types.elementary_type import ElementaryType
+
+
+class ProxyFeatures(AbstractDetector, ABC):
+    ARGUMENT = "proxy-features"
+    IMPACT = DetectorClassification.INFORMATIONAL
+    CONFIDENCE = DetectorClassification.MEDIUM
+
+    HELP = "Proxy contract does not conform to any known standard"
+    WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#non-standard-proxy"
+    WIKI_TITLE = "Proxy Features"
+
+    # region wiki_description
+    WIKI_DESCRIPTION = """
+Determine whether an upgradeable proxy contract conforms to any known proxy standards, i.e. OpenZeppelin, UUPS, Diamond 
+Multi-Facet Proxy, etc.
+"""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """
+```solidity
+contract Proxy{
+    address logicAddress;
+
+    function() payable {
+        logicAddress.delegatecall(msg.data)
+    }
+}
+
+contract Logic{
+    uint variable1;
+}
+```
+The new version, `V2` does not contain `variable1`. 
+If a new variable is added in an update of `V2`, this variable will hold the latest value of `variable2` and
+will be corrupted.
+"""
+    # endregion wiki_exploit_scenario
+
+    # region wiki_recommendation
+    WIKI_RECOMMENDATION = """
+It is better to use one of the common standards for upgradeable proxy contracts. Consider EIP-1967, EIP-1822, EIP-2523, 
+or one of the proxy patterns developed by OpenZeppelin.
+"""
+
+    # endregion wiki_recommendation
+
+    @staticmethod
+    def find_slot_in_setter_asm(
+            inline_asm: Union[str, Dict],
+            delegate: LocalVariable
+    ) -> Optional[str]:
+        slot = None
+        if "AST" in inline_asm and isinstance(inline_asm, Dict):
+            for statement in inline_asm["AST"]["statements"]:
+                if statement["nodeType"] == "YulExpressionStatement":
+                    statement = statement["expression"]
+                if statement["nodeType"] == "YulVariableDeclaration":
+                    statement = statement["value"]
+                if statement["nodeType"] == "YulFunctionCall":
+                    if statement["functionName"]["name"] == "sstore":
+                        if statement["arguments"][1] == delegate.name:
+                            slot = statement["arguments"][0]
+        else:
+            asm_split = inline_asm.split("\n")
+            for asm in asm_split:
+                if "sstore" in asm:
+                    params = asm.split("(")[1].strip(")").split(", ")
+                    slot = params[0]
+        return slot
+
+    @staticmethod
+    def find_slot_string_from_assert(
+            proxy: Contract,
+            slot: StateVariable
+    ):
+        slot_string = None
+        assert_exp = None
+        minus = 0
+        if proxy.constructor is not None:
+            for exp in proxy.constructor.all_expressions():
+                if isinstance(exp, CallExpression) and str(exp.called) == "assert(bool)" and slot.name in str(exp):
+                    print(f"Found assert statement in constructor:\n{str(exp)}")
+                    assert_exp = exp
+                    arg = exp.arguments[0]
+                    if isinstance(arg, BinaryOperation) and str(arg.type) == "==" and arg.expression_left.value == slot:
+                        e = arg.expression_right
+                        print("BinaryOperation ==")
+                        if isinstance(e, TypeConversion) and str(e.type) == "bytes32":
+                            print(f"TypeConversion bytes32: {str(e)}")
+                            e = e.expression
+                        if isinstance(e, BinaryOperation) and str(e.type) == "-":
+                            print(f"BinaryOperation -: {str(e)}")
+                            if isinstance(e.expression_right, Literal):
+                                print(f"Minus: {str(e.expression_right.value)}")
+                                minus = int(e.expression_right.value)
+                                e = e.expression_left
+                        if isinstance(e, TypeConversion) and str(e.type) == "uint256":
+                            print(f"TypeConversion uint256: {str(e)}")
+                            e = e.expression
+                        if isinstance(e, CallExpression) and "keccak256(" in str(e.called):
+                            print(f"CallExpression keccak256: {str(e)}")
+                            arg = e.arguments[0]
+                            if isinstance(arg, Literal):
+                                if str(arg.type) == "string":
+                                    slot_string = arg.value
+                                    break
+        return slot_string, assert_exp, minus
+
+    @staticmethod
+    def find_mapping_in_var_exp(
+            delegate: Variable,
+            proxy: Contract
+    ) -> (Optional["Variable"], Optional["IndexAccess"]):
+        mapping = None
+        exp = None
+        e = delegate.expression
+        if e is not None:
+            print(f"{delegate} expression is {e}")
+            while isinstance(e, TypeConversion) or isinstance(e, MemberAccess):
+                e = e.expression
+            if isinstance(e, IndexAccess):
+                exp = e
+                left = e.expression_left
+                if isinstance(left, MemberAccess):
+                    e = left.expression
+                    member = left.member_name
+                    if isinstance(e, Identifier):
+                        v = e.value
+                        if isinstance(v.type, UserDefinedType) and isinstance(v.type.type, Structure):
+                            if isinstance(v.type.type.elems[member].type, MappingType):
+                                mapping = v.type.type.elems[member]
+                elif isinstance(left, Identifier):
+                    v = left.value
+                    if isinstance(v.type, MappingType):
+                        mapping = v
+        elif isinstance(delegate.type, MappingType):
+            mapping = delegate
+            for e in proxy.fallback_function.variables_read_as_expression:
+                if isinstance(e, IndexAccess) and isinstance(e.expression_left, Identifier):
+                    if e.expression_left.value == mapping:
+                        exp = e
+                        break
+        return mapping, exp
+
+    def _detect(self):
+        results = []
+        storage_inheritance_index = None  # Use to ensure
+        for contract in self.contracts:
+            if contract.is_upgradeable_proxy:
+                proxy = contract
+                info = [proxy, " appears to ",
+                        "maybe " if not contract.is_upgradeable_proxy_confirmed else "",
+                        "be an upgradeable proxy contract.\n"]
+                json = self.generate_result(info)
+                results.append(json)
+                delegate = proxy.delegate_variable
+                print(f"{proxy.name} delegates to variable of type {delegate.type} called {delegate.name}")
+
+                # Try to extract a mapping from delegate variable
+                # If found, this could suggest the proxy implements EIP-1538 or EIP-2535
+                mapping, exp = self.find_mapping_in_var_exp(delegate, proxy)
+                if mapping is not None and isinstance(mapping.type, MappingType):
+                    mtype: MappingType = mapping.type
+                    struct = None
+                    if isinstance(mapping, StructureVariable):
+                        struct = mapping.structure
+                    info = [
+                        proxy, " stores the values for ", delegate,
+                        " in the mapping called ", mapping,
+                        " which is located in the structure " if struct is not None else "",
+                        struct if struct is not None else "",
+                        "\n"
+                    ]
+                    json = self.generate_result(info)
+                    results.append(json)
+                    # Extract EIP-2535 Diamond features
+                    lib_diamond = proxy.compilation_unit.get_contract_from_name("LibDiamond")
+                    if lib_diamond is not None and lib_diamond.get_structure_from_name(
+                            "DiamondStorage") is not None:
+                        info = [proxy, " appears to be an EIP-2535 Diamond Proxy.\n"]
+                        json = self.generate_result(info)
+                        results.append(json)
+                        # TODO: Determine if the Diamond is upgradeable
+                        # i.e., if it adds a DiamondCut facet in constructor
+                        # TODO: Determine if the compilation unit contains the required Loupe functions
+                    elif str(mtype.type_from) == "bytes4" and str(exp.expression_right) == "msg.sig":
+                        info = [proxy, " appears to be an EIP-1538 Transparent Proxy.\n"]
+                        json = self.generate_result(info)
+                        results.append(json)
+                else:
+                    print(f"{delegate} expression is None")
+                # else:
+                #     print(f"{delegate} is a StateVariable")
+            elif contract.is_proxy:
+                proxy = contract
+        return results
+
+
+class ProxyStandards(ProxyFeatures, ABC):
+    ARGUMENT = "proxy-standards"
+    IMPACT = DetectorClassification.INFORMATIONAL
+    CONFIDENCE = DetectorClassification.MEDIUM
+
+    HELP = "Proxy contract does not conform to any known standard"
+    WIKI = "https://github.com/crytic/slither/wiki/Upgradeability-Checks#non-standard-proxy"
+    WIKI_TITLE = "Non-Standard Proxy"
+
+    # region wiki_description
+    WIKI_DESCRIPTION = """
+Determine whether an upgradeable proxy contract conforms to any known proxy standards, i.e. OpenZeppelin, UUPS, Diamond 
+Multi-Facet Proxy, etc.
+"""
+    # endregion wiki_description
+
+    # region wiki_exploit_scenario
+    WIKI_EXPLOIT_SCENARIO = """
+```solidity
+contract Proxy{
+    address logicAddress;
+    
+    function() payable {
+        logicAddress.delegatecall(msg.data)
+    }
+}
+
+contract Logic{
+    uint variable1;
+}
+```
+The new version, `V2` does not contain `variable1`. 
+If a new variable is added in an update of `V2`, this variable will hold the latest value of `variable2` and
+will be corrupted.
+"""
+    # endregion wiki_exploit_scenario
+
+    # region wiki_recommendation
+    WIKI_RECOMMENDATION = """
+It is better to use one of the common standards for upgradeable proxy contracts. Consider EIP-1967, EIP-1822, EIP-2523, 
+or one of the proxy patterns developed by OpenZeppelin.
+"""
+    # endregion wiki_recommendation
+
+    def _detect(self):
+        results = []
+        storage_inheritance_index = None    # Use to ensure
+        ProxyFeatures._detect(self)
+        for contract in self.contracts:
+            if contract.is_upgradeable_proxy:
+                proxy = contract
+                info = [proxy, " appears to ",
+                        "maybe " if not contract.is_upgradeable_proxy_confirmed else "",
+                        "be an upgradeable proxy contract.\n"]
+                json = self.generate_result(info)
+                results.append(json)
+                delegate = proxy.delegate_variable
+                print(f"{proxy.name} delegates to variable of type {delegate.type} called {delegate.name}")
+                lib_diamond = proxy.compilation_unit.get_contract_from_name("LibDiamond")
+                ierc_1538 = proxy.compilation_unit.get_contract_from_name("IERC1538")
+                if lib_diamond is not None and lib_diamond.get_structure_from_name("DiamondStorage") is not None:
+                    info = [proxy, " appears to be an EIP-2535 Diamond Proxy: This is a WIP.\n"]
+                    json = self.generate_result(info)
+                    results.append(json)
+                elif ierc_1538 is not None and ierc_1538 in proxy.inheritance:
+                    info = [proxy, " appears to be an EIP-1538 Transparent Proxy:\nThis EIP has been "
+                                   "withdrawn and replaced with EIP-2535: Diamonds, Multi-Facet Proxy\n"]
+                    json = self.generate_result(info)
+                    results.append(json)
+                elif isinstance(delegate, StateVariable):
+                    print(f"delegate.contract = {delegate.contract}\nproxy = {proxy}")
+                    if delegate.contract == proxy:
+                        info = [
+                            proxy,
+                            " stores implementation as state variable: ",
+                            delegate,
+                            "\nAvoid variables in the proxy. Better to use a standard storage slot, e.g. as proposed in ",
+                            "EIP-1967, EIP-1822, Unstructured Storage, Eternal Storage or another well-audited pattern.\n"
+                        ]
+                        json = self.generate_result(info)
+                        results.append(json)
+                    elif delegate.contract in proxy.inheritance:
+                        print(f"State variable {delegate.name} is in the inherited contract: {delegate.contract.name}")
+                        for idx, c in enumerate(proxy.inheritance_reverse):
+                            if idx == 0:
+                                suffix = "st"
+                            elif idx == 1:
+                                suffix = "nd"
+                            elif idx == 2:
+                                suffix = "rd"
+                            else:
+                                suffix = "th"
+                            if c == delegate.contract:
+                                info = [
+                                    proxy,
+                                    " stores implementation as state variable called ",
+                                    delegate,
+                                    " which is located in the inherited contract called ",
+                                    c,
+                                    "\nIf this is a storage contract which is shared with the logic contract, it is"
+                                    " essential that both have the same order of inheritance, i.e. the storage contract"
+                                    " must be the ",
+                                    str(idx + 1),
+                                    suffix,
+                                    " contract inherited, and any preceding inheritances must also be identical.\n"
+                                ]
+                                json = self.generate_result(info)
+                                results.append(json)
+                    else:
+                        print(f"State variable {delegate.name} is defined in another contract: "
+                              f"{delegate.contract.name}")
+                        setter = proxy.proxy_implementation_setter
+                        getter = proxy.proxy_implementation_getter
+                        contract = delegate.contract
+                        for c in self.contracts:
+                            if contract in c.inheritance:
+                                contract = c
+                                if setter is not None and isinstance(setter, FunctionContract):
+                                    setter.set_contract(c)
+                        info = [
+                            "The implementation address for ",
+                            proxy.name,
+                            " is a state variable declared and stored in another contract:\n",
+                            delegate.contract
+                        ]
+                        if contract != delegate.contract:
+                            info.append(" which is inherited by ")
+                            info.append(contract)
+                        if setter is not None:
+                            info.append("\nThe implementation setter is: ")
+                            info.append(setter)
+                        if getter is not None:
+                            info.append("\nThe implementation getter is: ")
+                            info.append(getter)
+                            if delegate.expression is not None:
+                                info.append("\nwhich calls " + str(delegate.expression))
+                        info.append("\n")
+                        json = self.generate_result(info)
+                        results.append(json)
+                elif isinstance(delegate, LocalVariable) and delegate.location is not None and\
+                        "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7" in str(delegate.location):
+                    print(proxy.name + " appears to be an EIP-1822 proxy. Looking for Proxiable contract.")
+                    proxiable = proxy.compilation_unit.get_contract_from_name("Proxiable")
+                    if proxiable is not None:
+                        setter = proxiable.get_function_from_signature("updateCodeAddress(address)")
+                        if setter is None:
+                            setter = proxiable.get_function_from_signature("_updateCodeAddress(address)")
+                        if setter is not None:
+                            print(f"Found implementation setter {setter.signature_str}"
+                                  f" in contract {proxiable.name}")
+                            for c in proxy.compilation_unit.contracts:
+                                if c == proxiable:
+                                    continue
+                                if proxiable in c.inheritance:
+                                    print(f"Contract {c.name} inherits {proxiable.name}")
+                                    proxiable = c
+                            info = [
+                                proxy,
+                                " appears to be an EIP-1822 Universal Upgradeable Proxy:\nThis proxy doesn't contain"
+                                " its own upgrade logic - it is in the logic contract which must inherit Proxiable.\n",
+                                proxiable,
+                                " appears to be the logic contract used by this proxy.\n"
+                            ]
+                            json = self.generate_result(info)
+                            results.append(json)
+                        else:
+                            info = [
+                                proxy,
+                                " appears to be an EIP-1822 Universal Upgradeable Proxy:\nHowever, the Proxiable "
+                                "contract ",
+                                proxiable,
+                                " does not appear to contain the expected implementation setter, updateCodeAddress()."
+                                " If this is indeed an EIP-1822 logic contract, then it may no longer be upgradeable!\n"
+                            ]
+                            json = self.generate_result(info)
+                            results.append(json)
+                    else:
+                        info = [
+                            proxy,
+                            " appears to be an EIP-1822 Universal Upgradeable Proxy:\nThis proxy doesn't contain"
+                            " its own upgrade logic - it is in the logic contract which must inherit Proxiable.\n",
+                            "However, the Proxiable contract could not be found in the compilation unit.\n"
+                        ]
+                        json = self.generate_result(info)
+                        results.append(json)
+                else:
+                    setter = proxy.proxy_implementation_setter
+                    slot = proxy.proxy_impl_storage_offset
+                    if slot is None:
+                        if setter is not None:
+                            if isinstance(setter, FunctionContract) and setter.contract != proxy:
+                                info = [
+                                    "Implementation setter for proxy contract ",
+                                    proxy,
+                                    " is located in another contract:\n",
+                                    setter,
+                                    "\n"
+                                ]
+                                json = self.generate_result(info)
+                                results.append(json)
+                            if isinstance(delegate, LocalVariable):
+                                exp = delegate.expression
+                                if exp is not None:
+                                    print(exp)
+                                else:
+                                    for node in setter.all_nodes():
+                                        # print(str(node.type))
+                                        if node.type == NodeType.VARIABLE:
+                                            exp = node.variable_declaration.expression
+                                            if exp is not None and isinstance(exp, Identifier):
+                                                slot = str(exp.value.expression)
+                                                break
+                                        # elif node.type == NodeType.EXPRESSION:
+                                        #     print(node.expression)
+                                        elif node.type == NodeType.ASSEMBLY:
+                                            slot = self.find_slot_in_setter_asm(node.inline_asm, delegate)
+                                            break
+                                    if slot is not None:
+                                        print(slot)
+                        else:
+                            getter = proxy.proxy_implementation_getter
+                            exp = None
+                            ext_call = None
+                            if getter is not None:
+                                for node in getter.all_nodes():
+                                    # print(node.type)
+                                    exp = node.expression
+                                    # print(exp)
+                                    # if node.expression is not None:
+                                    if node.type == NodeType.RETURN and isinstance(exp, CallExpression):
+                                        print("This return node is a CallExpression")
+                                        if isinstance(exp.called, MemberAccess):
+                                            print("The CallExpression is for MemberAccess")
+                                            exp = exp.called
+                                            break
+                                        elif isinstance(node.expression, Identifier):
+                                            print("This return node is a variable Identifier")
+                                        elif isinstance(node.expression, Expression):
+                                            print(node.expression.type)
+                                    elif node.type == NodeType.EXPRESSION and isinstance(exp, AssignmentOperation):
+                                        left = exp.expression_left
+                                        right = exp.expression_right
+                                        if isinstance(left, Identifier):
+                                            print(f"Left: Identifier {left.type}")
+                                        if isinstance(right, CallExpression):
+                                            print(f"Right: {right.called}")
+                                            if "call" in str(right):
+                                                exp = right.called
+                                                break
+                            if isinstance(exp, MemberAccess):
+                                # Getter calls function of another contract in return expression
+                                call_exp = exp.expression
+                                print(call_exp)
+                                call_function = exp.member_name
+                                call_contract = None
+                                call_type = None
+                                if isinstance(call_exp, TypeConversion):
+                                    print(f"The getter calls a function from a contract of type {call_exp.type}")
+                                    call_type = call_exp.type
+                                elif isinstance(call_exp, Identifier):
+                                    val = call_exp.value
+                                    if isinstance(val, Variable) and str(val.type) == "address" and val.is_constant:
+                                        info = [
+                                            "Implementation getter for proxy contract ",
+                                            proxy,
+                                            " appears to make a call to a constant address variable: ",
+                                            val,
+                                            "\nWithout the Contract associated with this we cannot confirm upgradeability\n"
+                                        ]
+                                        if "beacon" in val.name.lower():
+                                            info.append("However, it appears to be the address of an Upgrade Beacon\n")
+                                        json = self.generate_result(info)
+                                        results.append(json)
+                                if call_type is not None:
+                                    call_contract = proxy.compilation_unit.get_contract_from_name(str(call_type))
+                                    if call_contract is not None:
+                                        print(f"\nFound contract called by proxy: {call_contract.name}")
+                                        interface = None
+                                        if call_contract.is_interface:
+                                            interface = call_contract
+                                            call_contract = None
+                                            print(f"It's an interface\nLooking for a contract that implements "
+                                                  f"the interface {interface.name}")
+                                            for c in proxy.compilation_unit.contracts:
+                                                if interface in c.inheritance:
+                                                    print(f"{c.name} inherits the interface {interface.name}")
+                                                    call_contract = c
+                                                    break
+                                            if call_contract is None:
+                                                print(f"Could not find a contract that inherits {interface.name}\n"
+                                                      f"Looking for a contract with {call_function}")
+                                                for c in self.compilation_unit.contracts:
+                                                    has_called_func = False
+                                                    if c == interface:
+                                                        continue
+                                                    for f in interface.functions_signatures:
+                                                        if exp.member_name not in f:
+                                                            continue
+                                                        if f in c.functions_signatures:
+                                                            print(f"{c.name} has function {f} from interface")
+                                                            has_called_func = True
+                                                            break
+                                                    if has_called_func:
+                                                        print(f"{c.name} contains the implementation getter")
+                                                        call_contract = c
+                                                        break
+                                            if call_contract is None:
+                                                print(f"Could not find a contract that implements {exp.member_name}"
+                                                      f" from {interface.name}:")
+                                            else:
+                                                print(f"Looking for implementation setter in {call_contract.name}")
+                                                setter = proxy.find_setter_in_contract(call_contract, delegate,
+                                                                                       proxy.proxy_impl_storage_offset,
+                                                                                       True)
+                                                if setter is not None:
+                                                    print(f"\nImplementation set by function: {setter.name}"
+                                                          f" in contract: {call_contract.name}")
+                                                    info = [
+                                                        "Implementation setter for proxy contract ",
+                                                        proxy,
+                                                        " is located in another contract:\n",
+                                                        setter,
+                                                        "\n"
+                                                    ]
+                                                    json = self.generate_result(info)
+                                                    results.append(json)
+                                                    break
+                                        if call_contract is not None and not call_contract.is_interface:
+                                            contains_getter = False
+                                            contains_setter = False
+                                            implementation = None
+                                            for f in call_contract.functions:
+                                                if f.name == exp.member_name:
+                                                    for v in f.returns:
+                                                        if str(v.type) == "address":
+                                                            print(f"Found getter {f.name} in {call_contract.name}")
+                                                            contains_getter = True
+                                                            call_function = f
+                                                            break
+                                                    if contains_getter:
+                                                        for v in f.variables_read:
+                                                            if isinstance(v, StateVariable):
+                                                                implementation = v
+                                                                break
+                                                        break
+                                            if contains_getter:
+                                                print(f"Looking for implementation setter in {call_contract.name}")
+                                                setter = proxy.find_setter_in_contract(call_contract, delegate,
+                                                                                       proxy.proxy_impl_storage_offset,
+                                                                                       True)
+                                                if setter is not None:
+                                                    print("Found implementation setter ")
+                                                    info = [
+                                                        "Implementation setter for proxy contract ",
+                                                        proxy,
+                                                        " is located in another contract:\n",
+                                                        setter,
+                                                        "\n"
+                                                    ]
+                                                    json = self.generate_result(info)
+                                                    results.append(json)
+                                                    break
+                                                else:
+                                                    info = [
+                                                        "Could not find implementation setter for proxy contract ",
+                                                        proxy,
+                                                        " which should be located in another contract:\n",
+                                                        call_contract,
+                                                        "\n"
+                                                    ]
+                                                    json = self.generate_result(info)
+                                                    results.append(json)
+                                    else:
+                                        print(f"Could not find a contract called {call_type} in compilation unit")
+                            elif isinstance(exp, CallExpression):
+                                print(f"Not member access, just a CallExpression\n{exp}")
+                                exp = exp.called
+                                if isinstance(exp, MemberAccess):
+                                    print(exp.type)
+                                if "." in str(exp):
+                                    target = str(exp).split(".")[0]
+                    else:
+                        print(f"Implementation slot: {slot.name} = {slot.expression}")
+                        slot_value = str(slot.expression)
+                        slot_string, assert_exp, minus = self.find_slot_string_from_assert(proxy, slot)
+                        if slot_string is not None:
+                            s = hashlib.sha3_256()
+                            # s = sha3.keccak_256()
+                            s.update(slot_string.encode("utf-8"))
+                            hashed = int("0x" + s.hexdigest(), 16) - minus
+                            if int(slot_value, 16) == hashed:
+                                print(f"{slot.name} value matches keccak256('{slot_string}')")
+                                if slot_string == "eip1967.proxy.implementation":
+                                    info = [
+                                        proxy,
+                                        " implements EIP-1967: Standard Proxy Storage Slots\n"
+                                    ]
+                                    json = self.generate_result(info)
+                                    results.append(json)
+                                else:
+                                    info = [
+                                        proxy,
+                                        " uses a proxy implementation storage slot called ",
+                                        slot,
+                                        " which equals keccack256('",
+                                        slot_string,
+                                        "')\nHowever it is recommended to use the standard set down by EIP-1967,\ni.e.",
+                                        " IMPLEMENTATION_SLOT = bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1) \n"
+                                    ]
+                                    json = self.generate_result(info)
+                                    results.append(json)
+                            else:
+                                info = [
+                                    "The value of ",
+                                    slot.name,
+                                    " does not appear to match keccak256('",
+                                    slot_string,
+                                    "') as required by the assert statement:\n",
+                                    str(assert_exp) + "\n"
+                                ]
+                                json = self.generate_result(info)
+                                results.append(json)
+                        elif assert_exp is None:
+                            info = [
+                                "The value of ",
+                                slot.name,
+                                " does not appear to be checked in the constructor.\n",
+                                "When using a hardcoded storage slot, always include an assert statement ",
+                                "in the first line of the constructor. For example:\n",
+                                "assert(",
+                                slot.name,
+                                " == keccak256('some.well.defined.string'))\n"
+                            ]
+                            json = self.generate_result(info)
+                            results.append(json)
+                    slots = [var for var in proxy.state_variables if var.is_constant and str(var.type) == "bytes32"
+                             and "slot" in var.name.lower()]
+                    print(f"slots = {slots}")
+                    if len(slots) > 1 or (slot is None and len(slots) > 0):
+                        info = [
+                            proxy,
+                            " also uses the following storage slots:\n"
+                        ]
+                        for s in slots:
+                            print(s.name)
+                            if s == slot or (slot is not None and s.name == slot.name):
+                                continue
+                            slot_string, assert_exp, minus = self.find_slot_string_from_assert(proxy, s)
+                            if assert_exp is not None:
+                                assert_str = str(assert_exp).replace("assert(bool)(", "").replace("))", "')")\
+                                    .replace("()(", "('").replace("(bytes)(", "('").replace("==", "=")
+                                print(assert_str)
+                                info.append(assert_str + "\n")
+                            else:
+                                info.append(s.name)
+                                info.append(((" = " + str(s.expression)) if s.expression is not None else ""))
+                                info.append(" (not validated in the constructor!)\n")
+                        json = self.generate_result(info)
+                        results.append(json)
+            elif contract.is_proxy:
+                info = [contract, " appears to be a proxy contract, but it doesn't seem to be upgradeable.\n"]
+                json = self.generate_result(info)
+                results.append(json)
+                if contract.delegate_variable is not None:
+                    if contract.constructor is not None \
+                            and contract.delegate_variable in contract.constructor.variables_written:
+                        if contract.delegate_variable.is_immutable:
+                            info = [contract, " delegate destination address initialized in Constructor and its type is immutable.\n"]
+                            json = self.generate_result(info)
+                            results.append(json)
+                        else:
+                            info = [contract, " delegate destination address initialized in Constructor and its type is regular variable.\n"]
+                            json = self.generate_result(info)
+                            results.append(json)
+                    elif isinstance(contract.delegate_variable.expression, Literal):
+                        info = [contract, " delegate destination address is hard-coded in the proxy.\n"]
+                        json = self.generate_result(info)
+                        results.append(json)
+        return results

--- a/slither/utils/erc.py
+++ b/slither/utils/erc.py
@@ -13,6 +13,14 @@ def erc_to_signatures(erc: List[ERC]):
     """
     return [f'{e.name}({",".join(e.parameters)})' for e in erc if e.required]
 
+def erc_to_all_signatures(erc: List[ERC]):
+    """
+    Return the list of signatures (mandatory and optional)
+    :param erc:
+    :return:
+    """
+    return [f'{e.name}({",".join(e.parameters)})' for e in erc]
+
 
 # Final
 # https://eips.ethereum.org/EIPS/eip-20
@@ -46,6 +54,15 @@ ERC20_OPTIONAL = [
 ERC20 = ERC20 + ERC20_OPTIONAL
 
 ERC20_signatures = erc_to_signatures(ERC20)
+ERC20_all_signatures = erc_to_all_signatures(ERC20)
+
+# Final
+# https://eips.ethereum.org/EIPS/eip-165
+
+ERC165_EVENTS: List = []
+
+ERC165 = [ERC("supportsInterface", ["bytes4"], "bool", True, True, [])]
+ERC165_signatures = erc_to_signatures(ERC165)
 
 # Draft
 # https://github.com/ethereum/eips/issues/223
@@ -154,6 +171,7 @@ ERC721_OPTIONAL = [
 ERC721 = ERC721 + ERC721_OPTIONAL
 
 ERC721_signatures = erc_to_signatures(ERC721)
+ERC721_all_signatures = erc_to_all_signatures(ERC721)
 
 # Final
 # https://eips.ethereum.org/EIPS/eip-1820
@@ -237,6 +255,16 @@ ERC777 = [
 ]
 ERC777_signatures = erc_to_signatures(ERC777)
 
+# Stagnant
+# https://eips.ethereum.org/EIPS/eip-897
+
+ERC897 = [
+    ERC("proxyType", [], "uint256", True, True, []),
+    ERC("implementation", [], "address", True, True, [])
+]
+
+ERC897_signatures = erc_to_signatures(ERC897)
+
 # Final
 # https://eips.ethereum.org/EIPS/eip-1155
 # Must have ERC165
@@ -319,6 +347,60 @@ ERC1155_METADATA = [ERC("uri", ["uint256"], "string", True, False, [])]
 ERC1155 = ERC1155 + ERC1155_TOKEN_RECEIVER + ERC1155_METADATA
 
 ERC1155_signatures = erc_to_signatures(ERC1155)
+ERC1155_all_signatures = erc_to_all_signatures(ERC1155)
+
+# Final
+# https://eips.ethereum.org/EIPS/eip-1820
+ERC1820_EVENTS: List = []
+ERC1820 = [
+    ERC(
+        "canImplementInterfaceForAddress",
+        ["bytes32", "address"],
+        "bytes32",
+        True,
+        True,
+        [],
+    )
+]
+ERC1820_signatures = erc_to_signatures(ERC1820)
+
+# Final
+# https://eips.ethereum.org/EIPS/eip-1967
+ERC1967_upgraded_event = ERC_EVENT("Upgraded", ["address"], [True])
+ERC1967_beaconupgraded_event = ERC_EVENT("BeaconUpgraded", ["address"], [True])
+ERC1967_adminchanged_event = ERC_EVENT("AdminChanged", ["address", "address"], [False, False])
+ERC1967_EVENTS = [
+    ERC1967_upgraded_event,
+    ERC1967_beaconupgraded_event,
+    ERC1967_adminchanged_event
+]
+
+ERC1967_PROXY = [
+    ERC("constructor", ["address", "bytes"], "", False, True, []),
+    ERC("_delegate", ["address"], "", False, True, []),
+    ERC("_implementation", [], "address", True, True, []),
+    ERC("_fallback", [], "", False, True, []),
+    ERC("_beforeFallback", [], "", False, True, [])
+]
+
+ERC1967_UPGRADE = [
+    ERC("_getImplementation", [], "address", True, True, []),
+    ERC("_setImplementation", ["address"], "address", False, True, []),
+    ERC("_upgradeTo", ["address"], "", False, True, [ERC1967_upgraded_event]),
+    ERC("_upgradeToAndCall", ["address", "bytes", "bool"], "", False, True, []),
+    ERC("_upgradeToAndCallSecure", ["address", "bytes", "bool"], "", False, False, []),
+    ERC("_getAdmin", [], "address", True, False, []),
+    ERC("_setAdmin", ["address"], "", False, False, []),
+    ERC("_changeAdmin", ["address"], "", False, False, [ERC1967_adminchanged_event]),
+    ERC("_getBeacon", [], "address", True, False, []),
+    ERC("_setBeacon", ["address"], "", False, False, []),
+    ERC("_upgradeBeaconToAndCall", ["address", "bytes", "bool"], "", False, False, [ERC1967_beaconupgraded_event])
+]
+
+ERC1967 = ERC1967_PROXY + ERC1967_UPGRADE
+
+ERC1967_signatures = erc_to_signatures(ERC1967)
+ERC1967_all_signatures = erc_to_all_signatures(ERC1967)
 
 # Review
 # https://eips.ethereum.org/EIPS/eip-2612
@@ -451,6 +533,7 @@ ERCS = {
     "ERC1820": (ERC1820, ERC1820_EVENTS),
     "ERC777": (ERC777, ERC777_EVENTS),
     "ERC1155": (ERC1155, ERC1155_EVENTS),
+    "ERC1967": (ERC1967, ERC1967_EVENTS),
     "ERC2612": (ERC2612, ERC2612_EVENTS),
     "ERC1363": (ERC1363, ERC1363_EVENTS),
     "ERC4524": (ERC4524, ERC4524_EVENTS),

--- a/slither/utils/proxy_output.py
+++ b/slither/utils/proxy_output.py
@@ -1,0 +1,80 @@
+import hashlib
+import os
+import json
+import logging
+import zipfile
+from collections import OrderedDict
+from typing import Optional, Dict, List, Union, Any, TYPE_CHECKING
+from zipfile import ZipFile
+
+from slither.core.cfg.node import Node
+from slither.core.declarations import Contract, Function, Enum, Event, Structure, Pragma
+from slither.core.source_mapping.source_mapping import SourceMapping
+from slither.core.variables.variable import Variable
+from slither.exceptions import SlitherError
+from slither.utils.colors import yellow
+from slither.utils.myprettytable import MyPrettyTable
+
+if TYPE_CHECKING:
+    from slither.core.compilation_unit import SlitherCompilationUnit
+    from slither.detectors.abstract_detector import AbstractDetector
+
+from slither.utils.output import (
+    Output,
+    SupportedOutput,
+    _convert_to_id,
+    _convert_to_markdown,
+    _convert_to_description
+)
+
+logger = logging.getLogger("Slither")
+
+
+class ProxyOutput(Output):
+    """
+    Custom Output subclass used by the proxy-patterns detector.
+    Contains the minimum subset of keys that are present in the Output class
+    which are required in order to make use of Slither's --json CLI option.
+    i.e., the 'elements', 'description' and 'id' fields are necessary in
+    order to pass the `valid_result` checks in slither/core/slither_core.py,
+    though we don't need to populate the 'elements' field with source mapping
+    information, which makes the json results output difficult to read.
+    """
+    def __init__(self,
+                 contract: Optional[Contract],
+                 info_: Union[str, List[Union[str, SupportedOutput]]],
+                 additional_fields: Optional[Dict] = None,
+                 markdown_root="",
+                 standard_format=False
+    ):
+        super().__init__("", None, markdown_root, standard_format)
+        if additional_fields is None:
+            additional_fields = {}
+
+        # Allow info to be a string to simplify the API
+        info: List[Union[str, SupportedOutput]]
+        if isinstance(info_, str):
+            info = [info_]
+        else:
+            info = info_
+
+        self._data: Dict[str, Any] = OrderedDict()
+        if contract is not None:
+            self._data["contract"] = _convert_to_description(contract)
+        self._data["elements"] = []
+        self._data["description"] = "".join(_convert_to_description(d) for d in info)
+        # self._data["markdown"] = "".join(_convert_to_markdown(d, markdown_root) for d in info)
+        # self._data["first_markdown_element"] = ""
+        # self._markdown_root = markdown_root
+
+        id_txt = "".join(_convert_to_id(d) for d in info)
+        self._data["id"] = hashlib.sha3_256(id_txt.encode("utf-8")).hexdigest()
+
+        # if standard_format:
+        #     to_add = [i for i in info if not isinstance(i, str)]
+        #
+        #     for add in to_add:
+        #         self.add(add)
+
+        if additional_fields:
+            self._data["features"] = additional_fields


### PR DESCRIPTION
This PR updates **[uschunt](https://github.com/USCHunt-Anon/USCHunt)** to run with Slither version 0.11.3.

### Changes
- Migrated uschunt code to be compatible with Slither 0.11.3.
- Updated imports and replaced deprecated function calls.

### Motivation
The original uschunt relied on Slither (0.9.3) and no longer worked on current releases.
This adaptation revives the tool and ensures compatibility with Slither 0.11.3, the latest stable version at this time.
