### PR TITLE
fix: remove Etherscan API dependency from CI tests

### DIFF
--- a/scripts/ci_test_etherscan.sh
+++ b/scripts/ci_test_etherscan.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-### Test etherscan integration
+### Test slither analysis on a contract
 
-# Skip when API key is not present
-if [ "$GITHUB_ETHERSCAN" = "" ]; then
-    echo "Skipped, no Etherscan API key provided"
-    exit
-fi
+DIR_TESTS="tests/tools/etherscan"
 
-mkdir etherscan
-cd etherscan || exit 255
+solc-select use 0.4.25 --always-install
 
-echo "::group::Etherscan mainnet"
-if ! slither 0x7F37f78cBD74481E593F9C737776F7113d76B315 --etherscan-apikey "$GITHUB_ETHERSCAN" --no-fail-pedantic; then
-    echo "Etherscan mainnet test failed"
+echo "::group::BalanceChecker analysis"
+if ! slither "$DIR_TESTS/BalanceChecker.sol" --no-fail-pedantic; then
+    echo "BalanceChecker test failed"
     exit 1
 fi
 echo "::endgroup::"

--- a/scripts/ci_test_interface.sh
+++ b/scripts/ci_test_interface.sh
@@ -5,25 +5,21 @@ set -euo pipefail
 
 DIR_TESTS="tests/tools/interface"
 
-solc-select use 0.8.19 --always-install
-
-if [ "$GITHUB_ETHERSCAN" = "" ]; then
-    echo "skipping test 1, no api key for etherscan"
-else
-    #Test 1 - Etherscan target
-    slither-interface WETH9 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --etherscan-apikey "$GITHUB_ETHERSCAN"
-    DIFF=$(diff crytic-export/interfaces/IWETH9.sol "$DIR_TESTS/test_1.sol" --strip-trailing-cr)
-    if [  "$DIFF" != "" ]
-    then
-        echo "slither-interface test 1 failed"
-        cat "crytic-export/interfaces/IWETH9.sol"
-        echo ""
-        cat "$DIR_TESTS/test_1.sol"
-        exit 255
-    fi
+#Test 1 - WETH9 contract (uses solc 0.4.x)
+solc-select use 0.4.18 --always-install
+slither-interface WETH9 "$DIR_TESTS/WETH9.sol"
+DIFF=$(diff crytic-export/interfaces/IWETH9.sol "$DIR_TESTS/test_1.sol" --strip-trailing-cr)
+if [  "$DIFF" != "" ]
+then
+    echo "slither-interface test 1 failed"
+    cat "crytic-export/interfaces/IWETH9.sol"
+    echo ""
+    cat "$DIR_TESTS/test_1.sol"
+    exit 255
 fi
 
-#Test 2 - Local file target
+#Test 2 - Local file target (uses solc 0.8.x)
+solc-select use 0.8.19 --always-install
 slither-interface Mock tests/tools/interface/ContractMock.sol
 DIFF=$(diff crytic-export/interfaces/IMock.sol "$DIR_TESTS/test_2.sol" --strip-trailing-cr)
 if [  "$DIFF" != "" ]

--- a/tests/tools/etherscan/BalanceChecker.sol
+++ b/tests/tools/etherscan/BalanceChecker.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: UNLICENSED
+// Source: https://etherscan.io/address/0x7F37f78cBD74481E593F9C737776F7113d76B315
+pragma solidity ^0.4.24;
+
+contract Token {
+    function balanceOf(address) public view returns (uint);
+}
+
+contract BalanceChecker {
+
+    function tokenBalance(address user, address token) public view returns (uint) {
+        // check if token is actually a contract
+        uint256 tokenCode;
+        assembly { tokenCode := extcodesize(token) } // contract code size
+
+        // is it a contract and does it implement balanceOf
+        if (tokenCode > 0 && token.call(bytes4(0x70a08231), user)) {
+            return Token(token).balanceOf(user);
+        } else {
+            return 0;
+        }
+    }
+
+    function balances(address user, address[] tokens) external view returns (uint[]) {
+        uint[] memory addrBalances = new uint[](tokens.length);
+
+        for(uint i = 0; i < tokens.length; i++) {
+            addrBalances[i] = tokenBalance(user, tokens[i]);
+        }
+        return addrBalances;
+    }
+}

--- a/tests/tools/interface/WETH9.sol
+++ b/tests/tools/interface/WETH9.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0
+// Source: https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+pragma solidity ^0.4.18;
+
+contract WETH9 {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+
+    event  Approval(address indexed src, address indexed guy, uint wad);
+    event  Transfer(address indexed src, address indexed dst, uint wad);
+    event  Deposit(address indexed dst, uint wad);
+    event  Withdrawal(address indexed src, uint wad);
+
+    mapping (address => uint)                       public  balanceOf;
+    mapping (address => mapping (address => uint))  public  allowance;
+
+    function() public payable {
+        deposit();
+    }
+
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        msg.sender.transfer(wad);
+        Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return this.balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        Transfer(src, dst, wad);
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace live Etherscan API calls with cached local contract sources
- Fix intermittent CI failures from API rate limits when jobs run in parallel
- Etherscan platform integration is already tested by crytic-compile's CI

## Changes
- Add `tests/tools/etherscan/BalanceChecker.sol` (cached from mainnet)
- Add `tests/tools/interface/WETH9.sol` (cached from mainnet)
- Update `scripts/ci_test_etherscan.sh` to use local fixture
- Update `scripts/ci_test_interface.sh` to use local fixture for Test 1

## Test plan
- [x] `bash scripts/ci_test_etherscan.sh` passes locally
- [x] `bash scripts/ci_test_interface.sh` passes locally
- [ ] CI passes without `GITHUB_ETHERSCAN` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)