### PR TITLE
Optimize Dockerfile: migrate to uv, reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,56 @@
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Virtual environments
+.venv/
+venv/
+.tox/
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+wheels/
+
+# Tests (not needed in production image)
+tests/
+
+# Development tooling
+.github/
+.pre-commit-config.yaml
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+.yamllint
+
+# Documentation (README needed for pyproject.toml)
+docs/
+
+# IDE/Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Docker files
 Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# CI/CD
+.coderabbit.yaml
+CITATION.cff
+CLAUDE.md
+CONTRIBUTING.md
+Makefile


### PR DESCRIPTION
## Summary

- Replace pip with uv for faster dependency installation (~10x faster)
- Use `uv.lock` for reproducible builds with `uv sync --frozen`
- Expand `.dockerignore` to reduce build context from 937MB to ~9MB (99% reduction)
- Remove multi-stage build (no longer needed with uv)
- Optimize layer caching by copying lockfile before source code
- Consolidate LABEL instructions into single layer
- Use JSON notation for CMD (proper signal handling)
- Update syntax directive to 1.12

## Test plan

- [x] `docker build -t slither-test .` succeeds
- [x] `docker run --rm slither-test slither --version` returns `0.11.4`
- [x] `docker run --rm slither-test solc --version` returns installed solc version
- [ ] CI docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)