### PR TITLE
fix: add fasttext as optional dependency for slither-simil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "eth-utils>=5.0.0",
 ]
 
+[project.optional-dependencies]
+simil = ["fasttext>=0.9.0"]
+
 # Development dependencies using PEP 735 dependency-groups
 [dependency-groups]
 lint = [

--- a/slither/tools/similarity/model.py
+++ b/slither/tools/similarity/model.py
@@ -4,6 +4,8 @@ try:
     from fasttext import load_model
     from fasttext import train_unsupervised
 except ImportError:
-    print("ERROR: in order to use slither-simil, you need to install fasttext>=0.2.0:")
-    print("$ pip3 install fasttext --user\n")
+    print("ERROR: slither-simil requires fasttext. Install with:")
+    print("  pip install slither-analyzer[simil]")
+    print("  # or: uv pip install slither-analyzer[simil]")
+    print("  # or add fasttext to existing install: pip install fasttext")
     sys.exit(-1)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1172,6 +1172,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fasttext"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pybind11" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/3b/9a10b95eaf565358339162848863197c3f0a29b540ca22b2951df2d66a48/fasttext-0.9.3.tar.gz", hash = "sha256:eb03f2ef6340c6ac9e4398a30026f05471da99381b307aafe2f56e4cd26baaef", size = 73439, upload-time = "2024-06-12T09:44:42.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/f2/8d3c5969c4cca40752b9da43978b5c65b74a2eab48a2964dacfd2a53c5d5/fasttext-0.9.3-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:8b39f3ac5df43873648ea400cb75d4f7f9455730ac5105490b23b70f14e03ea7", size = 282837, upload-time = "2024-06-12T09:44:40.646Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2278,6 +2294,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pybind11"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/7b/a6d8dcb83c457e24a9df1e4d8fd5fb8034d4bbc62f3c324681e8a9ba57c2/pybind11-3.0.1.tar.gz", hash = "sha256:9c0f40056a016da59bab516efb523089139fcc6f2ba7e4930854c61efb932051", size = 546914, upload-time = "2025-08-22T20:09:27.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl", hash = "sha256:aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89", size = 293611, upload-time = "2025-08-22T20:09:25.235Z" },
+]
+
+[[package]]
 name = "pycryptodome"
 version = "3.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2830,6 +2855,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
 name = "slither-analyzer"
 version = "0.11.4"
 source = { editable = "." }
@@ -2844,6 +2878,11 @@ dependencies = [
     { name = "prettytable", version = "3.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pycryptodome" },
     { name = "web3" },
+]
+
+[package.optional-dependencies]
+simil = [
+    { name = "fasttext" },
 ]
 
 [package.dev-dependencies]
@@ -2895,12 +2934,14 @@ requires-dist = [
     { name = "eth-abi", specifier = ">=5.0.1" },
     { name = "eth-typing", specifier = ">=5.0.0" },
     { name = "eth-utils", specifier = ">=5.0.0" },
+    { name = "fasttext", marker = "extra == 'simil'", specifier = ">=0.9.0" },
     { name = "importlib-metadata", specifier = ">=3.6" },
     { name = "packaging" },
     { name = "prettytable", specifier = ">=3.10.2" },
     { name = "pycryptodome", specifier = ">=3.4.6" },
     { name = "web3", specifier = ">=7.10,<8" },
 ]
+provides-extras = ["simil"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Add `simil` optional dependency extra containing `fasttext>=0.9.0`
- Update error message in `slither-simil` to show new installation methods

Users can now install with:
```bash
pip install slither-analyzer[simil]
uv pip install slither-analyzer[simil]
uv tool install slither-analyzer[simil]
```

Fixes #2621

## Test plan
- [ ] Verify `pip install slither-analyzer[simil]` installs fasttext
- [ ] Verify `slither-simil` runs without import error after installation
- [ ] Verify error message displays correctly when fasttext is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)