### PR TITLE
Fix: filter is_constructor_variables in printers

### DIFF
--- a/slither/printers/call/call_graph.py
+++ b/slither/printers/call/call_graph.py
@@ -332,7 +332,9 @@ class PrinterCallGraph(AbstractPrinter):
             ]
             all_functions = [item for sublist in all_functionss for item in sublist]
             all_functions_as_dict = {
-                function.canonical_name: function for function in all_functions
+                function.canonical_name: function
+                for function in all_functions
+                if not function.is_constructor_variables
             }
             content = "\n".join(
                 ["strict digraph {"]
@@ -352,7 +354,15 @@ class PrinterCallGraph(AbstractPrinter):
                     ["strict digraph {"]
                     + ['rankdir="LR"']
                     + ["node [shape=box]"]
-                    + [_process_functions(derived_contract.functions)]
+                    + [
+                        _process_functions(
+                            [
+                                f
+                                for f in derived_contract.functions
+                                if not f.is_constructor_variables
+                            ]
+                        )
+                    ]
                     + ["}"]
                 )
                 f.write(content)

--- a/slither/printers/functions/authorization.py
+++ b/slither/printers/functions/authorization.py
@@ -48,6 +48,8 @@ class PrinterWrittenVariablesAndAuthorization(AbstractPrinter):
                 ["Function", "State variables written", "Conditions on msg.sender"]
             )
             for function in contract.functions:
+                if function.is_constructor_variables:
+                    continue
                 state_variables_written = [
                     v.name for v in function.all_state_variables_written() if v.name
                 ]

--- a/slither/printers/functions/cfg.py
+++ b/slither/printers/functions/cfg.py
@@ -19,6 +19,8 @@ class CFG(AbstractPrinter):
         all_files = []
         for contract in self.contracts:  # type: ignore
             for function in contract.functions + list(contract.modifiers):
+                if function.is_constructor_variables:
+                    continue
                 if filename:
                     new_filename = f"{filename}-{contract.name}-{function.full_name}.dot"
                 else:

--- a/slither/printers/functions/dominator.py
+++ b/slither/printers/functions/dominator.py
@@ -19,6 +19,8 @@ class Dominator(AbstractPrinter):
         all_files = []
         for contract in self.contracts:
             for function in contract.functions + contract.modifiers:
+                if function.is_constructor_variables:
+                    continue
                 if filename:
                     new_filename = f"{filename}-{contract.name}-{function.full_name}.dot"
                 else:

--- a/slither/printers/summary/evm.py
+++ b/slither/printers/summary/evm.py
@@ -130,6 +130,8 @@ class PrinterEVM(AbstractPrinter):
                 continue
 
             for function in contract.functions:
+                if function.is_constructor_variables:
+                    continue
                 txt += blue(f"\tFunction {function.canonical_name}\n")
 
                 txt += self.build_element_node_str(

--- a/slither/printers/summary/modifier_calls.py
+++ b/slither/printers/summary/modifier_calls.py
@@ -27,6 +27,8 @@ class Modifiers(AbstractPrinter):
             txt = f"\nContract {contract.name}"
             table = MyPrettyTable(["Function", "Modifiers"])
             for function in contract.functions:
+                if function.is_constructor_variables:
+                    continue
                 modifiers = function.modifiers
                 for ir in function.all_internal_calls():
                     if isinstance(ir.function, Function):

--- a/slither/printers/summary/require_calls.py
+++ b/slither/printers/summary/require_calls.py
@@ -38,6 +38,8 @@ class RequireOrAssert(AbstractPrinter):
             txt = f"\nContract {contract.name}"
             table = MyPrettyTable(["Function", "require or assert"])
             for function in contract.functions:
+                if function.is_constructor_variables:
+                    continue
                 require = function.all_slithir_operations()
                 require = [
                     ir

--- a/slither/printers/summary/slithir.py
+++ b/slither/printers/summary/slithir.py
@@ -39,6 +39,8 @@ class PrinterSlithIR(AbstractPrinter):
             for contract in compilation_unit.contracts:
                 txt += f"Contract {contract.name}\n"
                 for function in contract.functions:
+                    if function.is_constructor_variables:
+                        continue
                     txt += f"\tFunction {function.canonical_name} {'' if function.is_shadowed else '(*)'}\n"
                     txt += _print_function(function)
                 for modifier in contract.modifiers:

--- a/slither/printers/summary/slithir_ssa.py
+++ b/slither/printers/summary/slithir_ssa.py
@@ -22,6 +22,8 @@ class PrinterSlithIRSSA(AbstractPrinter):
         for contract in self.contracts:
             txt += f"Contract {contract.name}" + "\n"
             for function in contract.functions:
+                if function.is_constructor_variables:
+                    continue
                 txt += f"\tFunction {function.canonical_name}" + "\n"
                 for node in function.nodes:
                     if node.expression:


### PR DESCRIPTION
Closes #865

Printers that iterate over `contract.functions` were including synthetic constructor-variable functions (`slitherConstructorVariables`, `slitherConstructorConstantVariables`) in their output. These are internal bookkeeping functions and shouldn't be displayed.

This adds `is_constructor_variables` filtering to the 9 printers that were missing it, matching the pattern already used in `contract-summary`, `function-id`, and `inheritance-graph`.

**Printers fixed:**
- `cfg` — CFG export
- `dominator` — dominator tree export
- `vars-and-auth` — state variables and authorization
- `modifiers` — modifier calls
- `require` — require/assert calls
- `evm` — EVM instructions
- `slithir` — SlithIR representation
- `slithir-ssa` — SlithIR SSA representation
- `call-graph` — call graph export