### PR TITLE
fix: guard against None func in convert_type_of_high_and_internal_level_call (#2375)

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1818,6 +1818,9 @@ def convert_type_of_high_and_internal_level_call(
         to_log = f"Function not found {ir.function_name}"
         logger.error(to_log)
     ir.function = func
+    if func is None:
+        ir.lvalue = None
+        return None
     if isinstance(func, Function):
         return_type = func.return_type
         # if its not a tuple; return a singleton


### PR DESCRIPTION
## Summary

Fixes #2375.

**Root cause:** Vyper interface calls with default arguments (e.g. `def price_oracle(i: uint256 = 0)`) omit the argument when calling (`Pool(a).price_oracle()`). The function lookup filters by `len(f.parameters) == len(ir.arguments)`, so the interface function is excluded. `func` remains None, but the code then accessed `func.type`, causing `AttributeError: 'NoneType' object has no attribute 'type'`.

**Fix:** Add a guard when `func` is None: set `ir.lvalue = None` and return early instead of accessing `func.type`.

## Changes

- `slither/slithir/convert.py`: Add `if func is None` check before accessing `func.type` in `convert_type_of_high_and_internal_level_call`

## Testing

- Verified the fix addresses the reported scenario: Vyper contract with interface `def price_oracle(i: uint256 = 0)` and call `Pool(a).price_oracle()` no longer crashes
- Change is minimal (3 lines) and follows existing error-handling pattern
- No unrelated changes included

Made with [Cursor](https://cursor.com)