### PR TITLE
feat: honor slither.config.json in slither-check-upgradeability

### DIFF
--- a/slither/tools/upgradeability/__main__.py
+++ b/slither/tools/upgradeability/__main__.py
@@ -13,6 +13,7 @@ from slither import Slither
 from slither.core.declarations import Contract
 from slither.exceptions import SlitherException
 from slither.utils.colors import red
+from slither.utils.command_line import read_config_file
 from slither.utils.output import output_to_json
 from slither.tools.upgradeability.checks import all_checks
 from slither.tools.upgradeability.checks.abstract_checks import (
@@ -115,6 +116,14 @@ def parse_args(check_classes: list[type[AbstractCheck]]) -> argparse.Namespace:
         help="URL for markdown generation",
         action="store",
         default="",
+    )
+
+    parser.add_argument(
+        "--config-file",
+        help="Provide a config file (default: slither.config.json or slither.conf.json)",
+        action="store",
+        dest="config_file",
+        default=None,
     )
 
     parser.add_argument(
@@ -286,6 +295,7 @@ def main() -> None:
 
     detectors = _get_checks()
     args = parse_args(detectors)
+    read_config_file(args)
     detectors_to_run = choose_checks(args, detectors)
     v1_filename = vars(args)["contract.sol"]
     number_detectors_run = 0

--- a/tests/unit/tools/test_upgradeability_cli.py
+++ b/tests/unit/tools/test_upgradeability_cli.py
@@ -1,0 +1,51 @@
+"""Tests for slither-check-upgradeability CLI wiring."""
+
+import json
+import sys
+
+import pytest
+
+from slither.tools.upgradeability.__main__ import _get_checks, parse_args
+from slither.utils.command_line import read_config_file
+
+
+@pytest.fixture
+def in_tmp_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _invoke_parse_args(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", argv)
+    return parse_args(_get_checks())
+
+
+def test_parser_exposes_config_file(monkeypatch):
+    args = _invoke_parse_args(
+        monkeypatch,
+        ["slither-check-upgradeability", "x.sol", "Foo", "--config-file", "custom.json"],
+    )
+    assert args.config_file == "custom.json"
+
+
+def test_parser_config_file_defaults_to_none(monkeypatch):
+    args = _invoke_parse_args(monkeypatch, ["slither-check-upgradeability", "x.sol", "Foo"])
+    assert args.config_file is None
+
+
+def test_read_config_file_autodetects_default(in_tmp_cwd, monkeypatch):
+    (in_tmp_cwd / "slither.config.json").write_text(json.dumps({"exclude_low": True}))
+    args = _invoke_parse_args(monkeypatch, ["slither-check-upgradeability", "x.sol", "Foo"])
+    assert args.exclude_low is False
+    read_config_file(args)
+    assert args.config_file == "slither.config.json"
+    assert args.exclude_low is True
+
+
+def test_read_config_file_applies_solc_remaps(in_tmp_cwd, monkeypatch):
+    (in_tmp_cwd / "slither.config.json").write_text(
+        json.dumps({"solc_remaps": "@openzeppelin=node_modules/@openzeppelin"})
+    )
+    args = _invoke_parse_args(monkeypatch, ["slither-check-upgradeability", "x.sol", "Foo"])
+    read_config_file(args)
+    assert args.solc_remaps == "@openzeppelin=node_modules/@openzeppelin"


### PR DESCRIPTION
Closes #1260

## Summary

`slither-check-upgradeability` already forwards `--solc-remaps` and other crytic-compile flags through `cryticparser`, but unlike `slither` and `slither-format` it never looked at `slither.config.json` / `slither.conf.json`. That forced users to repeat remappings and other config on the command line.

This PR wires up the existing `read_config_file` helper:

- Adds a `--config-file` option to `slither-check-upgradeability` with the same help text as `slither`/`slither-format`.
- Calls `read_config_file(args)` after parsing so defaults from the config file (including `solc_remaps` and the other crytic-compile flags shared via `DEFAULTS_FLAG_IN_CONFIG_CRYTIC_COMPILE`) are applied before Slither runs.

## Tests

New `tests/unit/tools/test_upgradeability_cli.py` covers:

- `--config-file` is exposed and defaults to `None`
- The default `slither.config.json` in cwd is autodetected
- `solc_remaps` from the config file is applied to `args`

```
$ uv run pytest tests/unit/tools/test_upgradeability_cli.py -q
4 passed in 0.47s
```

`ruff check` and `ruff format --check` pass on the touched files.