### PR TITLE
Fix detector documentation typos

### DIFF
--- a/docs/src/detectors/Detector-Documentation.md
+++ b/docs/src/detectors/Detector-Documentation.md
@@ -1493,7 +1493,7 @@ contract Constant{
     uint counter;
     function get() public view returns(uint){
        counter = counter +1;
-       return counter
+       return counter;
     }
 }
 ```
@@ -1529,7 +1529,7 @@ contract Constant{
     uint counter;
     function get() public view returns(uint){
        counter = counter +1;
-       return counter
+       return counter;
     }
 }
 ```
@@ -1857,7 +1857,7 @@ Uninitialized local variables.
 contract Uninitialized is Owner{
     function withdraw() payable public onlyOwner{
         address to;
-        to.transfer(this.balance)
+        to.transfer(this.balance);
     }
 }
 ```
@@ -1950,7 +1950,7 @@ If a modifier does not execute `_` or revert, the execution of the function will
 ### Exploit Scenario
 
 ```solidity
-    modidfier myModif(){
+    modifier myModif(){
         if(..){
            _;
         }
@@ -2212,7 +2212,7 @@ If one of the destinations has a fallback function that reverts, `bad` will alwa
 
 ### Recommendation
 
-Favor [pull over push](https://github.com/ethereum/wiki/wiki/Safety#favor-pull-over-push-for-external-calls) strategy for external calls.
+Favor [pull over push](https://docs.soliditylang.org/en/latest/common-patterns.html#withdrawal-from-contracts) strategy for external calls.
 
 ## Missing events access control
 
@@ -2371,7 +2371,7 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
         if( ! (msg.sender.call()() ) ){
             throw;
         }
-        counter += 1
+        counter += 1;
     }
 ```
 
@@ -3035,11 +3035,11 @@ Functions that are not used.
 
 ```solidity
 contract Contract{
-    function dead_code() internal() {}
+    function dead_code() internal {}
 }
 ```
 
-`dead_code` is not used in the contract, and make the code's review more difficult.
+`dead_code` is not used in the contract, and makes the code's review more difficult.
 
 ### Recommendation
 
@@ -3062,7 +3062,7 @@ Only report reentrancy that is based on `transfer` or `send`.
 
 ```solidity
     function callme(){
-        msg.sender.transfer(balances[msg.sender]):
+        msg.sender.transfer(balances[msg.sender]);
         balances[msg.sender] = 0;
     }
 ```

--- a/slither/detectors/attributes/const_functions_asm.py
+++ b/slither/detectors/attributes/const_functions_asm.py
@@ -45,7 +45,7 @@ contract Constant{
     uint counter;
     function get() public view returns(uint){
        counter = counter +1;
-       return counter
+       return counter;
     }
 }
 ```

--- a/slither/detectors/attributes/const_functions_state.py
+++ b/slither/detectors/attributes/const_functions_state.py
@@ -45,7 +45,7 @@ contract Constant{
     uint counter;
     function get() public view returns(uint){
        counter = counter +1;
-       return counter
+       return counter;
     }
 }
 ```

--- a/slither/detectors/functions/dead_code.py
+++ b/slither/detectors/functions/dead_code.py
@@ -30,10 +30,10 @@ class DeadCode(AbstractDetector):
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
 contract Contract{
-    function dead_code() internal() {}
+    function dead_code() internal {}
 }
 ```
-`dead_code` is not used in the contract, and make the code's review more difficult."""
+`dead_code` is not used in the contract, and makes the code's review more difficult."""
     # endregion wiki_exploit_scenario
 
     WIKI_RECOMMENDATION = "Remove unused functions."

--- a/slither/detectors/functions/modifier.py
+++ b/slither/detectors/functions/modifier.py
@@ -51,7 +51,7 @@ class ModifierDefaultDetection(AbstractDetector):
     # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
-    modidfier myModif(){
+    modifier myModif(){
         if(..){
            _;
         }

--- a/slither/detectors/reentrancy/reentrancy_benign.py
+++ b/slither/detectors/reentrancy/reentrancy_benign.py
@@ -40,7 +40,7 @@ Only report reentrancy that acts as a double call (see `reentrancy-eth`, `reentr
         if( ! (msg.sender.call()() ) ){
             throw;
         }
-        counter += 1
+        counter += 1;
     }
 ```
 

--- a/slither/detectors/reentrancy/reentrancy_no_gas.py
+++ b/slither/detectors/reentrancy/reentrancy_no_gas.py
@@ -44,7 +44,7 @@ Only report reentrancy that is based on `transfer` or `send`."""
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
     function callme(){
-        msg.sender.transfer(balances[msg.sender]):
+        msg.sender.transfer(balances[msg.sender]);
         balances[msg.sender] = 0;
     }
 ```

--- a/slither/detectors/statements/calls_in_loop.py
+++ b/slither/detectors/statements/calls_in_loop.py
@@ -94,7 +94,7 @@ contract CallsInLoop{
 If one of the destinations has a fallback function that reverts, `bad` will always revert."""
     # endregion wiki_exploit_scenario
 
-    WIKI_RECOMMENDATION = "Favor [pull over push](https://github.com/ethereum/wiki/wiki/Safety#favor-pull-over-push-for-external-calls) strategy for external calls."
+    WIKI_RECOMMENDATION = "Favor [pull over push](https://docs.soliditylang.org/en/latest/common-patterns.html#withdrawal-from-contracts) strategy for external calls."
 
     def _detect(self) -> list[Output]:
         """"""

--- a/slither/detectors/variables/uninitialized_local_variables.py
+++ b/slither/detectors/variables/uninitialized_local_variables.py
@@ -28,7 +28,7 @@ class UninitializedLocalVars(AbstractDetector):
 contract Uninitialized is Owner{
     function withdraw() payable public onlyOwner{
         address to;
-        to.transfer(this.balance)
+        to.transfer(this.balance);
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Fix Solidity syntax typos in detector documentation examples.
- Correct the `incorrect-modifier` example typo and dead-code wording.
- Replace the old Ethereum wiki pull-over-push link with the current Solidity withdrawal-pattern docs.
- Keep `docs/src/detectors/Detector-Documentation.md` in sync with the detector `WIKI_*` strings.

Fixes #1206

## Testing
- `codespell docs/src/detectors/Detector-Documentation.md slither/detectors/attributes/const_functions_asm.py slither/detectors/attributes/const_functions_state.py slither/detectors/variables/uninitialized_local_variables.py slither/detectors/statements/calls_in_loop.py slither/detectors/reentrancy/reentrancy_benign.py slither/detectors/functions/dead_code.py slither/detectors/reentrancy/reentrancy_no_gas.py slither/detectors/functions/modifier.py`
- `uv run ruff check slither/detectors/attributes/const_functions_asm.py slither/detectors/attributes/const_functions_state.py slither/detectors/variables/uninitialized_local_variables.py slither/detectors/statements/calls_in_loop.py slither/detectors/reentrancy/reentrancy_benign.py slither/detectors/functions/dead_code.py slither/detectors/reentrancy/reentrancy_no_gas.py slither/detectors/functions/modifier.py`
- `git diff --check`