### PR TITLE
fix: update snapshots for typo fix in uninitialized detector

### DIFF
--- a/tests/e2e/detectors/snapshots/detectors__detector_UninitializedFunctionPtrsConstructor_0_4_25_uninitialized_function_ptr_constructor_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_UninitializedFunctionPtrsConstructor_0_4_25_uninitialized_function_ptr_constructor_sol__0.txt
@@ -1,12 +1,12 @@
-Contract bad2 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#20-29) 
-	 s.a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#27) is an unintialized function pointer call in a constructor
-
-Contract bad0 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#3-9) 
-	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#7) is an unintialized function pointer call in a constructor
-
 Contract bad3 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#31-42) 
-	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#36) is an unintialized function pointer call in a constructor
+	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#36) is an uninitialized function pointer call in a constructor
+
+Contract bad2 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#20-29) 
+	 s.a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#27) is an uninitialized function pointer call in a constructor
 
 Contract bad1 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#11-18) 
-	 b(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#16) is an unintialized function pointer call in a constructor
+	 b(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#16) is an uninitialized function pointer call in a constructor
+
+Contract bad0 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#3-9) 
+	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.4.25/uninitialized_function_ptr_constructor.sol#7) is an uninitialized function pointer call in a constructor
 

--- a/tests/e2e/detectors/snapshots/detectors__detector_UninitializedFunctionPtrsConstructor_0_5_8_uninitialized_function_ptr_constructor_sol__0.txt
+++ b/tests/e2e/detectors/snapshots/detectors__detector_UninitializedFunctionPtrsConstructor_0_5_8_uninitialized_function_ptr_constructor_sol__0.txt
@@ -1,12 +1,12 @@
+Contract bad2 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#20-29) 
+	 s.a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#27) is an uninitialized function pointer call in a constructor
+
 Contract bad3 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#31-42) 
-	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#36) is an unintialized function pointer call in a constructor
+	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#36) is an uninitialized function pointer call in a constructor
 
 Contract bad1 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#11-18) 
-	 b(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#16) is an unintialized function pointer call in a constructor
+	 b(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#16) is an uninitialized function pointer call in a constructor
 
 Contract bad0 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#3-9) 
-	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#7) is an unintialized function pointer call in a constructor
-
-Contract bad2 (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#20-29) 
-	 s.a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#27) is an unintialized function pointer call in a constructor
+	 a(10) (tests/e2e/detectors/test_data/uninitialized-fptr-cst/0.5.8/uninitialized_function_ptr_constructor.sol#7) is an uninitialized function pointer call in a constructor
 


### PR DESCRIPTION
## Summary
- Updates test snapshots to match the corrected spelling from PR #2723
- The typo 'unintialized' was fixed to 'uninitialized' in the detector code, but snapshots weren't updated

## Test plan
- [ ] Integration tests pass for `UninitializedFunctionPtrsConstructor` detector

🤖 Generated with [Claude Code](https://claude.ai/claude-code)