### PR TITLE
fix: resolve shadowed modifiers via IdentifierPath

### DIFF
--- a/slither/solc_parsing/expressions/find_variable.py
+++ b/slither/solc_parsing/expressions/find_variable.py
@@ -55,6 +55,7 @@ def _find_variable_from_ref_declaration(
     all_functions: list["Function"],
     function_parser: Optional["FunctionSolc"],
     contract_declarer: Optional["Contract"],
+    is_identifier_path: bool = False,
 ) -> Contract | Function | None:
     """
     Reference declarations take the highest priority, but they are not available for legacy AST.
@@ -77,7 +78,9 @@ def _find_variable_from_ref_declaration(
         if contract_candidate and contract_candidate.id == referenced_declaration:
             return contract_candidate
     for function_candidate in all_functions:
-        if function_candidate.id == referenced_declaration and not function_candidate.is_shadowed:
+        if function_candidate.id == referenced_declaration and (
+            is_identifier_path or not function_candidate.is_shadowed
+        ):
             return function_candidate
     return None
 
@@ -445,6 +448,7 @@ def find_variable(
         direct_functions,
         function_parser,
         contract_declarer,
+        is_identifier_path,
     )
     if ret0:
         return ret0, False


### PR DESCRIPTION
## Summary

Fixes #2838

When a modifier is referenced via `IdentifierPath` (e.g. `A.m` in `function f() public A.m`), the compiler resolves the exact declaration id via `referencedDeclaration`. However, `_find_variable_from_ref_declaration` was filtering out matches where `is_shadowed` is true — which incorrectly rejected parent modifiers that are overridden by a child contract.

Since `referencedDeclaration` is the compiler's authoritative resolution, we should trust it without filtering by `is_shadowed`. The shadowed filter is appropriate for name-based lookups (where you want the most-derived version), but not when looking up by compiler-resolved id.

### Before

```
ERROR:ContractSolcParsing:Missing function Variable not found: A.m (context C)
```

### After

Parses correctly, no error.

## Reproducer

```solidity
contract A {
    modifier m() virtual { _; }
}

contract C is A {
    modifier m() override { _; }
    function f() public A.m returns (uint) { return 1; }
}
```

## Test plan

- Verified fix resolves the exact reproducer from #2838
- All 6593 AST parsing tests pass
- All 150 modifier-related parsing tests pass