### PR TITLE
fix: use block comments in CR mutator to prevent compilation errors

### DIFF
--- a/slither/tools/mutator/mutators/CR.py
+++ b/slither/tools/mutator/mutators/CR.py
@@ -27,7 +27,7 @@ class CR(AbstractMutator):  # pylint: disable=too-few-public-methods
                     stop = start + node.source_mapping.length
                     old_str = node.source_mapping.content
                     line_no = node.source_mapping.lines
-                    new_str = "//" + old_str
+                    new_str = "/* " + old_str + " */"
                     create_patch_with_line(
                         result,
                         self.in_file,

--- a/tests/tools/mutator/test_mutator.py
+++ b/tests/tools/mutator/test_mutator.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 from slither import Slither
 from slither.tools.mutator.__main__ import _get_mutators, main
+from slither.tools.mutator.mutators.CR import CR
 from slither.tools.mutator.utils.testing_generated_mutant import run_test_cmd
 from slither.tools.mutator.utils.file_handling import get_sol_file_list, backup_source_file
 
@@ -131,3 +132,38 @@ def test_run_tests_timeout(caplog, monkeypatch):
         result = run_test_cmd("forge test", timeout=1)
         assert not result
         assert "Tests took too long" in caplog.messages[0]
+
+
+def test_cr_mutator_uses_block_comments(solc_binary_path):
+    """CR mutator should use block comments /* */ not line comments //"""
+    solc_path = solc_binary_path("0.8.15")
+    file_path = (TEST_DATA_DIR / "test_source_unit" / "src" / "Counter.sol").as_posix()
+    sl = Slither(file_path, solc=solc_path)
+
+    for contract in sl.contracts:
+        if contract.name == "Counter":
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                mutator = CR(
+                    compilation_unit=contract.compilation_unit,
+                    timeout=10,
+                    testing_command="forge test",
+                    testing_directory=".",
+                    contract_instance=contract,
+                    solc_remappings=None,
+                    verbose=False,
+                    output_folder=Path(tmp_dir),
+                    dont_mutate_line=[],
+                    rate=100,
+                )
+                result = mutator._mutate()
+
+                # Verify mutations were generated
+                assert "patches" in result, "CR mutator should generate patches"
+
+                # Verify all patches use block comments
+                for patches in result["patches"].values():
+                    for patch in patches:
+                        new_str = patch["new_string"]
+                        assert new_str.startswith("/*"), f"Expected block comment, got: {new_str}"
+                        assert new_str.endswith("*/"), f"Expected block comment, got: {new_str}"
+                        assert "//" not in new_str, f"Should not use line comment: {new_str}"


### PR DESCRIPTION
### Summary

CR mutator now uses block comments (`/* */`) instead of line comments (`//`).

### Problem

Line comment `//` comments out everything after it on the line. This breaks compilation when code continues:
```solidity
// Original
function test() public onlyOwner {

// With // - BROKEN
function test() public // onlyOwner {

// With /* */ - WORKS  
function test() public /* onlyOwner */ {
```

### Solution
```python
new_str = "/* " + old_str + " */"
```

### Scenarios Improved

**Function modifier same line as brace:**
```solidity
// Original
function foo() onlyOwner {

// Before (broken)
function foo() // onlyOwner {

// After (works)
function foo() /* onlyOwner */ {
```

**Single-line functions:**
```solidity
// Original
function getX() view returns (uint) { return x; }

// Before (broken) - commenting return statement
function getX() view returns (uint) { // return x; }

// After (works)
function getX() view returns (uint) { /* return x; */ }
```

**Compact statements:**
```solidity
// Original
if (x > 0) y = 1;

// Before (broken) - commenting assignment
if (x > 0) // y = 1;

// After (works)
if (x > 0) /* y = 1; */;
```

**For loop components:**
```solidity
// Original
for (uint i = 0; i < 10; i++) {

// Before (broken) - commenting condition
for (uint i = 0; // i < 10; i++) {

// After (works)
for (uint i = 0; /* i < 10 */; i++) {
```