### PR TITLE
Fix AssertionError crash in reorder_arguments for misresolved structs

### DIFF
--- a/tests/unit/slithir/test_data/argument_reorder/test_same_name_structs.sol
+++ b/tests/unit/slithir/test_data/argument_reorder/test_same_name_structs.sol
@@ -1,0 +1,25 @@
+// Regression test for https://github.com/crytic/slither/issues/2217
+// Two contracts define structs with the same name but different field counts.
+// Slither must not crash when processing named struct constructor arguments.
+contract A {
+    struct S {
+        int x;
+    }
+
+    function test() external pure returns (int) {
+        S memory p = S({x: 1});
+        return p.x;
+    }
+}
+
+contract B {
+    struct S {
+        int x;
+        int y;
+    }
+
+    function test() external pure returns (int) {
+        S memory p = S({y: 4, x: 5});
+        return p.x + p.y;
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the strict assertion in `reorder_arguments` with a filter that skips mismatched `decl_names` entries and returns args unmodified when no entry matches.
- Add a bounds check in `convert_constant_types` for the same scenario (`IndexError` on `st.elems_ordered[idx]`).

## Root cause

`reorder_arguments` crashes with an `AssertionError` when `decl_names` contains entries whose length doesn't match the call argument count. This happens when Slither misresolves a struct to a same-named struct with a different number of fields (e.g. two structs named `PlasmaVaultAddress` in different files, one with 7 fields and one with 1).

Fixes #2217