### PR TITLE
chore: modernize Makefile to use uv-native workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ For development setup, we use [uv](https://github.com/astral-sh/uv):
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Setup development environment
-make dev  # Creates venv and installs all dependencies
+make dev  # Installs dependencies and pre-commit hooks
 ```
 
 Run `make test` for all tests, or `make test TESTS=$name` for specific tests. List test names with `pytest tests --collect-only`.

--- a/Makefile
+++ b/Makefile
@@ -4,87 +4,74 @@ PY_MODULE := slither
 TEST_MODULE := tests
 SCRIPT_MODULE := scripts
 
-ALL_PY_SRCS := $(shell find $(PY_MODULE) -name '*.py') \
-	$(shell find tests -name '*.py')
-
-# Optionally overridden by the user, if they're using a virtual environment manager.
-VENV ?= env
-
-# On Windows, venv scripts/shims are under `Scripts` instead of `bin`.
-VENV_BIN := $(VENV)/bin
-ifeq ($(OS),Windows_NT)
-	VENV_BIN := $(VENV)/Scripts
-endif
-
-# Optionally overridden by the user in the `release` target.
-BUMP_ARGS :=
-
 # Optionally overridden by the user in the `test` target.
 TESTS :=
 
-# Optionally overridden by the user/CI, to limit the installation to a specific
-# subset of development dependencies.
-SLITHER_EXTRA := dev
-
 # If the user selects a specific test pattern to run, set `pytest` to fail fast
 # and only run tests that match the pattern.
-# Otherwise, run all tests and enable coverage assertions, since we expect
-# complete test coverage.
 ifneq ($(TESTS),)
 	TEST_ARGS := -x -k $(TESTS)
-	COV_ARGS :=
 else
 	TEST_ARGS := -n auto
-	COV_ARGS := # --fail-under 100
 endif
 
-.PHONY: all
-all:
-	@echo "Run my targets individually!"
+.PHONY: help
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Setup:"
+	@echo "  dev        Install dependencies and pre-commit hooks"
+	@echo ""
+	@echo "Development:"
+	@echo "  lint       Run all linters (ruff, yamllint, actionlint, zizmor)"
+	@echo "  reformat   Auto-fix lint issues and format code"
+	@echo "  test       Run test suite (use TESTS=pattern to filter)"
+	@echo "  check      Run lint + test"
+	@echo "  run        Run slither (use ARGS='...' to pass arguments)"
+	@echo ""
+	@echo "Build:"
+	@echo "  doc        Generate documentation"
+	@echo "  package    Build distribution package"
+	@echo "  clean      Remove build artifacts and caches"
 
 .PHONY: dev
-dev: $(VENV)/pyvenv.cfg
+dev:
+	uv sync --group dev
 	prek install
 
 .PHONY: run
-run: $(VENV)/pyvenv.cfg
-	@. $(VENV_BIN)/activate && slither $(ARGS)
-
-$(VENV)/pyvenv.cfg: pyproject.toml
-	# Create virtual environment and install dependencies using uv
-	uv venv $(VENV)
-	uv sync --python $(VENV_BIN)/python --group $(SLITHER_EXTRA)
+run:
+	uv run slither $(ARGS)
 
 .PHONY: lint
-lint: $(VENV)/pyvenv.cfg
-	. $(VENV_BIN)/activate && \
-		ruff check $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE) && \
-		yamllint -c .yamllint .github/ && \
-		actionlint .github/workflows/ && \
-		zizmor .github/workflows/
+lint:
+	uv run ruff check $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE)
+	uv run yamllint -c .yamllint .github/
+	actionlint
+	zizmor .github/workflows/
 
 .PHONY: reformat
 reformat:
-	. $(VENV_BIN)/activate && \
-		ruff check --fix $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE) && \
-		ruff format $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE)
+	uv run ruff check --fix $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE)
+	uv run ruff format $(PY_MODULE) $(TEST_MODULE) $(SCRIPT_MODULE)
 
 .PHONY: test tests
-test tests: $(VENV)/pyvenv.cfg
-	. $(VENV_BIN)/activate && \
-		pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
-		python -m coverage report -m $(COV_ARGS)
+test tests:
+	uv run pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS)
+	uv run coverage report -m
+
+.PHONY: check
+check: lint test
 
 .PHONY: doc
-doc: $(VENV)/pyvenv.cfg
-	. $(VENV_BIN)/activate && \
-		PDOC_ALLOW_EXEC=1 pdoc -o html slither '!slither.tools'
+doc:
+	PDOC_ALLOW_EXEC=1 uv run pdoc -o html slither '!slither.tools'
 
 .PHONY: package
-package: $(VENV)/pyvenv.cfg
-	. $(VENV_BIN)/activate && \
-		uv build
+package:
+	uv build
 
-.PHONY: edit
-edit:
-	$(EDITOR) $(ALL_PY_SRCS)
+.PHONY: clean
+clean:
+	rm -rf .venv/ build/ dist/ *.egg-info/ .pytest_cache/ .coverage htmlcov/ html/
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/plugin_example/README.md
+++ b/plugin_example/README.md
@@ -12,10 +12,9 @@ See the [detector documentation](https://github.com/trailofbits/slither/wiki/Add
 
 ## Installation
 
-Once these files are updated with your plugin, install it in a virtual environment:
+Once these files are updated with your plugin, install it:
 
 ```bash
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-pip install -e .
+uv sync
+uv run slither --help  # Verify plugin is loaded
 ```


### PR DESCRIPTION
## Summary
- Replace manual venv activation with `uv run` pattern
- Remove legacy VENV variables and Windows/Unix path handling
- Simpler, modern workflow: `uv sync` creates `.venv` automatically

## Changes
- `make dev` → `uv sync --group dev && prek install`
- `make lint/test/etc` → `uv run <command>` (no activation needed)
- Updated docs (CONTRIBUTING.md, plugin_example/README.md)

## Test plan
- [x] `make dev` works
- [x] `make lint` works
- [x] `make reformat` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)