### PR TITLE
Remove obsolete solc AST CLI flag

### DIFF
--- a/scripts/ci_test_cli.sh
+++ b/scripts/ci_test_cli.sh
@@ -6,11 +6,6 @@ set -euo pipefail
 
 solc-select use 0.7.0
 
-if ! slither "tests/e2e/config/test_json_config/test.sol" --solc-ast --no-fail-pedantic; then
-    echo "--solc-ast failed"
-    exit 1
-fi
-
 if ! slither "tests/e2e/config/test_json_config/test.sol" --solc-disable-warnings --no-fail-pedantic; then
     echo "--solc-disable-warnings failed"
     exit 1

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -623,13 +623,6 @@ def parse_args(
     )
 
     group_misc.add_argument(
-        "--solc-ast",
-        help="Provide the contract as a json AST",
-        action="store_true",
-        default=False,
-    )
-
-    group_misc.add_argument(
         "--generate-patches",
         help="Generate patches (json output only)",
         action="store_true",
@@ -906,7 +899,7 @@ def main_impl(
         filename = args.filename
 
         # Determine if we are handling ast from solc
-        if args.solc_ast or (filename.endswith(".json") and not is_supported(filename)):
+        if filename.endswith(".json") and not is_supported(filename):
             globbed_filenames = glob.glob(filename, recursive=True)
             filenames = glob.glob(os.path.join(filename, "*.json"))
             if not filenames:


### PR DESCRIPTION
Fixes #2501.

This removes the obsolete --solc-ast CLI flag, whose help text suggested that Slither could accept a JSON AST directly. Maintainer discussion in #2501 notes that this support was removed and should stay unavailable unless it is re-added properly in crytic-compile.

The PR also removes the CLI smoke test for that deprecated flag so the test suite no longer preserves the misleading option.

Validation:
- python -m py_compile slither\__main__.py
- git diff --check
- rg solc_ast/--solc-ast/solc-ast across slither, scripts, tests, docs, README.md, pyproject.toml