### PR TITLE
Fix function-summary printer incorrectly classifying internal calls as external

### DIFF
--- a/slither/core/declarations/function_contract.py
+++ b/slither/core/declarations/function_contract.py
@@ -102,8 +102,10 @@ class FunctionContract(Function, ContractLevel):
             Return the function summary
         Returns:
             (str, str, str, list(str), list(str), listr(str), list(str), list(str);
-            contract_name, name, visibility, modifiers, vars read, vars written, internal_calls, external_calls_as_expressions
+            contract_name, name, visibility, modifiers, vars read, vars written, internal_calls, external_calls
         """
+        from slither.slithir.operations import LibraryCall
+
         return (
             self.contract_declarer.name,
             self.full_name,
@@ -112,7 +114,11 @@ class FunctionContract(Function, ContractLevel):
             [str(x) for x in self.state_variables_read + self.solidity_variables_read],
             [str(x) for x in self.state_variables_written],
             [str(x) for x in self.internal_calls],
-            [str(x) for x in self.external_calls_as_expressions],
+            [
+                str(ir.expression)
+                for (_, ir) in self.high_level_calls
+                if not isinstance(ir, LibraryCall)
+            ],
             compute_cyclomatic_complexity(self),
         )
 

--- a/slither/core/declarations/function_top_level.py
+++ b/slither/core/declarations/function_top_level.py
@@ -75,8 +75,10 @@ class FunctionTopLevel(Function, TopLevel):
             Return the function summary
         Returns:
             (str, str, str, list(str), list(str), listr(str), list(str), list(str);
-            contract_name, name, visibility, modifiers, vars read, vars written, internal_calls, external_calls_as_expressions
+            contract_name, name, visibility, modifiers, vars read, vars written, internal_calls, external_calls
         """
+        from slither.slithir.operations import LibraryCall
+
         return (
             "",
             self.full_name,
@@ -85,7 +87,11 @@ class FunctionTopLevel(Function, TopLevel):
             [str(x) for x in self.state_variables_read + self.solidity_variables_read],
             [str(x) for x in self.state_variables_written],
             [str(x) for x in self.internal_calls],
-            [str(x) for x in self.external_calls_as_expressions],
+            [
+                str(ir.expression)
+                for (_, ir) in self.high_level_calls
+                if not isinstance(ir, LibraryCall)
+            ],
         )
 
     # endregion


### PR DESCRIPTION
## Summary

- Replace heuristic `external_calls_as_expressions` with IR-based `high_level_calls` filtering (excluding `LibraryCall`) in `get_summary()` for both `FunctionContract` and `FunctionTopLevel`
- `external_calls_as_expressions` matches any expression containing a `.`, which misclassifies `bytes.concat()`, `abi.encode()`, library calls, and similar dotted expressions as external calls
- `high_level_calls` uses the SlithIR intermediate representation, which correctly distinguishes actual external contract calls from other dotted syntax

Closes #2073

## Test plan

- [ ] Verify `slither . --print function-summary` no longer lists `bytes.concat()`, `abi.encode()`, or library calls under external calls
- [ ] Verify actual external calls (e.g., `token.transfer()`) still appear correctly
- [ ] Run existing printer e2e tests