### PR TITLE
Fix Docker armv7 build: add build tools for pip wheel compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,16 @@ RUN if [ ! "$(uname -m)" = "x86_64" ]; then \
   && apt-get install -y --no-install-recommends libc6-amd64-cross \
   && rm -rf /var/lib/apt/lists/*; fi
 
+# Install build tools only on armv7 (needed for pip to compile wheels)
+# amd64/arm64 use uv with pre-built wheels, so they don't need these
+RUN arch=$(uname -m) && \
+    if [ "$arch" = "armv7l" ]; then \
+      export DEBIAN_FRONTEND=noninteractive && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends build-essential python3-dev && \
+      rm -rf /var/lib/apt/lists/*; \
+    fi
+
 RUN useradd -m slither
 USER slither
 


### PR DESCRIPTION
## Summary

Fixes the armv7 Docker build failure where pip can't compile C extensions.

**Root cause:** Packages like `pycryptodome`, `bitarray`, `regex` have C extensions and no pre-built armv7 wheels on PyPI. pip needs to compile them from source but `gcc`/`python3-dev` weren't installed.

**Fix:** Add `build-essential` and `python3-dev` conditionally only on armv7:
- amd64/arm64: Use uv with pre-built wheels (no build tools needed)
- armv7: Use pip with build tools for compilation

## Test plan

- [x] Local build succeeds on arm64
- [x] `slither --version` works in container
- [ ] CI multi-platform build passes (amd64, arm64, armv7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)