### PR TITLE
perf: cache functions_and_modifiers property

### DIFF
--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -119,6 +119,7 @@ class Contract(SourceMapping):
         self._state_variables_used_in_reentrant_targets: (
             dict[StateVariable, set[StateVariable | Function]] | None
         ) = None
+        self._functions_and_modifiers_cached: list[Function] | None = None
 
         self._comments: str | None = None
 
@@ -730,7 +731,10 @@ class Contract(SourceMapping):
         """
         list(Function|Modifier): List of the functions and modifiers
         """
-        return self.functions + self.modifiers  # type: ignore
+        if self._functions_and_modifiers_cached is None:
+            result: list[Function] = self.functions + self.modifiers  # type: ignore
+            self._functions_and_modifiers_cached = result
+        return self._functions_and_modifiers_cached
 
     @property
     def functions_and_modifiers_inherited(self) -> list["Function"]:


### PR DESCRIPTION
## Summary
- Memoize the `functions_and_modifiers` property to avoid list concatenation on every access

## Problem
The `functions_and_modifiers` property created a new combined list (`self.functions + self.modifiers`) on every access.

## Solution
- Added `_functions_and_modifiers_cached` field
- Added memoization to `functions_and_modifiers` property

## Impact
- Complexity: O(n) → O(1) for repeated access
- Expected improvement: Small but noticeable in tight loops over contract members

## Test Plan
- [x] `uv run ruff check` passes
- [x] `uv run python -c "from slither import Slither"` works

🤖 Generated with [Claude Code](https://claude.ai/code)