### PR TITLE
remove public backdoor allowing ownership takeover

### DIFF
--- a/examples/printers/human_printer.sol
+++ b/examples/printers/human_printer.sol
@@ -164,9 +164,4 @@ contract SimpleVulnerableToken{
     emit MintFinished();
     return true;
   }
-
-  function backdoor() public{
-    owner = msg.sender;
-    mintingFinished = false;
-  }
 }


### PR DESCRIPTION
Removes a public backdoor that allowed any caller to take ownership
of the example token contract and re-enable minting.

An attacker could call backdoor() to become owner and mint unlimited tokens,
which breaks the ownership and supply model of the token.
