### PR TITLE
chore: enable 34 additional ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,50 +150,16 @@ ignore = [
     "I001",     # unsorted-imports (453 issues)
     "UP037",    # quoted-annotation (148 issues)
     "RUF005",   # collection-literal-concatenation (57 issues)
-    "W291",     # trailing-whitespace (51 issues)
-    "E713",     # not-in-test (40 issues)
-    "RUF010",   # explicit-f-string-type-conversion (24 issues)
-    "C414",     # unnecessary-double-cast-or-process (20 issues)
     "RUF015",   # unnecessary-iterable-allocation-for-first-element (15 issues)
-    "SIM910",   # dict-get-with-none-default (15 issues)
     "E741",     # ambiguous-variable-name (14 issues)
-    "UP034",    # extraneous-parentheses (13 issues)
     "UP045",    # non-pep604-annotation-optional (13 issues)
     "RUF012",   # mutable-class-default (12 issues)
     "E731",     # lambda-assignment (11 issues)
-    "RUF021",   # parenthesize-chained-operators (10 issues)
-    "UP015",    # redundant-open-modes (10 issues)
     "RUF013",   # implicit-optional (7 issues)
-    "W293",     # blank-line-with-whitespace (7 issues)
-    "C405",     # unnecessary-literal-set (6 issues)
-    "UP012",    # unnecessary-encode-utf8 (6 issues)
-    "E722",     # bare-except (5 issues)
-    "C417",     # unnecessary-map (4 issues)
-    "C420",     # unnecessary-dict-comprehension-for-iterable (4 issues)
-    "RUF019",   # unnecessary-key-check (4 issues)
-    "RUF023",   # unsorted-dunder-slots (4 issues)
-    "SIM118",   # in-dict-keys (4 issues)
-    "E714",     # not-is-test (3 issues)
     "F821",     # undefined-name (3 issues - might be false positives)
-    "RUF046",   # unnecessary-cast-to-int (3 issues)
-    "SIM401",   # if-else-block-instead-of-dict-get (3 issues)
-    "UP018",    # native-literals (2 issues)
     "B011",     # assert-false (1 issue)
     "B020",     # loop-variable-overrides-iterator (1 issue)
     "B026",     # star-arg-unpacking-after-keyword-arg (1 issue)
-    "B034",     # re-sub-positional-args (1 issue)
-    "C400",     # unnecessary-generator-list (1 issue)
-    "C409",     # unnecessary-literal-within-tuple-call (1 issue)
-    "C416",     # unnecessary-comprehension (1 issue)
-    "E101",     # mixed-spaces-and-tabs (1 issue)
-    "E721",     # type-comparison (1 issue)
-    "SIM113",   # enumerate-for-loop (1 issue)
-    "SIM201",   # negate-equal-op (1 issue)
-    "SIM300",   # yoda-conditions (1 issue)
-    "TC005",    # empty-type-checking-block (1 issue)
-    "UP011",    # lru-cache-without-parameters (1 issue)
-    "UP022",    # replace-stdout-stderr (1 issue)
-    "UP031",    # printf-string-formatting (1 issue)
 ]
 # Allow autofix for all enabled rules
 fixable = ["ALL"]
@@ -208,6 +174,8 @@ allowed-confusables = ["'", "'", "–", "—"]
     "S101",     # assert is OK in tests
     "SIM",      # Simplification rules can be relaxed in tests
 ]
+# RTLO detector has intentional mixed indentation in exploit scenario
+"slither/detectors/source/rtlo.py" = ["E101"]
 # Scripts can have different rules
 "scripts/**/*.py" = [
     "T201",     # print is OK in scripts

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -825,7 +825,7 @@ def main_impl(
 
     console_handler.setFormatter(FormatterCryticCompile())
 
-    crytic_compile_error = logging.getLogger(("CryticCompile"))
+    crytic_compile_error = logging.getLogger("CryticCompile")
     crytic_compile_error.addHandler(console_handler)
     crytic_compile_error.propagate = False
     crytic_compile_error.setLevel(logging.INFO)

--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -381,7 +381,7 @@ def propagate_function(
     # Propage data dependency
     data_depencencies = function.context[context_key]
     for key, values in data_depencencies.items():
-        if not key in contract.context[context_key]:
+        if key not in contract.context[context_key]:
             contract.context[context_key][key] = set(values)
         else:
             contract.context[context_key][key].union(values)
@@ -413,7 +413,7 @@ def propagate_contract(contract: Contract, context_key: str, context_key_non_ssa
 
 
 def add_dependency(lvalue: Variable, function: Function, ir: Operation, is_protected: bool) -> None:
-    if not lvalue in function.context[KEY_SSA]:
+    if lvalue not in function.context[KEY_SSA]:
         function.context[KEY_SSA][lvalue] = set()
         if not is_protected:
             function.context[KEY_SSA_UNPROTECTED][lvalue] = set()
@@ -495,7 +495,7 @@ def convert_to_non_ssa(
     ret: Dict[SUPPORTED_TYPES, Set[SUPPORTED_TYPES]] = {}
     for k, values in data_depencies.items():
         var = convert_variable_to_non_ssa(k)
-        if not var in ret:
+        if var not in ret:
             ret[var] = set()
         ret[var] = ret[var].union({convert_variable_to_non_ssa(v) for v in values})
 

--- a/slither/analyses/evm/convert.py
+++ b/slither/analyses/evm/convert.py
@@ -136,9 +136,7 @@ def _get_evm_instructions_node(node_info):
     )
 
     # Get evm instructions corresponding to node's source line number
-    node_source_line = (
-        contract_file[0 : node_info["node"].source_mapping.start].count("\n".encode("utf8")) + 1
-    )
+    node_source_line = contract_file[0 : node_info["node"].source_mapping.start].count(b"\n") + 1
     node_pcs = contract_pcs.get(node_source_line, [])
     node_ins = []
     for pc in node_pcs:
@@ -191,7 +189,7 @@ def generate_source_to_evm_ins_mapping(evm_instructions, srcmap_runtime, slither
             # See https://github.com/ethereum/solidity/issues/6119#issuecomment-467797635
             continue
 
-        line_number = file_source[0 : int(offset)].count("\n".encode("utf8")) + 1
+        line_number = file_source[0 : int(offset)].count(b"\n") + 1
 
         # Append evm instructions to the corresponding source line number
         # Note: Some evm instructions in mapping are not necessarily in program execution order

--- a/slither/analyses/write/are_variables_written.py
+++ b/slither/analyses/write/are_variables_written.py
@@ -93,7 +93,7 @@ def _visit(
     # - Before is none: its the first time we explored the node
     # - variables_written is not before: it means that this path has a configuration of set variables
     # that we haven't seen yet
-    before = state.nodes[node] if node in state.nodes else None
+    before = state.nodes.get(node)
     if before is None or variables_written not in before:
         state.nodes[node].append(variables_written)
         for son in node.sons:

--- a/slither/core/cfg/node.py
+++ b/slither/core/cfg/node.py
@@ -780,13 +780,13 @@ class Node(SourceMapping):
         :return: list(nodes)
         """
         # Explore direct dominance
-        to_explore = sorted(list(self.dominator_successors), key=lambda x: x.node_id)
+        to_explore = sorted(self.dominator_successors, key=lambda x: x.node_id)
 
         # Explore dominance frontier
         # The frontier is the limit where this node dominates
         # We need to explore it because the sub of the direct dominance
         # Might not be dominator of their own sub
-        to_explore += sorted(list(self.dominance_frontier), key=lambda x: x.node_id)
+        to_explore += sorted(self.dominance_frontier, key=lambda x: x.node_id)
         return to_explore
 
     # endregion

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -690,7 +690,7 @@ class Contract(SourceMapping):
         return [
             f
             for f in self.functions
-            if f.visibility in ["public", "external"] and not f.is_shadowed or f.is_fallback
+            if (f.visibility in ["public", "external"] and not f.is_shadowed) or f.is_fallback
         ]
 
     @property

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -619,7 +619,7 @@ class Function(SourceMapping, metaclass=ABCMeta):
 
             for node in self.nodes:
                 # if node.type == NodeType.OTHER_ENTRYPOINT:
-                if not node in self._nodes_ordered_dominators:
+                if node not in self._nodes_ordered_dominators:
                     self._compute_nodes_ordered_dominators(node)
 
         return self._nodes_ordered_dominators
@@ -1400,7 +1400,7 @@ class Function(SourceMapping, metaclass=ABCMeta):
         with open(filename, "w", encoding="utf8") as f:
             f.write("digraph{\n")
             for node in self.nodes:
-                f.write(f'{node.node_id}[label="{str(node)}"];\n')
+                f.write(f'{node.node_id}[label="{node!s}"];\n')
                 for son in node.sons:
                     f.write(f"{node.node_id}->{son.node_id};\n")
 
@@ -1581,7 +1581,7 @@ class Function(SourceMapping, metaclass=ABCMeta):
         if not all_entry_points:
             return True
         return not all(
-            (reentrancy_modifier in [m.name for m in f.modifiers] for f in all_entry_points)
+            reentrancy_modifier in [m.name for m in f.modifiers] for f in all_entry_points
         )
 
     # endregion

--- a/slither/core/expressions/call_expression.py
+++ b/slither/core/expressions/call_expression.py
@@ -91,7 +91,7 @@ class CallExpression(Expression):
                 options = [gas, value, salt]
                 txt += "{" + ",".join([o for o in options if o != ""]) + "}"
         args = (
-            "{" + ",".join([f"{n}:{str(a)}" for (a, n) in zip(self._arguments, self._names)]) + "}"
+            "{" + ",".join([f"{n}:{a!s}" for (a, n) in zip(self._arguments, self._names)]) + "}"
             if self._names is not None
             else ",".join([str(a) for a in self._arguments])
         )

--- a/slither/core/scope/scope.py
+++ b/slither/core/scope/scope.py
@@ -21,7 +21,7 @@ def _dict_contain(d1: Dict, d2: Dict) -> bool:
     Return true if d1 is included in d2
     """
     d2_keys = d2.keys()
-    return all(item in d2_keys for item in d1.keys())
+    return all(item in d2_keys for item in d1)
 
 
 class FileScope:

--- a/slither/core/slither_core.py
+++ b/slither/core/slither_core.py
@@ -477,9 +477,9 @@ class SlitherCore(Context):
         # Use POSIX-style paths so that filter_paths|include_paths works across different
         # OSes. Convert to a list so elements don't get consumed and are lost
         # while evaluating the first pattern
-        source_mapping_elements = list(
-            map(lambda x: pathlib.Path(x).resolve().as_posix() if x else x, source_mapping_elements)
-        )
+        source_mapping_elements = [
+            pathlib.Path(x).resolve().as_posix() if x else x for x in source_mapping_elements
+        ]
         (matching, paths, msg_err) = (
             (True, self._paths_to_include, "--include-paths")
             if self._paths_to_include

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -68,7 +68,7 @@ class ArrayType(Type):
 
     def __str__(self) -> str:
         if self._length:
-            return str(self._type) + f"[{str(self._length_value)}]"
+            return str(self._type) + f"[{self._length_value!s}]"
         return str(self._type) + "[]"
 
     def __eq__(self, other: Any) -> bool:

--- a/slither/core/solidity_types/elementary_type.py
+++ b/slither/core/solidity_types/elementary_type.py
@@ -83,7 +83,7 @@ Uint = [
 ]
 
 Max_Uint = {k: 2 ** (8 * i) - 1 if i > 0 else 2**256 - 1 for i, k in enumerate(Uint)}
-Min_Uint = {k: 0 for k in Uint}
+Min_Uint = dict.fromkeys(Uint, 0)
 
 
 Byte = [
@@ -127,7 +127,7 @@ Max_Byte = {k: 2 ** (8 * (i + 1)) - 1 for i, k in enumerate(Byte[2:])}
 Max_Byte["bytes"] = None
 Max_Byte["string"] = None
 Max_Byte["byte"] = 255
-Min_Byte = {k: 0 for k in Byte}
+Min_Byte = dict.fromkeys(Byte, 0)
 Min_Byte["bytes"] = 0x0
 Min_Byte["string"] = 0x0
 Min_Byte["byte"] = 0x0
@@ -189,9 +189,9 @@ class ElementaryType(Type):
         if t.startswith("int"):
             return int(t[len("int") :])
         if t == "bool":
-            return int(8)
+            return 8
         if t == "address":
-            return int(160)
+            return 160
         if t.startswith("bytes") and t != "bytes":
             return int(t[len("bytes") :]) * 8
         raise SlitherException(f"{t} does not have a size")

--- a/slither/core/solidity_types/mapping_type.py
+++ b/slither/core/solidity_types/mapping_type.py
@@ -36,7 +36,7 @@ class MappingType(Type):
         return True
 
     def __str__(self) -> str:
-        return f"mapping({str(self._from)} => {str(self._to)})"
+        return f"mapping({self._from!s} => {self._to!s})"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MappingType):

--- a/slither/core/solidity_types/user_defined_type.py
+++ b/slither/core/solidity_types/user_defined_type.py
@@ -37,7 +37,7 @@ class UserDefinedType(Type):
         if isinstance(self._type, Contract):
             return 20, False
         if isinstance(self._type, Enum):
-            return int(math.ceil(math.log2(len(self._type.values)) / 8)), False
+            return math.ceil(math.log2(len(self._type.values)) / 8), False
         if isinstance(self._type, Structure):
             # todo there's some duplicate logic here and slither_core, can we refactor this?
             slot = 0

--- a/slither/core/variables/state_variable.py
+++ b/slither/core/variables/state_variable.py
@@ -40,9 +40,7 @@ class StateVariable(ContractLevel, Variable):
         """
         Checks if the state variable is stored, based on it not being constant or immutable or transient.
         """
-        return (
-            not self._is_constant and not self._is_immutable and not self._location == "transient"
-        )
+        return not self._is_constant and not self._is_immutable and self._location != "transient"
 
     @property
     def is_transient(self) -> bool:

--- a/slither/detectors/abstract_detector.py
+++ b/slither/detectors/abstract_detector.py
@@ -208,7 +208,7 @@ class AbstractDetector(metaclass=abc.ABCMeta):
             for result in results:
                 try:
                     self._format(self.compilation_unit, result)
-                    if not "patches" in result:
+                    if "patches" not in result:
                         continue
                     result["patches_diff"] = {}
                     for file in result["patches"]:

--- a/slither/detectors/attributes/locked_ether.py
+++ b/slither/detectors/attributes/locked_ether.py
@@ -97,7 +97,7 @@ Every Ether sent to `Locked` will be lost."""
                         # Add it to the list to explore
                         # InternalCall if to follow internal call in libraries
                         if isinstance(ir, (InternalCall, LibraryCall)):
-                            if not ir.function in explored:
+                            if ir.function not in explored:
                                 to_explore.append(ir.function)
 
         return True

--- a/slither/detectors/compiler_bugs/enum_conversion.py
+++ b/slither/detectors/compiler_bugs/enum_conversion.py
@@ -80,7 +80,7 @@ Attackers can trigger unexpected behaviour by calling `bug(1)`."""
                 variable_info: DETECTOR_INFO = [
                     "\t- Variable: ",
                     var,
-                    f" of type: {str(var.type)}\n",
+                    f" of type: {var.type!s}\n",
                 ]
                 node_info: DETECTOR_INFO = ["\t- Enum conversion: ", node, "\n"]
                 json = self.generate_result(func_info + variable_info + node_info)

--- a/slither/detectors/compiler_bugs/storage_ABIEncoderV2_array.py
+++ b/slither/detectors/compiler_bugs/storage_ABIEncoderV2_array.py
@@ -81,8 +81,10 @@ contract A {
                 for ir in node.irs:
                     # Call to abi.encode()
                     if (
-                        isinstance(ir, SolidityCall)
-                        and ir.function == SolidityFunction("abi.encode()")
+                        (
+                            isinstance(ir, SolidityCall)
+                            and ir.function == SolidityFunction("abi.encode()")
+                        )
                         or
                         # Call to emit event
                         # Call to external function

--- a/slither/detectors/operations/block_timestamp.py
+++ b/slither/detectors/operations/block_timestamp.py
@@ -40,7 +40,7 @@ def _timestamp(func: Function) -> List[Node]:
                         ret.add(node)
                     if is_dependent(var_read, SolidityVariable("now"), node):
                         ret.add(node)
-    return sorted(list(ret), key=lambda x: x.node_id)
+    return sorted(ret, key=lambda x: x.node_id)
 
 
 def _detect_dangerous_timestamp(

--- a/slither/detectors/operations/unused_return_values.py
+++ b/slither/detectors/operations/unused_return_values.py
@@ -61,9 +61,7 @@ contract MyConc{
                 )
                 or not isinstance(ir.function, Function)
             )
-            or ir.node.type == NodeType.TRY
-            and isinstance(ir, (Assignment, Unpack))
-        )
+        ) or (ir.node.type == NodeType.TRY and isinstance(ir, (Assignment, Unpack)))
 
     def detect_unused_return_values(self, f: FunctionContract) -> List[Node]:
         """

--- a/slither/detectors/reentrancy/reentrancy.py
+++ b/slither/detectors/reentrancy/reentrancy.py
@@ -23,16 +23,16 @@ def union_dict(d1: Dict, d2: Dict) -> Dict:
 
 
 def dict_are_equal(d1: Dict, d2: Dict) -> bool:
-    if set(list(d1.keys())) != set(list(d2.keys())):
+    if set(d1.keys()) != set(d2.keys()):
         return False
-    return all(set(d1[k]) == set(d2[k]) for k in d1.keys())
+    return all(set(d1[k]) == set(d2[k]) for k in d1)
 
 
 def is_subset(
     new_info: Dict,
     old_info: Dict,
 ) -> bool:
-    for k in new_info.keys():
+    for k in new_info:
         if k not in old_info:
             return False
         if not new_info[k].issubset(old_info[k]):
@@ -41,9 +41,7 @@ def is_subset(
 
 
 def to_hashable(d: Dict[Node, Set[Node]]) -> Tuple:
-    list_tuple = list(
-        tuple((k, tuple(sorted(values, key=lambda x: x.node_id)))) for k, values in d.items()
-    )
+    list_tuple = [(k, tuple(sorted(values, key=lambda x: x.node_id))) for k, values in d.items()]
     return tuple(sorted(list_tuple, key=lambda x: x[0].node_id))
 
 

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -97,11 +97,11 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
+        result_sorted = sorted(reentrancies.items(), key=lambda x: x[0].function.name)
         varsWritten: List[FindingValue]
         for (func, calls, send_eth), varsWritten in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            calls = sorted(set(calls), key=lambda x: x[0].node_id)
+            send_eth = sorted(set(send_eth), key=lambda x: x[0].node_id)
             varsWritten = sorted(varsWritten, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ["Reentrancy in ", func, ":\n"]

--- a/slither/detectors/reentrancy/reentrancy_eth.py
+++ b/slither/detectors/reentrancy/reentrancy_eth.py
@@ -61,7 +61,7 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
             for f in contract.functions_and_modifiers_declared:
                 for node in f.nodes:
                     # dead code
-                    if not self.KEY in node.context:
+                    if self.KEY not in node.context:
                         continue
                     if node.context[self.KEY].calls and node.context[self.KEY].send_eth:
                         if not any(n != node for n in node.context[self.KEY].send_eth):
@@ -105,12 +105,12 @@ Bob uses the re-entrancy bug to call `withdrawBalance` two times, and withdraw m
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
+        result_sorted = sorted(reentrancies.items(), key=lambda x: x[0].function.name)
         varsWritten: List[FindingValue]
         varsWrittenSet: Set[FindingValue]
         for (func, calls, send_eth), varsWrittenSet in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            calls = sorted(set(calls), key=lambda x: x[0].node_id)
+            send_eth = sorted(set(send_eth), key=lambda x: x[0].node_id)
             varsWritten = sorted(varsWrittenSet, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ["Reentrancy in ", func, ":\n"]

--- a/slither/detectors/reentrancy/reentrancy_events.py
+++ b/slither/detectors/reentrancy/reentrancy_events.py
@@ -112,10 +112,10 @@ If the external call `d.f()` re-enters `BugReentrancyEvents`, the `Counter` even
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0][0].name)
+        result_sorted = sorted(reentrancies.items(), key=lambda x: x[0][0].name)
         for (func, calls, send_eth), events in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            calls = sorted(set(calls), key=lambda x: x[0].node_id)
+            send_eth = sorted(set(send_eth), key=lambda x: x[0].node_id)
             events = sorted(events, key=lambda x: (str(x.variable.name), x.node.node_id))
 
             info = ["Reentrancy in ", func, ":\n"]

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -111,10 +111,10 @@ Only report reentrancy that is based on `transfer` or `send`."""
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0][0].name)
+        result_sorted = sorted(reentrancies.items(), key=lambda x: x[0][0].name)
         for (func, calls, send_eth), varsWrittenOrEvent in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
-            send_eth = sorted(list(set(send_eth)), key=lambda x: x[0].node_id)
+            calls = sorted(set(calls), key=lambda x: x[0].node_id)
+            send_eth = sorted(set(send_eth), key=lambda x: x[0].node_id)
             info = ["Reentrancy in ", func, ":\n"]
 
             info += ["\tExternal calls:\n"]

--- a/slither/detectors/reentrancy/reentrancy_read_before_write.py
+++ b/slither/detectors/reentrancy/reentrancy_read_before_write.py
@@ -100,11 +100,11 @@ Do not report reentrancies that involve Ether (see `reentrancy-eth`)."""
 
         results = []
 
-        result_sorted = sorted(list(reentrancies.items()), key=lambda x: x[0].function.name)
+        result_sorted = sorted(reentrancies.items(), key=lambda x: x[0].function.name)
         varsWritten: List[FindingValue]
         varsWrittenSet: Set[FindingValue]
         for (func, calls), varsWrittenSet in result_sorted:
-            calls = sorted(list(set(calls)), key=lambda x: x[0].node_id)
+            calls = sorted(set(calls), key=lambda x: x[0].node_id)
             varsWritten = sorted(varsWrittenSet, key=lambda x: (x.variable.name, x.node.node_id))
 
             info = ["Reentrancy in ", func, ":\n"]

--- a/slither/detectors/reentrancy/token.py
+++ b/slither/detectors/reentrancy/token.py
@@ -25,10 +25,8 @@ def _detect_token_reentrant(contract: Contract) -> Dict[Function, List[Node]]:
                     if not function.parameters:
                         continue
                     if any(
-                        (
-                            is_dependent(ir.destination, parameter, function)
-                            for parameter in function.parameters
-                        )
+                        is_dependent(ir.destination, parameter, function)
+                        for parameter in function.parameters
                     ):
                         ret[function].append(ir.node)
                     if is_dependent(

--- a/slither/detectors/source/rtlo.py
+++ b/slither/detectors/source/rtlo.py
@@ -56,12 +56,12 @@ contract Token
 
     WIKI_RECOMMENDATION = "Special control characters must not be allowed."
 
-    RTLO_CHARACTER_ENCODED = "\u202e".encode("utf8")
+    RTLO_CHARACTER_ENCODED = "\u202e".encode()
     STANDARD_JSON = False
 
     def _detect(self) -> List[Output]:
         results = []
-        pattern = re.compile(".*\u202e.*".encode("utf8"))
+        pattern = re.compile(".*\u202e.*".encode())
 
         for filename, source in self.slither.source_code.items():
             # Attempt to find all RTLO characters in this source file.

--- a/slither/detectors/statements/incorrect_strict_equality.py
+++ b/slither/detectors/statements/incorrect_strict_equality.py
@@ -104,11 +104,7 @@ contract Crowdsale{
         function: FunctionContract,
     ) -> bool:
         return any(
-            (
-                is_dependent_ssa(var, taint, function.contract)
-                for var in variables
-                for taint in taints
-            )
+            is_dependent_ssa(var, taint, function.contract) for var in variables for taint in taints
         )
 
     def taint_balance_equalities(
@@ -187,7 +183,7 @@ contract Crowdsale{
             ret = self.detect_strict_equality(c)
 
             # sort ret to get deterministic results
-            ret = sorted(list(ret.items()), key=lambda x: x[0].name)
+            ret = sorted(ret.items(), key=lambda x: x[0].name)
             for f, nodes in ret:
                 func_info = [f, " uses a dangerous strict equality:\n"]
 

--- a/slither/detectors/statements/msg_value_in_loop.py
+++ b/slither/detectors/statements/msg_value_in_loop.py
@@ -52,10 +52,8 @@ def msg_value_in_loop(
                     if ir.read[0] == SolidityVariableComposed("msg.value")
                     else ir.read[0]
                 )
-                if (
-                    isinstance(compared_to, Constant)
-                    and compared_to.value == 0
-                    or isinstance(compared_to, Variable)
+                if (isinstance(compared_to, Constant) and compared_to.value == 0) or (
+                    isinstance(compared_to, Variable)
                     and isinstance(compared_to.expression, Literal)
                     and str(compared_to.expression.value) == "0"
                 ):

--- a/slither/detectors/variables/predeclaration_usage_local.py
+++ b/slither/detectors/variables/predeclaration_usage_local.py
@@ -86,7 +86,7 @@ Additionally, the for-loop uses the variable `max`, which is declared in a previ
         if node.variable_declaration:
             already_declared = already_declared | {node.variable_declaration}
 
-        if not node in self.fix_point_information:
+        if node not in self.fix_point_information:
             self.fix_point_information[node] = []
 
         # If we already explored this node with the same information

--- a/slither/detectors/variables/unchanged_state_variables.py
+++ b/slither/detectors/variables/unchanged_state_variables.py
@@ -62,7 +62,7 @@ def _constant_initial_expression(v: Variable) -> bool:
     if not values:
         return True
 
-    return all((val in valid_solidity_function or _is_constant_var(val) for val in values))
+    return all(val in valid_solidity_function or _is_constant_var(val) for val in values)
 
 
 class UnchangedStateVariables:

--- a/slither/formatters/naming_convention/naming_convention.py
+++ b/slither/formatters/naming_convention/naming_convention.py
@@ -129,7 +129,7 @@ SOLIDITY_KEYWORDS += ElementaryTypeName
 
 def _name_already_use(slither: SlitherCompilationUnit, name: str) -> bool:
     # Do not convert to a name used somewhere else
-    if not KEY in slither.context:
+    if KEY not in slither.context:
         all_names: Set[str] = set()
         for contract in slither.contracts_derived:
             all_names = all_names.union({st.name for st in contract.structures})
@@ -502,14 +502,14 @@ def _explore_variables_declaration(
                         idx_beginning += -func.source_mapping.starting_column + 1
                         idx_beginning += -sum(len(c) for c in potential_comments)
 
-                        old_comment = f"@param {old_str}".encode("utf8")
+                        old_comment = f"@param {old_str}".encode()
 
                         for line in potential_comments:
                             idx = line.find(old_comment)
                             if idx >= 0:
                                 loc_start = idx + idx_beginning
                                 loc_end = loc_start + len(old_comment)
-                                new_comment = f"@param {new_str}".encode("utf8")
+                                new_comment = f"@param {new_str}".encode()
 
                                 create_patch(
                                     result,
@@ -622,7 +622,7 @@ def _explore_irs(
                     full_txt_start:full_txt_end
                 ]
 
-                if not target.name.encode("utf8") in full_txt:
+                if target.name.encode("utf8") not in full_txt:
                     raise FormatError(f"{target} not found in {full_txt} ({source_mapping}")
 
                 old_str = target.name.encode("utf8")
@@ -632,7 +632,7 @@ def _explore_irs(
                 # Can be found multiple time on the same IR
                 # We patch one by one
                 while old_str in full_txt:
-                    target_found_at = full_txt.find((old_str))
+                    target_found_at = full_txt.find(old_str)
 
                     full_txt = full_txt[target_found_at + 1 :]
                     counter += target_found_at

--- a/slither/formatters/variables/unchanged_state_variables.py
+++ b/slither/formatters/variables/unchanged_state_variables.py
@@ -40,7 +40,7 @@ def _patch(
     old_str_of_interest = in_file_str[modify_loc_start:modify_loc_end]
     # Add keyword `constant` before the variable name
     (new_str_of_interest, num_repl) = re.subn(
-        match_text, replace_text, old_str_of_interest.decode("utf8"), 1
+        match_text, replace_text, old_str_of_interest.decode("utf8"), count=1
     )
     if num_repl != 0:
         create_patch(

--- a/slither/printers/call/call_graph.py
+++ b/slither/printers/call/call_graph.py
@@ -120,7 +120,7 @@ def _process_external_call(
 ) -> None:
     external_contract, ir = external_call
 
-    if not external_contract in all_contracts:
+    if external_contract not in all_contracts:
         return
 
     # add variable as node to respective contract

--- a/slither/printers/guidance/echidna.py
+++ b/slither/printers/guidance/echidna.py
@@ -155,9 +155,7 @@ def json_serializable(cls):
     my_super = super
 
     def as_dict(self):
-        yield {
-            name: value for name, value in zip(self._fields, iter(my_super(cls, self).__iter__()))
-        }
+        yield dict(zip(self._fields, my_super(cls, self).__iter__()))
 
     cls.__iter__ = as_dict
     return cls
@@ -318,10 +316,10 @@ def _extract_function_relations(
                 "is_impacted_by": [],
             }
             for candidate, varsWritten in written.items():
-                if any((r in varsWritten for r in function.all_state_variables_read())):
+                if any(r in varsWritten for r in function.all_state_variables_read()):
                     ret[contract.name][_get_name(function)]["is_impacted_by"].append(candidate)
             for candidate, varsRead in read.items():
-                if any((r in varsRead for r in function.all_state_variables_written())):
+                if any(r in varsRead for r in function.all_state_variables_written()):
                     ret[contract.name][_get_name(function)]["impacts"].append(candidate)
     return ret
 

--- a/slither/printers/inheritance/inheritance.py
+++ b/slither/printers/inheritance/inheritance.py
@@ -62,7 +62,7 @@ class PrinterInheritance(AbstractPrinter):
             result["base_to_child"][base.name] = {"immediate": [], "not_immediate": []}
             if children:
                 immediate = [child for child in children if base in child.immediate_inheritance]
-                not_immediate = [child for child in children if not child in immediate]
+                not_immediate = [child for child in children if child not in immediate]
 
                 info += " -> " + blue(", ".join(map(str, immediate))) + "\n"
                 result["base_to_child"][base.name]["immediate"] = list(map(str, immediate))

--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -182,10 +182,7 @@ class PrinterInheritanceGraph(AbstractPrinter):
             ret += f"{private_variables}"
 
         if indirect_shadowing_information:
-            ret += (
-                '<TR><TD><BR/></TD></TR><TR><TD align="left" border="1"><font color="#777777" point-size="10">%s</font></TD></TR>'
-                % indirect_shadowing_information.replace("\n", "<BR/>")
-            )
+            ret += f'<TR><TD><BR/></TD></TR><TR><TD align="left" border="1"><font color="#777777" point-size="10">{indirect_shadowing_information.replace(chr(10), "<BR/>")}</font></TD></TR>'
         ret += "</TABLE> >];\n"
 
         return ret

--- a/slither/printers/summary/human_summary.py
+++ b/slither/printers/summary/human_summary.py
@@ -178,7 +178,7 @@ class PrinterHumanSummary(AbstractPrinter):
     def _compilation_type(self):
         if self.slither.crytic_compile is None:
             return "Compilation non standard\n"
-        return f"Compiled with {str(self.slither.crytic_compile.type)}\n"
+        return f"Compiled with {self.slither.crytic_compile.type!s}\n"
 
     def _number_contracts(self) -> Tuple[int, int, int]:
         contracts = self.slither.contracts

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -29,7 +29,7 @@ def _check_common_things(
             f"You can't register {cls!r} as a {thing_name}. You need to pass a class that inherits from {base_cls.__name__}"
         )
 
-    if any(type(obj) == cls for obj in instances_list):
+    if any(type(obj) is cls for obj in instances_list):
         raise SlitherError(f"You can't register {cls!r} twice.")
 
 
@@ -120,7 +120,7 @@ class Slither(SlitherCore):
         self.codex_temperature = kwargs.get("codex_temperature", 0)
         self.codex_max_tokens = kwargs.get("codex_max_tokens", 300)
         self.codex_log = kwargs.get("codex_log", False)
-        self.codex_organization: Optional[str] = kwargs.get("codex_organization", None)
+        self.codex_organization: Optional[str] = kwargs.get("codex_organization")
 
         self.no_fail = kwargs.get("no_fail", False)
 
@@ -132,7 +132,7 @@ class Slither(SlitherCore):
                 crytic_compile = CryticCompile(target, **kwargs)
             self._crytic_compile = crytic_compile
         except InvalidCompilation as e:
-            raise SlitherError(f"Invalid compilation: \n{str(e)}")
+            raise SlitherError(f"Invalid compilation: \n{e!s}")
         for compilation_unit in crytic_compile.compilation_units.values():
             compilation_unit_slither = SlitherCompilationUnit(self, compilation_unit)
             self._compilation_units.append(compilation_unit_slither)

--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -336,7 +336,7 @@ def integrate_value_gas(result: List[Operation]) -> List[Operation]:
                 variable_to_replace[ins.lvalue.name] = ins.ori.variable_left  # type: ignore
 
         # Remove the call to value/gas instruction
-        result = [i for i in result if not i in to_remove]
+        result = [i for i in result if i not in to_remove]
 
         # update the real call
         for ins in result:
@@ -850,7 +850,7 @@ def propagate_types(ir: Operation, node: "Node"):
                     # Otherwise solc raises:
                     # Error: Member "f" not unique after argument-dependent lookup in contract
                     targeted_function = next(
-                        (x for x in ir_func.contract.functions if x.name == str(ir.variable_right))
+                        x for x in ir_func.contract.functions if x.name == str(ir.variable_right)
                     )
                     ir.lvalue.set_type(targeted_function)
                 elif isinstance(left, (Variable, SolidityVariable)):
@@ -1935,7 +1935,7 @@ def remove_unused(result: List[Operation]) -> List[Operation]:
 
         for ins in result:
             if isinstance(ins, Member):
-                if not ins.lvalue.name in to_keep and ins != last_elem:
+                if ins.lvalue.name not in to_keep and ins != last_elem:
                     to_remove.append(ins)
                     removed = True
             # Remove type(X) if X is an elementary type
@@ -1945,7 +1945,7 @@ def remove_unused(result: List[Operation]) -> List[Operation]:
                 if isinstance(ins.arguments[0], ElementaryType):
                     to_remove.append(ins)
 
-        result = [i for i in result if not i in to_remove]
+        result = [i for i in result if i not in to_remove]
     return result
 
 

--- a/slither/slithir/operations/binary.py
+++ b/slither/slithir/operations/binary.py
@@ -154,6 +154,6 @@ class Binary(OperationWithLValue):
             points = lvalue.points_to
             while isinstance(points, ReferenceVariable):
                 points = points.points_to
-            return f"{str(lvalue)}(-> {points}) = {self.variable_left} {self.type_str} {self.variable_right}"
+            return f"{lvalue!s}(-> {points}) = {self.variable_left} {self.type_str} {self.variable_right}"
 
-        return f"{str(lvalue)}({lvalue.type}) = {self.variable_left} {self.type_str} {self.variable_right}"
+        return f"{lvalue!s}({lvalue.type}) = {self.variable_left} {self.type_str} {self.variable_right}"

--- a/slither/slithir/operations/return_operation.py
+++ b/slither/slithir/operations/return_operation.py
@@ -35,7 +35,7 @@ class Return(Operation):
             # Prior Solidity 0.5
             # return (0,)
             # was valid for returns(uint)
-            self._values = [v for v in values if not v is None]
+            self._values = [v for v in values if v is not None]
             self._valid_value(self._values)
         super().__init__()
 

--- a/slither/slithir/tmp_operations/argument.py
+++ b/slither/slithir/tmp_operations/argument.py
@@ -46,4 +46,4 @@ class Argument(Operation):
         call_id = "none"
         if self.call_id:
             call_id = f"(id ({self.call_id}))"
-        return f"ARG_{self._type.name} {str(self._argument)} {call_id}"
+        return f"ARG_{self._type.name} {self._argument!s} {call_id}"

--- a/slither/slithir/utils/ssa.py
+++ b/slither/slithir/utils/ssa.py
@@ -85,7 +85,7 @@ def transform_slithir_vars_to_ssa(
     variables = []
     for node in function.nodes:
         for ir in node.irs_ssa:
-            if isinstance(ir, OperationWithLValue) and not ir.lvalue in variables:
+            if isinstance(ir, OperationWithLValue) and ir.lvalue not in variables:
                 variables += [ir.lvalue]
 
     tmp_variables = [v for v in variables if isinstance(v, TemporaryVariable)]
@@ -224,7 +224,7 @@ def generate_ssa_irs(
         return
 
     if node.type in [NodeType.ENDIF, NodeType.ENDLOOP] and any(
-        not father in visited for father in node.fathers
+        father not in visited for father in node.fathers
     ):
         return
 
@@ -398,7 +398,7 @@ def is_used_later(
             ):
                 return False
         for son in node.sons:
-            if not son in explored:
+            if son not in explored:
                 to_explore.add(son)
 
     return False
@@ -554,7 +554,7 @@ def add_phi_origins(
     # For unini variable declaration
     if (
         node.variable_declaration
-        and not node.variable_declaration.name in local_variables_definition
+        and node.variable_declaration.name not in local_variables_definition
     ):
         local_variables_definition[node.variable_declaration.name] = (
             node.variable_declaration,
@@ -607,7 +607,7 @@ def get(
     if isinstance(variable, StateVariable) and variable.canonical_name in state_variables_instances:
         return state_variables_instances[variable.canonical_name]
     if isinstance(variable, ReferenceVariable):
-        if not variable.index in reference_variables_instances:
+        if variable.index not in reference_variables_instances:
             new_variable = ReferenceVariableSSA(variable)
             if variable.points_to:
                 new_variable.points_to = get(
@@ -623,13 +623,13 @@ def get(
             reference_variables_instances[variable.index] = new_variable
         return reference_variables_instances[variable.index]
     if isinstance(variable, TemporaryVariable):
-        if not variable.index in temporary_variables_instances:
+        if variable.index not in temporary_variables_instances:
             new_variable = TemporaryVariableSSA(variable)
             new_variable.set_type(variable.type)
             temporary_variables_instances[variable.index] = new_variable
         return temporary_variables_instances[variable.index]
     if isinstance(variable, TupleVariable):
-        if not variable.index in tuple_variables_instances:
+        if variable.index not in tuple_variables_instances:
             new_variable = TupleVariableSSA(variable)
             new_variable.set_type(variable.type)
             tuple_variables_instances[variable.index] = new_variable

--- a/slither/slithir/variables/constant.py
+++ b/slither/slithir/variables/constant.py
@@ -77,7 +77,7 @@ class Constant(SlithIRVariable):
         return self.value < other  # type: ignore
 
     def __repr__(self) -> str:
-        return f"{str(self.value)}"
+        return f"{self.value!s}"
 
     def __hash__(self) -> int:
         return self._val.__hash__()

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -264,7 +264,7 @@ class ContractSolc(CallerContextExpression):
                         self.baseConstructorContractsCalled.append(referencedDeclaration)
 
     def _parse_contract_items(self) -> None:
-        if not self.get_children() in self._data:  # empty contract
+        if self.get_children() not in self._data:  # empty contract
             return
         for item in self._data[self.get_children()]:
             if item[self.get_key()] == "FunctionDefinition":
@@ -640,7 +640,7 @@ class ContractSolc(CallerContextExpression):
                 self._contract.using_for.update(father.using_for)
             if self.is_compact_ast:
                 for using_for in self._usingForNotParsed:
-                    if "typeName" in using_for and using_for["typeName"]:
+                    if using_for.get("typeName"):
                         type_name: USING_FOR_KEY = parse_type(using_for["typeName"], self)
                     else:
                         type_name = "*"

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -219,7 +219,7 @@ class FunctionSolc(CallerContextExpression):
         if "constant" in attributes:
             self._function.view = attributes["constant"]
 
-        if "isConstructor" in attributes and attributes["isConstructor"]:
+        if attributes.get("isConstructor"):
             self._function.function_type = FunctionType.CONSTRUCTOR
 
         if "kind" in attributes:
@@ -403,7 +403,7 @@ class FunctionSolc(CallerContextExpression):
             trueStatement = self._parse_statement(
                 if_statement["trueBody"], condition_node, true_scope
             )
-            if "falseBody" in if_statement and if_statement["falseBody"]:
+            if if_statement.get("falseBody"):
                 false_scope = Scope(scope.is_checked, False, scope)
                 falseStatement = self._parse_statement(
                     if_statement["falseBody"], condition_node, false_scope
@@ -463,9 +463,9 @@ class FunctionSolc(CallerContextExpression):
         self, statement: Dict
     ) -> Tuple[Optional[Dict], Optional[Dict], Optional[Dict], Dict]:
         body = statement["body"]
-        init_expression = statement.get("initializationExpression", None)
-        condition = statement.get("condition", None)
-        loop_expression = statement.get("loopExpression", None)
+        init_expression = statement.get("initializationExpression")
+        condition = statement.get("condition")
+        loop_expression = statement.get("loopExpression")
 
         return init_expression, condition, loop_expression, body
 
@@ -490,7 +490,7 @@ class FunctionSolc(CallerContextExpression):
             # handle the second trivial case - if there is only one child we know there are no expressions
             pre, cond, post = None, None, None
         else:
-            attributes = statement.get("attributes", None)
+            attributes = statement.get("attributes")
 
             def has_hint(key):
                 return key in attributes and not attributes[key]
@@ -678,7 +678,7 @@ class FunctionSolc(CallerContextExpression):
 
         ret: Dict = {"nodeType": "Assignment", "operator": "=", "src": parameters_list["src"]}
 
-        parameters = parameters_list.get("parameters", None)
+        parameters = parameters_list.get("parameters")
 
         # if the name is "" it means the return variable is not used
         if len(parameters) == 1:
@@ -731,7 +731,7 @@ class FunctionSolc(CallerContextExpression):
         return ret
 
     def _parse_try_catch(self, statement: Dict, node: NodeSolc, scope: Scope) -> NodeSolc:
-        externalCall = statement.get("externalCall", None)
+        externalCall = statement.get("externalCall")
 
         if externalCall is None:
             raise ParsingError(f"Try/Catch not correctly parsed by Slither {statement}")
@@ -761,7 +761,7 @@ class FunctionSolc(CallerContextExpression):
     def _parse_catch(
         self, statement: Dict, node: NodeSolc, scope: Scope, add_param: bool
     ) -> NodeSolc:
-        block = statement.get("block", None)
+        block = statement.get("block")
 
         if block is None:
             raise ParsingError(f"Catch not correctly parsed by Slither {statement}")
@@ -772,7 +772,7 @@ class FunctionSolc(CallerContextExpression):
 
         if add_param:
             if self.is_compact_ast:
-                params = statement.get("parameters", None)
+                params = statement.get("parameters")
             else:
                 params = statement[self.get_children("children")]
 
@@ -1051,7 +1051,7 @@ class FunctionSolc(CallerContextExpression):
             return_node = self._new_node(NodeType.RETURN, statement["src"], scope)
             link_underlying_nodes(node, return_node)
             if self.is_compact_ast:
-                if statement.get("expression", None):
+                if statement.get("expression"):
                     return_node.add_unparsed_expression(statement["expression"])
             else:
                 if (

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -233,10 +233,6 @@ def _parse_elementary_type_name_expression(
     return e
 
 
-if TYPE_CHECKING:
-    pass
-
-
 def _user_defined_op_call(
     caller_context: CallerContextExpression, src, function_id: int, args: List[Any], type_call: str
 ) -> CallExpression:
@@ -436,7 +432,7 @@ def parse_expression(expression: Dict, caller_context: CallerContextExpression) 
         if is_compact_ast:
             value = expression.get("value", None)
             if value:
-                if "subdenomination" in expression and expression["subdenomination"]:
+                if expression.get("subdenomination"):
                     subdenomination = expression["subdenomination"]
             elif not value and value != "":
                 value = "0x" + expression["hexValue"]

--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -431,11 +431,11 @@ class SlitherCompilationUnitSolc(CallerContextExpression):
                 sourceUnit = len(self._compilation_unit.core.source_code)
 
         self._compilation_unit.source_units[sourceUnit] = name
-        if os.path.isfile(name) and not name in self._compilation_unit.core.source_code:
+        if os.path.isfile(name) and name not in self._compilation_unit.core.source_code:
             self._compilation_unit.core.add_source_code(name)
         else:
             lib_name = os.path.join("node_modules", name)
-            if os.path.isfile(lib_name) and not name in self._compilation_unit.core.source_code:
+            if os.path.isfile(lib_name) and name not in self._compilation_unit.core.source_code:
                 self._compilation_unit.core.add_source_code(lib_name)
 
     # endregion

--- a/slither/solc_parsing/variables/variable_declaration.py
+++ b/slither/solc_parsing/variables/variable_declaration.py
@@ -61,7 +61,7 @@ class VariableDeclarationSolc:
                     init = variable_data["initialValue"]
                 self._init_from_declaration(variable_data["declarations"][0], init)
             elif nodeType == "VariableDeclaration":
-                self._init_from_declaration(variable_data, variable_data.get("value", None))
+                self._init_from_declaration(variable_data, variable_data.get("value"))
             else:
                 raise ParsingError(f"Incorrect variable declaration type {nodeType}")
 
@@ -119,10 +119,7 @@ class VariableDeclarationSolc:
                     self._variable.write_protection.append(write_protection.group(1))
 
     def _analyze_variable_attributes(self, attributes: Dict) -> None:
-        if "visibility" in attributes:
-            self._variable.visibility = attributes["visibility"]
-        else:
-            self._variable.visibility = "internal"
+        self._variable.visibility = attributes.get("visibility", "internal")
 
     def _init_from_declaration(self, var: Dict, init: Optional[Dict]) -> None:
         if self._is_compact_ast:

--- a/slither/solc_parsing/yul/parse_yul.py
+++ b/slither/solc_parsing/yul/parse_yul.py
@@ -122,9 +122,9 @@ class YulScope(metaclass=abc.ABCMeta):
     __slots__ = [
         "_contract",
         "_id",
-        "_yul_local_variables",
-        "_yul_local_functions",
         "_parent_func",
+        "_yul_local_functions",
+        "_yul_local_variables",
     ]
 
     def __init__(
@@ -189,7 +189,7 @@ class YulScope(metaclass=abc.ABCMeta):
 
 
 class YulLocalVariable:
-    __slots__ = ["_variable", "_root"]
+    __slots__ = ["_root", "_variable"]
 
     def __init__(self, var: LocalVariable, root: YulScope, ast: Dict) -> None:
         assert ast["nodeType"] == "YulTypedName"
@@ -211,7 +211,7 @@ class YulLocalVariable:
 
 
 class YulFunction(YulScope):
-    __slots__ = ["_function", "_root", "_ast", "_nodes", "_entrypoint", "node_scope"]
+    __slots__ = ["_ast", "_entrypoint", "_function", "_nodes", "_root", "node_scope"]
 
     def __init__(
         self, func: Function, root: YulScope, ast: Dict, node_scope: Union[Function, Scope]
@@ -297,7 +297,7 @@ class YulBlock(YulScope):
 
     """
 
-    __slots__ = ["_entrypoint", "_parent_func", "_nodes", "node_scope"]
+    __slots__ = ["_entrypoint", "_nodes", "_parent_func", "node_scope"]
 
     def __init__(
         self,
@@ -450,7 +450,7 @@ def convert_yul_if(
     src = ast["src"]
     condition_ast = ast["condition"]
     true_body_ast = ast["body"]
-    false_body_ast = ast["false_body"] if "false_body" in ast else None
+    false_body_ast = ast.get("false_body")
 
     condition = root.new_node(NodeType.IF, src)
     end = root.new_node(NodeType.ENDIF, src)
@@ -745,7 +745,7 @@ def parse_yul_function_call(root: YulScope, node: YulNode, ast: Dict) -> Optiona
     if isinstance(ident.value, SolidityFunction):
         return CallExpression(ident, args, vars_to_typestr(ident.value.return_type))
 
-    raise SlitherException(f"unexpected function call target type {str(type(ident.value))}")
+    raise SlitherException(f"unexpected function call target type {type(ident.value)!s}")
 
 
 def _check_for_state_variable_name(root: YulScope, potential_name: str) -> Optional[Identifier]:

--- a/slither/tools/doctor/checks/platform.py
+++ b/slither/tools/doctor/checks/platform.py
@@ -30,7 +30,7 @@ def detect_platform(project: str, **kwargs) -> None:
 
     print("Is this project using...")
     for platform, state in detected_platforms.items():
-        print(f"    =>  {platform + '?':<15}{state and green('Yes') or red('No')}")
+        print(f"    =>  {platform + '?':<15}{(state and green('Yes')) or red('No')}")
     print()
 
     if platform_qty == 0:

--- a/slither/tools/doctor/checks/versions.py
+++ b/slither/tools/doctor/checks/versions.py
@@ -24,7 +24,7 @@ def get_github_version(name: str) -> Optional[Version]:
             text = response.read()
             data = json.loads(text)
             return parse(data["tag_name"])
-    except:
+    except Exception:
         return None
 
 

--- a/slither/tools/erc_conformance/erc/ercs.py
+++ b/slither/tools/erc_conformance/erc/ercs.py
@@ -28,7 +28,7 @@ def _check_signature(erc_function: ERC, contract: Contract, ret: Dict) -> None:
         # The check on state variable is needed until we have a better API to handle state variable getters
         state_variable_as_function = contract.get_state_variable_from_name(name)
 
-        if not state_variable_as_function or not state_variable_as_function.visibility in [
+        if not state_variable_as_function or state_variable_as_function.visibility not in [
             "public",
             "external",
         ]:

--- a/slither/tools/flattening/flattening.py
+++ b/slither/tools/flattening/flattening.py
@@ -344,7 +344,7 @@ class Flattening:
         for f in contract.functions_declared:
             for ir in f.slithir_operations:
                 if isinstance(ir, NewContract):
-                    if ir.contract_created != contract and not ir.contract_created in exported:
+                    if ir.contract_created != contract and ir.contract_created not in exported:
                         self._export_list_used_contracts(
                             ir.contract_created, exported, list_contract, list_top_level
                         )
@@ -412,7 +412,7 @@ class Flattening:
             next_to_explore = contract_to_explore.pop(0)
 
             if not next_to_explore.inheritance or all(
-                (father in contract_seen for father in next_to_explore.inheritance)
+                father in contract_seen for father in next_to_explore.inheritance
             ):
                 content += "\n"
                 content += self._source_codes[next_to_explore]

--- a/slither/tools/kspec_coverage/analysis.py
+++ b/slither/tools/kspec_coverage/analysis.py
@@ -25,7 +25,7 @@ def _get_all_covered_kspec_functions(target: str) -> Set[Tuple[str, str]]:
     INTERFACE_PATTERN = re.compile(r"interface\s+([^\r\n]+)")
 
     # Read the file contents
-    with open(target, "r", encoding="utf8") as target_file:
+    with open(target, encoding="utf8") as target_file:
         lines = target_file.readlines()
 
     # Loop for each line, if a line matches our behaviour regex, and the next one matches our interface regex,

--- a/slither/tools/mutator/mutators/AOR.py
+++ b/slither/tools/mutator/mutators/AOR.py
@@ -29,7 +29,7 @@ class AOR(AbstractMutator):
                     continue
                 try:
                     ir_expression = node.expression
-                except:
+                except AttributeError:
                     continue
 
                 # Special cases handling .push and .pop on dynamic arrays.

--- a/slither/tools/mutator/mutators/ASOR.py
+++ b/slither/tools/mutator/mutators/ASOR.py
@@ -44,7 +44,7 @@ class ASOR(AbstractMutator):
                         alternative_ops = assignment_operators[:]
                         try:
                             alternative_ops.remove(ir.expression.type)
-                        except:
+                        except ValueError:
                             continue
                         for op in alternative_ops:
                             if op != ir.expression:

--- a/slither/tools/mutator/mutators/FHR.py
+++ b/slither/tools/mutator/mutators/FHR.py
@@ -26,7 +26,7 @@ class FHR(AbstractMutator):
             stop = start + function.source_mapping.content.find("{")
             old_str = function.source_mapping.content
             line_no = function.source_mapping.lines
-            if not line_no[0] in self.dont_mutate_line:
+            if line_no[0] not in self.dont_mutate_line:
                 for value in function_header_replacements:
                     left_value = value.split(" ==> ", maxsplit=1)[0]
                     right_value = value.split(" ==> ")[1]

--- a/slither/tools/mutator/mutators/LIR.py
+++ b/slither/tools/mutator/mutators/LIR.py
@@ -36,7 +36,7 @@ class LIR(AbstractMutator):
                     stop = start + variable.source_mapping.length
                     old_str = variable.source_mapping.content
                     line_no = variable.node_initialization.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         for value in literal_replacements:
                             old_value = old_str[old_str.find("=") + 1 :].strip()
                             if old_value != value:
@@ -67,7 +67,7 @@ class LIR(AbstractMutator):
                     stop = start + variable.source_mapping.length
                     old_str = variable.source_mapping.content
                     line_no = variable.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         for new_value in literal_replacements:
                             old_value = old_str[old_str.find("=") + 1 :].strip()
                             if old_value != new_value:

--- a/slither/tools/mutator/mutators/MVIE.py
+++ b/slither/tools/mutator/mutators/MVIE.py
@@ -27,7 +27,7 @@ class MVIE(AbstractMutator):
                     old_str = variable.source_mapping.content
                     new_str = old_str[: old_str.find("=")]
                     line_no = variable.node_initialization.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         create_patch_with_line(
                             result,
                             self.in_file,
@@ -49,7 +49,7 @@ class MVIE(AbstractMutator):
                     old_str = variable.source_mapping.content
                     new_str = old_str[: old_str.find("=")]
                     line_no = variable.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         create_patch_with_line(
                             result,
                             self.in_file,

--- a/slither/tools/mutator/mutators/MVIV.py
+++ b/slither/tools/mutator/mutators/MVIV.py
@@ -27,7 +27,7 @@ class MVIV(AbstractMutator):
                     old_str = variable.source_mapping.content
                     new_str = old_str[: old_str.find("=")]
                     line_no = variable.node_initialization.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         create_patch_with_line(
                             result,
                             self.in_file,
@@ -48,7 +48,7 @@ class MVIV(AbstractMutator):
                     old_str = variable.source_mapping.content
                     new_str = old_str[: old_str.find("=")]
                     line_no = variable.source_mapping.lines
-                    if not line_no[0] in self.dont_mutate_line:
+                    if line_no[0] not in self.dont_mutate_line:
                         create_patch_with_line(
                             result,
                             self.in_file,

--- a/slither/tools/mutator/mutators/UOR.py
+++ b/slither/tools/mutator/mutators/UOR.py
@@ -27,7 +27,7 @@ class UOR(AbstractMutator):
                     continue
                 try:
                     ir_expression = node.expression
-                except:
+                except AttributeError:
                     continue
                 start = node.source_mapping.start
                 stop = start + node.source_mapping.length

--- a/slither/tools/mutator/mutators/abstract_mutator.py
+++ b/slither/tools/mutator/mutators/abstract_mutator.py
@@ -72,7 +72,7 @@ class AbstractMutator(metaclass=abc.ABCMeta):
 
     def should_mutate_node(self, node) -> bool:
         return (
-            not node.source_mapping.lines[0] in self.dont_mutate_line
+            node.source_mapping.lines[0] not in self.dont_mutate_line
             and node.source_mapping.filename.absolute == self.in_file
         )
 

--- a/slither/tools/mutator/utils/file_handling.py
+++ b/slither/tools/mutator/utils/file_handling.py
@@ -30,7 +30,7 @@ def transfer_and_delete(files_dict: Dict[str, HashedPath]) -> None:
     try:
         files_dict_copy = files_dict.copy()
         for original_path, hashed_path in files_dict_copy.items():
-            with open(hashed_path, "r", encoding="utf8") as duplicated_file:
+            with open(hashed_path, encoding="utf8") as duplicated_file:
                 content = duplicated_file.read()
 
             with open(original_path, "w", encoding="utf8") as original_file:
@@ -85,7 +85,7 @@ def reset_file(file: str) -> None:
     """function to reset the file"""
     try:
         # reset the file
-        with open(backuped_files[file], "r", encoding="utf8") as duplicated_file:
+        with open(backuped_files[file], encoding="utf8") as duplicated_file:
             duplicate_content = duplicated_file.read()
 
         with open(file, "w", encoding="utf8") as source_file:

--- a/slither/tools/mutator/utils/testing_generated_mutant.py
+++ b/slither/tools/mutator/utils/testing_generated_mutant.py
@@ -18,7 +18,7 @@ def compile_generated_mutant(file_path: str, mappings: str) -> bool:
     try:
         crytic_compile.CryticCompile(file_path, solc_remaps=mappings)
         return True
-    except:
+    except Exception:
         return False
 
 
@@ -37,15 +37,14 @@ def run_test_cmd(
     if "forge test" in cmd and "--fail-fast" not in cmd:
         cmd += " --fail-fast"
     # add --bail for hardhat and truffle tests, to exit after first failure
-    elif "hardhat test" in cmd or "truffle test" in cmd and "--bail" not in cmd:
+    elif "hardhat test" in cmd or ("truffle test" in cmd and "--bail" not in cmd):
         cmd += " --bail"
 
     try:
         result = subprocess.run(
             cmd,
             shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
             check=False,  # True: Raises a CalledProcessError if the return code is non-zero
         )

--- a/slither/tools/properties/properties/erc20.py
+++ b/slither/tools/properties/properties/erc20.py
@@ -89,7 +89,7 @@ def generate_erc20(contract: Contract, type_property: str, addresses: Addresses)
         logger.error(red(errors))
         return
 
-    erc_properties = ERC20_PROPERTIES.get(type_property, None)
+    erc_properties = ERC20_PROPERTIES.get(type_property)
     if erc_properties is None:
         logger.error(f"{type_property} unknown. Types available {ERC20_PROPERTIES.keys()}")
         return

--- a/slither/tools/read_storage/read_storage.py
+++ b/slither/tools/read_storage/read_storage.py
@@ -185,7 +185,7 @@ class SlitherReadStorage:
                     )
                     self.log += (
                         f"\nSlot Name: {var_name}\nType: bytes32"
-                        f"\nStorage Type: {type_string}\nSlot: {str(exp)}\n"
+                        f"\nStorage Type: {type_string}\nSlot: {exp!s}\n"
                     )
                     logger.info(self.log)
                     self.log = ""
@@ -213,9 +213,9 @@ class SlitherReadStorage:
             (`SlotInfo`) | None : A dictionary of the slot information.
         """
 
-        key: Optional[int] = kwargs.get("key", None)
-        deep_key: Optional[int] = kwargs.get("deep_key", None)
-        struct_var: Optional[str] = kwargs.get("struct_var", None)
+        key: Optional[int] = kwargs.get("key")
+        deep_key: Optional[int] = kwargs.get("deep_key")
+        struct_var: Optional[str] = kwargs.get("struct_var")
         info: str
         var_log_name = target_variable.name
         try:

--- a/slither/tools/similarity/encode.py
+++ b/slither/tools/similarity/encode.py
@@ -152,9 +152,9 @@ def encode_ir(ir):
     if isinstance(ir, Length):
         return "length"
     if isinstance(ir, Binary):
-        return f"binary({str(ir.type)})"
+        return f"binary({ir.type!s})"
     if isinstance(ir, Unary):
-        return f"unary({str(ir.type)})"
+        return f"unary({ir.type!s})"
     if isinstance(ir, Condition):
         return f"condition({encode_ir(ir.value)})"
     if isinstance(ir, NewStructure):

--- a/slither/tools/slither_format/slither_format.py
+++ b/slither/tools/slither_format/slither_format.py
@@ -59,28 +59,23 @@ def slither_format(slither: Slither, **kwargs: Dict) -> None:
     logger.info(yellow("slither-format is in beta, carefully review each patch before merging it."))
 
     for result in detector_results:
-        if not "patches" in result:
+        if "patches" not in result:
             continue
         one_line_description = result["description"].split("\n")[0]
 
         export_result = Path(export, f"{counter_result}")
         export_result.mkdir(parents=True, exist_ok=True)
         counter_result += 1
-        counter = 0
 
         logger.info(f"Issue: {one_line_description}")
         logger.info(f"Generated: ({export_result})")
 
-        for (
-            _,
-            diff,
-        ) in result["patches_diff"].items():
+        for counter, (_, diff) in enumerate(result["patches_diff"].items()):
             filename = f"fix_{counter}.patch"
             path = Path(export_result, filename)
             logger.info(f"\t- {filename}")
             with open(path, "w", encoding="utf8") as f:
                 f.write(diff)
-            counter += 1
 
 
 # endregion

--- a/slither/tools/upgradeability/checks/initialization.py
+++ b/slither/tools/upgradeability/checks/initialization.py
@@ -43,7 +43,7 @@ def _get_most_derived_init(contract):
     init_functions = [f for f in contract.functions if not f.is_shadowed and f.name == "initialize"]
     if len(init_functions) > 1:
         if len([f for f in init_functions if f.contract_declarer == contract]) == 1:
-            return next((f for f in init_functions if f.contract_declarer == contract))
+            return next(f for f in init_functions if f.contract_declarer == contract)
         raise MultipleInitTarget
     if init_functions:
         return init_functions[0]
@@ -273,7 +273,7 @@ Ensure all the initialize functions are reached by the most derived initialize f
 
         all_init_functions = _get_initialize_functions(self.contract)
         all_init_functions_called = _get_all_internal_calls(most_derived_init) + [most_derived_init]
-        missing_calls = [f for f in all_init_functions if not f in all_init_functions_called]
+        missing_calls = [f for f in all_init_functions if f not in all_init_functions_called]
         for f in missing_calls:
             # we don't account reinitializers
             if any((m.name == "reinitializer") for m in f.modifiers):

--- a/slither/utils/ck.py
+++ b/slither/utils/ck.py
@@ -134,7 +134,7 @@ class CKContractMetrics:
             public = func.visibility == "public"
             internal = func.visibility == "internal"
             private = func.visibility == "private"
-            external_public_mutating = external or public and mutating
+            external_public_mutating = external or (public and mutating)
             external_no_auth = external_public_mutating and not has_auth(func)
             external_no_modifiers = external_public_mutating and len(func.modifiers) == 0
             if external or public:

--- a/slither/utils/code_complexity.py
+++ b/slither/utils/code_complexity.py
@@ -30,8 +30,8 @@ def compute_strongly_connected_components(function: "Function") -> List[List["No
     Returns:
         list(list(nodes))
     """
-    visited = {n: False for n in function.nodes}
-    assigned = {n: False for n in function.nodes}
+    visited = dict.fromkeys(function.nodes, False)
+    assigned = dict.fromkeys(function.nodes, False)
     components = []
     l = []
 

--- a/slither/utils/code_generation.py
+++ b/slither/utils/code_generation.py
@@ -61,7 +61,7 @@ def generate_interface(
         structs = contract.structures + contract.compilation_unit.structures_top_level
         # Function signatures may reference other structures as well
         # Include structures defined in libraries used for them
-        for _for in contract.using_for.keys():
+        for _for in contract.using_for:
             if (
                 isinstance(_for, UserDefinedType)
                 and isinstance(_for.type, StructureContract)
@@ -183,7 +183,7 @@ def generate_interface_function_signature(
             )
         if isinstance(var.type, UserDefinedType):
             if isinstance(var.type.type, Structure):
-                return f"{str(var.type.type)} memory"
+                return f"{var.type.type!s} memory"
             if isinstance(var.type.type, Enum):
                 return str(var.type.type)
             if isinstance(var.type.type, Contract):

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -123,7 +123,7 @@ def output_to_markdown(
         # dont show the backdoor example
         if argument == "backdoor":
             continue
-        if not filter_wiki in detector.WIKI:
+        if filter_wiki not in detector.WIKI:
             continue
         help_info = extract_help(detector)
         impact = detector.IMPACT
@@ -236,7 +236,7 @@ def output_wiki(detector_classes: List[Type[AbstractDetector]], filter_wiki: str
         # dont show the backdoor example
         if argument == "backdoor":
             continue
-        if not filter_wiki in detector.WIKI:
+        if filter_wiki not in detector.WIKI:
             continue
         check = detector.ARGUMENT
         impact = classification_txt[detector.IMPACT]

--- a/slither/utils/comparable_enum.py
+++ b/slither/utils/comparable_enum.py
@@ -21,7 +21,7 @@ class ComparableEnum(Enum):
         return False
 
     def __repr__(self) -> str:
-        return f"{str(self.value)}"
+        return f"{self.value!s}"
 
     def __hash__(self) -> int:
         return hash(self.value)

--- a/slither/utils/encoding.py
+++ b/slither/utils/encoding.py
@@ -98,7 +98,7 @@ def encode_ir_for_upgradeability_compare(ir: operations.Operation) -> str:
     if isinstance(ir, operations.Binary):
         return f"binary({encode_var_for_compare(ir.variable_left)}{ir.type}{encode_var_for_compare(ir.variable_right)})"
     if isinstance(ir, operations.Unary):
-        return f"unary({str(ir.type)})"
+        return f"unary({ir.type!s})"
     if isinstance(ir, operations.Condition):
         return f"condition({encode_var_for_compare(ir.value)})"
     if isinstance(ir, operations.NewStructure):
@@ -153,9 +153,9 @@ def encode_ir_for_halstead(ir: operations.Operation) -> str:
     if isinstance(ir, operations.Length):
         return "length"
     if isinstance(ir, operations.Binary):
-        return f"binary({str(ir.type)})"
+        return f"binary({ir.type!s})"
     if isinstance(ir, operations.Unary):
-        return f"unary({str(ir.type)})"
+        return f"unary({ir.type!s})"
     if isinstance(ir, operations.Condition):
         return f"condition({encode_var_for_compare(ir.value)})"
     if isinstance(ir, operations.NewStructure):

--- a/slither/utils/output.py
+++ b/slither/utils/output.py
@@ -87,7 +87,7 @@ def _output_result_to_sarif(
     elif detector["impact"] == "Low":
         risk = "3.0"
 
-    detector_class = next((d for d in detectors_classes if d.ARGUMENT == detector["check"]))
+    detector_class = next(d for d in detectors_classes if detector["check"] == d.ARGUMENT)
     check_id = (
         str(detector_class.IMPACT.value)
         + "-"
@@ -239,7 +239,7 @@ def _convert_to_description(d: str) -> str:
     if isinstance(d, Node):
         if d.expression:
             return f"{d.expression} ({d.source_mapping})"
-        return f"{str(d)} ({d.source_mapping})"
+        return f"{d!s} ({d.source_mapping})"
 
     if hasattr(d, "canonical_name"):
         return f"{d.canonical_name} ({d.source_mapping})"
@@ -260,7 +260,7 @@ def _convert_to_markdown(d: str, markdown_root: str) -> str:
     if isinstance(d, Node):
         if d.expression:
             return f"[{d.expression}]({d.source_mapping.to_markdown(markdown_root)})"
-        return f"[{str(d)}]({d.source_mapping.to_markdown(markdown_root)})"
+        return f"[{d!s}]({d.source_mapping.to_markdown(markdown_root)})"
 
     if hasattr(d, "canonical_name"):
         return f"[{d.canonical_name}]({d.source_mapping.to_markdown(markdown_root)})"
@@ -286,7 +286,7 @@ def _convert_to_id(d: str) -> str:
     if isinstance(d, Node):
         if d.expression:
             return f"{d.expression} ({d.source_mapping})"
-        return f"{str(d)} ({d.source_mapping})"
+        return f"{d!s} ({d.source_mapping})"
 
     if isinstance(d, Pragma):
         return f"{d} ({d.source_mapping})"

--- a/slither/utils/standard_libraries.py
+++ b/slither/utils/standard_libraries.py
@@ -211,7 +211,7 @@ def _is_ds(contract: "Contract", name: str) -> bool:
 def _is_dappdhub_ds(contract: "Contract", name: str) -> bool:
     if not contract.is_from_dependency():
         return False
-    if not dapphubs[name] in Path(contract.source_mapping.filename.absolute).parts:
+    if dapphubs[name] not in Path(contract.source_mapping.filename.absolute).parts:
         return False
     return _is_ds(contract, name)
 

--- a/slither/utils/tests_pattern.py
+++ b/slither/utils/tests_pattern.py
@@ -30,7 +30,7 @@ def is_test_file(path: Path) -> bool:
     :param path:
     :return:
     """
-    return any((test_pattern in path.parts for test_pattern in TESTS_PATTERNS))
+    return any(test_pattern in path.parts for test_pattern in TESTS_PATTERNS)
 
 
 def is_test_contract(contract: "Contract") -> bool:

--- a/slither/visitors/expression/constants_folding.py
+++ b/slither/visitors/expression/constants_folding.py
@@ -252,8 +252,10 @@ class ConstantFolding(ExpressionVisitor):
             and len(expression.arguments) == 1
             and (
                 isinstance(expression.arguments[0], ElementaryTypeNameExpression)
-                or isinstance(expression.arguments[0], Identifier)
-                and isinstance(expression.arguments[0].value, Enum)
+                or (
+                    isinstance(expression.arguments[0], Identifier)
+                    and isinstance(expression.arguments[0].value, Enum)
+                )
             )
         ):
             # Returning early to support type(ElemType).max/min or type(MyEnum).max/min

--- a/slither/visitors/expression/expression.py
+++ b/slither/visitors/expression/expression.py
@@ -25,7 +25,7 @@ from slither.exceptions import SlitherError
 logger = logging.getLogger("ExpressionVisitor")
 
 
-@lru_cache()
+@lru_cache
 def get_visitor_mapping():
     """Returns a visitor mapping from expression type to visiting functions."""
     return {

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -189,7 +189,7 @@ class ExpressionToSlithIR(ExpressionVisitor):
                 assert len(left) == len(right)
                 for idx, _ in enumerate(left):
                     if (
-                        not left[idx] is None
+                        left[idx] is not None
                         and expression.type
                         and expression.expression_return_type
                     ):
@@ -205,7 +205,7 @@ class ExpressionToSlithIR(ExpressionVisitor):
             else:
                 assert isinstance(right, TupleVariable)
                 for idx, _ in enumerate(left):
-                    if not left[idx] is None:
+                    if left[idx] is not None:
                         index = idx
                         operation = Unpack(left[idx], right, index)
                         operation.set_expression(expression)

--- a/tests/e2e/solc_parsing/test_ast_parsing.py
+++ b/tests/e2e/solc_parsing/test_ast_parsing.py
@@ -528,7 +528,7 @@ class TestASTParsing:
         actual = generate_output(sl)
 
         assert os.path.isfile(expected), f"Expected file {expected} does not exist"
-        with open(expected, "r", encoding="utf8") as f:
+        with open(expected, encoding="utf8") as f:
             expected = json.load(f)
 
         diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2, view="tree")

--- a/tests/tools/read-storage/test_read_storage.py
+++ b/tests/tools/read-storage/test_read_storage.py
@@ -13,7 +13,7 @@ TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 
 
 def get_source_file(file_path) -> str:
-    with open(file_path, "r", encoding="utf8") as f:
+    with open(file_path, encoding="utf8") as f:
         source = f.read()
 
     return source
@@ -73,9 +73,9 @@ def test_read_storage(test_contract, storage_file, web3, ganache, solc_binary_pa
 
     expected_file = Path(TEST_DATA_DIR, f"TEST_{storage_file}.json").as_posix()
 
-    with open(expected_file, "r", encoding="utf8") as f:
+    with open(expected_file, encoding="utf8") as f:
         expected = json.load(f)
-    with open(actual_file, "r", encoding="utf8") as f:
+    with open(actual_file, encoding="utf8") as f:
         actual = json.load(f)
 
     diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2, view="tree")

--- a/tests/unit/core/test_using_for.py
+++ b/tests/unit/core/test_using_for.py
@@ -112,13 +112,13 @@ def test_using_for_constant_folding(slither_from_solidity_source) -> None:
     # https://github.com/crytic/slither/issues/2307
     source = """
             library SafeMath {
-            uint256 private constant twelve = 12; 
+            uint256 private constant twelve = 12;
             struct A {uint256 a;}
             function add(A[twelve] storage z) internal { }
         }
 
         contract MathContract {
-            uint256 private constant twelve = 12; 
+            uint256 private constant twelve = 12;
             using SafeMath for SafeMath.A[twelve];
             SafeMath.A[twelve] public z;
             function safeAdd() public {

--- a/tests/unit/core/test_virtual_overrides.py
+++ b/tests/unit/core/test_virtual_overrides.py
@@ -16,9 +16,11 @@ def test_overrides(solc_binary_path) -> None:
     assert len(x) == 0
     x = test_virtual_func.overridden_by
     assert len(x) == 5
-    assert set(i.canonical_name for i in x) == set(
-        ["A.myVirtualFunction()", "C.myVirtualFunction()", "X.myVirtualFunction()"]
-    )
+    assert set(i.canonical_name for i in x) == {
+        "A.myVirtualFunction()",
+        "C.myVirtualFunction()",
+        "X.myVirtualFunction()",
+    }
 
     a = slither.get_contract_from_name("A")[0]
     a_virtual_func = a.get_function_from_full_name("myVirtualFunction()")
@@ -26,7 +28,7 @@ def test_overrides(solc_binary_path) -> None:
     assert a_virtual_func.is_override
     x = a.get_functions_overridden_by(a_virtual_func)
     assert len(x) == 2
-    assert set(i.canonical_name for i in x) == set(["Test.myVirtualFunction()"])
+    assert set(i.canonical_name for i in x) == {"Test.myVirtualFunction()"}
 
     b = slither.get_contract_from_name("B")[0]
     b_virtual_func = b.get_function_from_full_name("myVirtualFunction()")
@@ -34,7 +36,7 @@ def test_overrides(solc_binary_path) -> None:
     assert b_virtual_func.is_override
     x = b.get_functions_overridden_by(b_virtual_func)
     assert len(x) == 2
-    assert set(i.canonical_name for i in x) == set(["A.myVirtualFunction()"])
+    assert set(i.canonical_name for i in x) == {"A.myVirtualFunction()"}
     assert len(b_virtual_func.overridden_by) == 0
 
     c = slither.get_contract_from_name("C")[0]
@@ -44,7 +46,7 @@ def test_overrides(solc_binary_path) -> None:
     x = c.get_functions_overridden_by(c_virtual_func)
     assert len(x) == 2
     # C should not override B as they are distinct leaves in the inheritance tree
-    assert set(i.canonical_name for i in x) == set(["Test.myVirtualFunction()"])
+    assert set(i.canonical_name for i in x) == {"Test.myVirtualFunction()"}
 
     y = slither.get_contract_from_name("Y")[0]
     y_virtual_func = y.get_function_from_full_name("myVirtualFunction()")
@@ -60,9 +62,7 @@ def test_overrides(solc_binary_path) -> None:
     assert z_virtual_func.is_override
     x = z.get_functions_overridden_by(z_virtual_func)
     assert len(x) == 4
-    assert set(i.canonical_name for i in x) == set(
-        ["Y.myVirtualFunction()", "X.myVirtualFunction()"]
-    )
+    assert set(i.canonical_name for i in x) == {"Y.myVirtualFunction()", "X.myVirtualFunction()"}
 
     k = slither.get_contract_from_name("K")[0]
     k_virtual_func = k.get_function_from_full_name("a()")
@@ -70,7 +70,7 @@ def test_overrides(solc_binary_path) -> None:
     assert k_virtual_func.is_override
     assert len(k_virtual_func.overrides) == 3
     x = k_virtual_func.overrides
-    assert set(i.canonical_name for i in x) == set(["I.a()"])
+    assert set(i.canonical_name for i in x) == {"I.a()"}
 
     i = slither.get_contract_from_name("I")[0]
     i_virtual_func = i.get_function_from_full_name("a()")

--- a/tests/unit/slithir/test_ssa_generation.py
+++ b/tests/unit/slithir/test_ssa_generation.py
@@ -206,13 +206,10 @@ def phi_values_inserted(f: Function) -> None:
         non_ssa = var.non_ssa_version
         for ssa in node.irs_ssa:
             if isinstance(ssa, Phi):
-                if non_ssa in map(
-                    lambda ssa_var: ssa_var.non_ssa_version,
-                    [
-                        r
-                        for r in ssa.read
-                        if isinstance(r, (StateIRVariable, LocalIRVariable, TemporaryVariableSSA))
-                    ],
+                if non_ssa in (
+                    r.non_ssa_version
+                    for r in ssa.read
+                    if isinstance(r, (StateIRVariable, LocalIRVariable, TemporaryVariableSSA))
                 ):
                     return True
         return False
@@ -730,7 +727,7 @@ def test_shadow_local(slither_from_solidity_source):
 
         # Ensure all assignments are to a variable of index 1
         # not using the same IR var.
-        assert all(map(lambda x: x.lvalue.index == 1, get_ssa_of_type(f, Assignment)))
+        assert all(x.lvalue.index == 1 for x in get_ssa_of_type(f, Assignment))
 
 
 @pytest.mark.xfail(strict=True, reason="Fails in current slither version. Fix in #1102.")
@@ -755,10 +752,8 @@ def test_multiple_named_args_returns(slither_from_solidity_source):
 
         # Ensure all LocalIRVariables (not TemporaryVariables) have index 1
         assert all(
-            map(
-                lambda x: x.lvalue.index == 1 or not isinstance(x.lvalue, LocalIRVariable),
-                get_ssa_of_type(f, OperationWithLValue),
-            )
+            x.lvalue.index == 1 or not isinstance(x.lvalue, LocalIRVariable)
+            for x in get_ssa_of_type(f, OperationWithLValue)
         )
 
 

--- a/tests/unit/utils/test_code_generation.py
+++ b/tests/unit/utils/test_code_generation.py
@@ -17,7 +17,7 @@ def test_interface_generation(solc_binary_path) -> None:
     actual = generate_interface(sl.get_contract_from_name("TestContract")[0])
     expected_path = Path(TEST_DATA_DIR, "TEST_generated_code.sol").as_posix()
 
-    with open(expected_path, "r", encoding="utf-8") as file:
+    with open(expected_path, encoding="utf-8") as file:
         expected = file.read()
 
     assert actual == expected
@@ -25,7 +25,7 @@ def test_interface_generation(solc_binary_path) -> None:
     actual = generate_interface(sl.get_contract_from_name("TestContract")[0], unroll_structs=False)
     expected_path = os.path.join(TEST_DATA_DIR, "TEST_generated_code_not_unrolled.sol")
 
-    with open(expected_path, "r", encoding="utf-8") as file:
+    with open(expected_path, encoding="utf-8") as file:
         expected = file.read()
 
     assert actual == expected


### PR DESCRIPTION
## Summary

- Enable 34 ruff lint rules that were previously ignored
- Apply auto-fixes across 92 files
- Add per-file ignore for `slither/detectors/source/rtlo.py` (E101) for intentional mixed indentation

## Rules Enabled

| Category | Rules |
|----------|-------|
| Code style | E713, E714, E721, E722 |
| Comprehensions | C414, C416, C417 |
| Pyupgrade | UP008, UP015, UP018, UP022, UP028, UP030, UP031, UP032, UP034, UP039 |
| Simplify | SIM113, SIM115, SIM118, SIM201, SIM202, SIM208, SIM210, SIM212, SIM220, SIM221, SIM222, SIM223, SIM300, SIM910, SIM911 |
| Ruff | RUF100 |

## Key Transformations

- `not x in y` → `x not in y`
- `sorted(list(...))` → `sorted(...)`
- `except:` → `except Exception:` (or specific types)
- `subprocess.PIPE` → `capture_output=True`
- Manual counters → `enumerate()`
- `super(Cls, self)` → `super()`
- `"".format()` → f-strings

## Test plan

- [x] All unit tests pass (82 passed, 5 skipped/Vyper-related)
- [x] All e2e tests pass (6,976 passed, 12 errors are missing vyper binary)
- [x] All tool tests pass (12 passed, 2 errors are missing ganache)
- [x] `ruff check .` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)