### PR TITLE
Fix parsing of modifiers

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -9,6 +9,7 @@ from slither.core.declarations.function import (
     ModifierStatements,
     FunctionType,
 )
+from slither.core.declarations.modifier import Modifier
 from slither.core.declarations.function_contract import FunctionContract
 from slither.core.expressions import AssignmentOperation
 from slither.core.source_mapping.source_mapping import Source
@@ -1363,7 +1364,7 @@ class FunctionSolc(CallerContextExpression):
             return
 
         for m in ExportValues(m).result():
-            if isinstance(m, Function):
+            if isinstance(m, Modifier):
                 node_parser = self._new_node(
                     NodeType.EXPRESSION, modifier["src"], self.underlying_function
                 )

--- a/tests/unit/core/test_data/function_declaration/test_function.sol
+++ b/tests/unit/core/test_data/function_declaration/test_function.sol
@@ -54,6 +54,10 @@ contract TestFunction {
     function public_pure() public pure returns (bool) {
         return true;
     }
+
+    modifier m(uint y) { _; }
+    function helper_to_test_q() internal pure returns(uint) { return 3; }
+    function q() public pure m(helper_to_test_q()) {}
 }
 
 contract TestFunctionCanSendEth {

--- a/tests/unit/core/test_function_declaration.py
+++ b/tests/unit/core/test_function_declaration.py
@@ -247,6 +247,29 @@ def test_functions(solc_binary_path):
     assert f.parameters == []
     assert f.return_type[0] == ElementaryType("bool")
 
+    f = functions["q()"]
+    assert f.name == "q"
+    assert f.full_name == "q()"
+    assert f.canonical_name == "TestFunction.q()"
+    assert f.solidity_signature == "q()"
+    assert f.signature_str == "q() returns()"
+    assert f.function_type == FunctionType.NORMAL
+    assert f.contains_assembly is False
+    assert f.can_reenter() is False
+    assert f.can_send_eth() is False
+    assert f.is_constructor is False
+    assert f.is_fallback is False
+    assert f.is_receive is False
+    assert f.payable is False
+    assert f.visibility == "public"
+    assert f.view is True
+    assert f.pure is True
+    assert f.is_implemented is True
+    assert f.is_empty is True
+    assert f.parameters == []
+    assert f.return_type is None
+    assert len(f.modifiers) == 1 and f.modifiers[0].name == "m"
+
 
 def test_function_can_send_eth(solc_binary_path):
     solc_path = solc_binary_path("0.6.12")


### PR DESCRIPTION
Fix #2807 
Previously for the following code `q` would have had 2 modifiers, `helper_to_test_q` function was counted as modifier.
```solidity
    modifier m(uint y) { _; }
    function helper_to_test_q() internal pure returns(uint) { return 3; }
    function q() public pure m(helper_to_test_q()) {}
```