### PR TITLE
docs: add CLAUDE.md coding standards for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Python guidelines
 - Always use `uv` instead of pip
 - Build with `hatchling` (`[build-system]` in pyproject.toml)
-- Use `astral-sh/ruff-action@v1` in CI
+- Use `astral-sh/ruff-action@v3` or newer in CI
 - Let tools auto-detect versions from pyproject.toml
 - Verify builds: `uv build`, `uv tool install dist/*.whl`, `uv tool install -e .`
 


### PR DESCRIPTION
## Summary
- Add project-specific `CLAUDE.md` for AI assistants working on the Slither codebase
- Documents runtime/tooling requirements, coding rules, and common commands

## Test plan
- [x] File is valid markdown
- [x] Content reflects actual project conventions (tests in `/tests/`, ruff linting, uv for deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)