### PR TITLE
Add generated config wiki section

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -33,6 +33,7 @@ from slither.utils.command_line import (
     defaults_flag_in_config,
     output_detectors,
     output_detectors_json,
+    output_config_file_section,
     output_printers,
     output_printers_json,
     output_results_to_markdown,
@@ -669,6 +670,15 @@ def parse_args(
     )
 
     parser.add_argument(
+        "--wiki-configuration",
+        "--wiki-config",
+        help=argparse.SUPPRESS,
+        action=OutputConfigFileSection,
+        nargs=0,
+        default=False,
+    )
+
+    parser.add_argument(
         "--list-detectors-json",
         help=argparse.SUPPRESS,
         action=ListDetectorsJson,
@@ -775,6 +785,18 @@ class OutputWiki(argparse.Action):
         detectors, _ = get_detectors_and_printers()
         assert isinstance(values, str)
         output_wiki(detectors, values)
+        parser.exit()
+
+
+class OutputConfigFileSection(argparse.Action):
+    def __call__(
+        self,
+        parser: Any,
+        args: Any,
+        values: str | Sequence[Any] | None,
+        option_string: Any = None,
+    ) -> None:
+        output_config_file_section()
         parser.exit()
 
 

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -5,6 +5,7 @@ import os
 import re
 import logging
 from collections import defaultdict
+from typing import Any
 
 from crytic_compile.cryticparser.defaults import (
     DEFAULTS_FLAG_IN_CONFIG as DEFAULTS_FLAG_IN_CONFIG_CRYTIC_COMPILE,
@@ -77,6 +78,36 @@ defaults_flag_in_config = {
     "triage_database": "slither.db.json",
     **DEFAULTS_FLAG_IN_CONFIG_CRYTIC_COMPILE,
 }
+
+
+def _format_config_value(value: Any) -> Any:
+    if isinstance(value, enum.Enum):
+        return value.value
+    return value
+
+
+def format_config_file_defaults(defaults: dict[str, Any] | None = None) -> str:
+    defaults = defaults if defaults is not None else defaults_flag_in_config
+    serializable_defaults = {key: _format_config_value(value) for key, value in defaults.items()}
+    return json.dumps(serializable_defaults, indent=4)
+
+
+def output_config_file_section() -> None:
+    print("### Configuration File")
+    print()
+    print(
+        "Some options can be set through a json configuration file. By default, "
+        "`slither.config.json` is used if present (it can be changed through "
+        "`--config-file file.config.json`)."
+    )
+    print()
+    print("Options passed via the CLI have priority over options set in the configuration file.")
+    print()
+    print("The following flags are supported:")
+    print()
+    print("```json")
+    print(format_config_file_defaults())
+    print("```")
 
 
 def read_config_file(args: argparse.Namespace) -> None:

--- a/tests/unit/utils/test_command_line.py
+++ b/tests/unit/utils/test_command_line.py
@@ -1,0 +1,39 @@
+"""Tests for slither/utils/command_line.py"""
+
+import json
+
+from slither.utils.command_line import (
+    FailOnLevel,
+    format_config_file_defaults,
+    output_config_file_section,
+)
+
+
+def test_format_config_file_defaults_outputs_valid_json():
+    result = format_config_file_defaults(
+        {
+            "detectors_to_run": "all",
+            "fail_on": FailOnLevel.PEDANTIC,
+            "json": None,
+            "exclude_dependencies": False,
+        }
+    )
+
+    assert json.loads(result) == {
+        "detectors_to_run": "all",
+        "fail_on": "pedantic",
+        "json": None,
+        "exclude_dependencies": False,
+    }
+
+
+def test_output_config_file_section_includes_supported_defaults(capsys):
+    output_config_file_section()
+
+    captured = capsys.readouterr()
+    assert "### Configuration File" in captured.out
+    assert "```json" in captured.out
+    assert '"exclude_dependencies": false' in captured.out
+    assert '"exclude_optimization": false' in captured.out
+    assert '"sarif": null' in captured.out
+    assert '"json-types": "detectors,printers"' in captured.out


### PR DESCRIPTION
## Summary
- add a hidden `--wiki-configuration` / `--wiki-config` flag that emits the Configuration File wiki section from `defaults_flag_in_config`
- serialize enum defaults to JSON-safe values so the generated code block is valid JSON
- include the crytic-compile defaults that Slither already merges into its config defaults

Fixes #1155

## Testing
- `uv run pytest tests/unit/utils/test_command_line.py`
- `uv run ruff check slither/utils/command_line.py slither/__main__.py tests/unit/utils/test_command_line.py`
- `uv run python -m slither --wiki-configuration`