### PR TITLE
Add wiki output for config file options

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -33,6 +33,7 @@ from slither.utils.command_line import (
     defaults_flag_in_config,
     output_detectors,
     output_detectors_json,
+    output_config_file_options,
     output_printers,
     output_printers_json,
     output_results_to_markdown,
@@ -669,6 +670,10 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--wiki-config", help=argparse.SUPPRESS, action=OutputWikiConfig, nargs=0, default=False
+    )
+
+    parser.add_argument(
         "--list-detectors-json",
         help=argparse.SUPPRESS,
         action=ListDetectorsJson,
@@ -775,6 +780,18 @@ class OutputWiki(argparse.Action):
         detectors, _ = get_detectors_and_printers()
         assert isinstance(values, str)
         output_wiki(detectors, values)
+        parser.exit()
+
+
+class OutputWikiConfig(argparse.Action):
+    def __call__(
+        self,
+        parser: Any,
+        args: Any,
+        values: str | Sequence[Any] | None,
+        option_string: Any = None,
+    ) -> None:
+        output_config_file_options()
         parser.exit()
 
 

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -262,6 +262,23 @@ def output_wiki(detector_classes: list[type[AbstractDetector]], filter_wiki: str
         print(recommendation)
 
 
+def _config_default_to_markdown(value: object) -> str:
+    if isinstance(value, enum.Enum):
+        value = value.value
+
+    try:
+        return json.dumps(value)
+    except TypeError:
+        return json.dumps(str(value))
+
+
+def output_config_file_options() -> None:
+    print("| Key | Default |")
+    print("| --- | --- |")
+    for key, value in sorted(defaults_flag_in_config.items()):
+        print(f"| `{key}` | `{_config_default_to_markdown(value)}` |")
+
+
 def output_detectors(detector_classes: list[type[AbstractDetector]]) -> None:
     detectors_list = []
     for detector in detector_classes:

--- a/tests/unit/utils/test_command_line.py
+++ b/tests/unit/utils/test_command_line.py
@@ -1,0 +1,25 @@
+"""Unit tests for slither.utils.command_line."""
+
+from slither.utils.command_line import (
+    FailOnLevel,
+    _config_default_to_markdown,
+    output_config_file_options,
+)
+
+
+def test_config_default_to_markdown_handles_json_values():
+    assert _config_default_to_markdown(False) == "false"
+    assert _config_default_to_markdown(None) == "null"
+    assert _config_default_to_markdown("all") == '"all"'
+    assert _config_default_to_markdown(FailOnLevel.PEDANTIC) == '"pedantic"'
+
+
+def test_output_config_file_options_includes_known_slither_keys(capsys):
+    output_config_file_options()
+
+    output = capsys.readouterr().out
+    assert "| Key | Default |" in output
+    assert "| `exclude_dependencies` | `false` |" in output
+    assert "| `exclude_optimization` | `false` |" in output
+    assert "| `sarif` | `null` |" in output
+    assert "| `compile_force_framework` | `null` |" in output


### PR DESCRIPTION
## Summary
- add a hidden `--wiki-config` output for supported config file keys
- render Slither and crytic-compile config defaults as a Markdown table
- cover the output helper with unit tests, including keys mentioned in #1155

Refs #1155

## Testing
- `uv run pytest tests/unit/utils/test_command_line.py`
- `uv run python -m ruff check slither/utils/command_line.py slither/__main__.py tests/unit/utils/test_command_line.py`
- `uv run python -m slither.__main__ --wiki-config`