### PR TITLE
fix: handle Unicode characters correctly in mutator byte offset calculation

### DIFF
--- a/slither/formatters/utils/patches.py
+++ b/slither/formatters/utils/patches.py
@@ -31,7 +31,8 @@ def apply_patch(original_txt: bytes, patch: Dict, offset: int) -> Tuple[bytes, i
     patched_txt += original_txt[int(patch["end"] + offset) :]
 
     # Keep the diff of text added or sub, in case of multiple patches
-    patch_length_diff = len(patch["new_string"]) - (patch["end"] - patch["start"])
+    # Note: must use byte length since patch offsets are byte offsets from solc
+    patch_length_diff = len(patch["new_string"].encode("utf8")) - (patch["end"] - patch["start"])
     return patched_txt, patch_length_diff + offset
 
 

--- a/slither/tools/mutator/utils/testing_generated_mutant.py
+++ b/slither/tools/mutator/utils/testing_generated_mutant.py
@@ -92,12 +92,15 @@ def test_patch(
     function to verify whether each patch is caught by tests
     returns: 0 (uncaught), 1 (caught), or 2 (compilation failure)
     """
-    with open(file, "r", encoding="utf8") as filepath:
+    with open(file, "rb") as filepath:
         content = filepath.read()
     # Perform the replacement based on the index values
-    replaced_content = content[: patch["start"]] + patch["new_string"] + content[patch["end"] :]
+    # Note: patch offsets are byte offsets from solc, so we must work with bytes
+    replaced_content = (
+        content[: patch["start"]] + patch["new_string"].encode("utf8") + content[patch["end"] :]
+    )
     # Write the modified content back to the file
-    with open(file, "w", encoding="utf8") as filepath:
+    with open(file, "wb") as filepath:
         filepath.write(replaced_content)
 
     if compile_generated_mutant(file, mappings):


### PR DESCRIPTION
Fix source code corruption when `slither-mutate` processes Solidity files containing Unicode characters (e.g., arrow symbols, non-ASCII comments).

### Example

```solidity
// → Unicode arrow
contract Counter {
    function increment() public {
        number++;
    }
}
```

The `→` arrow is 3 bytes but 1 character. This 2-byte difference causes mutations to be applied at wrong positions.

**Without fix** - garbage output:
```
nurevert()
fufunction setNumber
nu++number
```

**With fix** - correct mutations:
```
revert()
function setNumber
++number
```