### PR TITLE
Fix Docker build for armv7: use curl to install uv with pip fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,15 @@ LABEL name=slither \
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y --no-install-recommends git python3 python3-venv \
+  && apt-get install -y --no-install-recommends ca-certificates curl git python3 python3-pip python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
-# Install uv from official image
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# Install uv if available for this architecture (amd64/arm64)
+# uv doesn't support armv7, so those builds will use pip instead
+RUN arch=$(uname -m) && \
+    if [ "$arch" = "x86_64" ] || [ "$arch" = "aarch64" ]; then \
+      curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh; \
+    fi
 
 # improve compatibility with amd64 solc in non-amd64 environments (e.g. Docker Desktop on M1 Mac)
 ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
@@ -31,15 +35,24 @@ WORKDIR /home/slither/slither
 # Copy dependency files first for layer caching
 COPY --chown=slither:slither pyproject.toml uv.lock ./
 
-# Install dependencies (creates venv in .venv)
-RUN uv sync --frozen --no-install-project
+# Install dependencies - use uv if available (with lockfile), pip otherwise
+RUN if command -v uv >/dev/null 2>&1; then \
+      uv sync --frozen --no-install-project; \
+    else \
+      python3 -m venv .venv; \
+    fi
 
 # Copy source code
 COPY --chown=slither:slither . .
 
 # Install the project itself and solc-select
-RUN uv sync --frozen && \
-    uv tool install solc-select
+RUN if command -v uv >/dev/null 2>&1; then \
+      uv sync --frozen && \
+      uv tool install solc-select; \
+    else \
+      . .venv/bin/activate && \
+      pip install --no-cache-dir -e . solc-select; \
+    fi
 
 ENV PATH="/home/slither/slither/.venv/bin:/home/slither/.local/bin:${PATH}"
 


### PR DESCRIPTION
## Summary

Fixes the CI Docker build failure on `linux/arm/v7` caused by #2883.

**Root cause:** `COPY --from=ghcr.io/astral-sh/uv:latest` fails because uv doesn't publish armv7 images.

**Fix:**
- Use `curl` to install uv instead of `COPY --from` (handles architecture automatically)
- Add pip fallback for armv7 where uv isn't available
- Add `ca-certificates`, `curl`, and `python3-pip` to apt dependencies

**Platform support:**
| Platform | Package Manager |
|----------|-----------------|
| linux/amd64 | uv (with lockfile) |
| linux/arm64 | uv (with lockfile) |
| linux/arm/v7 | pip (from pyproject.toml) |

## Test plan

- [x] Local build succeeds on arm64
- [x] `slither --version` works in container
- [ ] CI multi-platform build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)