### PR TITLE
Add exclude-test filter flag

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -54,6 +54,8 @@ from slither.utils.output_capture import StandardOutputCapture
 logging.basicConfig()
 logger = logging.getLogger("Slither")
 
+DEFAULT_EXCLUDE_TEST_PATHS = r"(?i)(^|/)(tests?|mocks?)(/|$)|(^|/)(test|mock)[^/]*\.sol$"
+
 
 ###################################################################################
 ###################################################################################
@@ -315,6 +317,16 @@ def parse_filter_paths(args: argparse.Namespace, filter_path: bool) -> list[str]
     return []
 
 
+def apply_exclude_test_filter(args: argparse.Namespace) -> None:
+    if not args.exclude_test:
+        return
+
+    if args.include_paths:
+        raise ValueError("Error: --exclude-test cannot be used with --include-paths")
+
+    args.filter_paths.append(DEFAULT_EXCLUDE_TEST_PATHS)
+
+
 def parse_args(
     detector_classes: list[type[AbstractDetector]],
     printer_classes: list[type[AbstractPrinter]],
@@ -440,6 +452,13 @@ def parse_args(
         help="Exclude high impact analyses",
         action="store_true",
         default=defaults_flag_in_config["exclude_high"],
+    )
+
+    group_detector.add_argument(
+        "--exclude-test",
+        help="Exclude detector results matching test or mock file paths",
+        action="store_true",
+        default=defaults_flag_in_config["exclude_test"],
     )
 
     group_detector.add_argument(
@@ -718,6 +737,7 @@ def parse_args(
 
     args.filter_paths = parse_filter_paths(args, True)
     args.include_paths = parse_filter_paths(args, False)
+    apply_exclude_test_filter(args)
 
     # Verify our json-type output is valid
     args.json_types = set(args.json_types.split(","))  # type:ignore

--- a/slither/utils/command_line.py
+++ b/slither/utils/command_line.py
@@ -55,6 +55,7 @@ defaults_flag_in_config = {
     "exclude_low": False,
     "exclude_medium": False,
     "exclude_high": False,
+    "exclude_test": False,
     "exclude_location": False,
     "fail_on": FailOnLevel.PEDANTIC,
     "json": None,

--- a/tests/unit/utils/test_command_line.py
+++ b/tests/unit/utils/test_command_line.py
@@ -1,0 +1,56 @@
+from argparse import Namespace
+import re
+
+import pytest
+
+from slither.__main__ import DEFAULT_EXCLUDE_TEST_PATHS, apply_exclude_test_filter
+
+
+def test_apply_exclude_test_filter_adds_default_pattern():
+    args = Namespace(exclude_test=True, filter_paths=[], include_paths=[])
+
+    apply_exclude_test_filter(args)
+
+    assert args.filter_paths == [DEFAULT_EXCLUDE_TEST_PATHS]
+
+
+def test_apply_exclude_test_filter_preserves_existing_filters():
+    args = Namespace(exclude_test=True, filter_paths=["vendor"], include_paths=[])
+
+    apply_exclude_test_filter(args)
+
+    assert args.filter_paths == ["vendor", DEFAULT_EXCLUDE_TEST_PATHS]
+
+
+def test_apply_exclude_test_filter_rejects_include_paths():
+    args = Namespace(exclude_test=True, filter_paths=[], include_paths=["contracts"])
+
+    with pytest.raises(ValueError, match="--exclude-test cannot be used with --include-paths"):
+        apply_exclude_test_filter(args)
+
+
+def test_apply_exclude_test_filter_noops_when_disabled():
+    args = Namespace(exclude_test=False, filter_paths=["vendor"], include_paths=[])
+
+    apply_exclude_test_filter(args)
+
+    assert args.filter_paths == ["vendor"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/repo/test/Token.sol",
+        "/repo/tests/Token.sol",
+        "/repo/mock/Token.sol",
+        "/repo/mocks/Token.sol",
+        "/repo/contracts/TestToken.sol",
+        "/repo/contracts/MockToken.sol",
+    ],
+)
+def test_exclude_test_default_pattern_matches_test_and_mock_paths(path):
+    assert re.search(DEFAULT_EXCLUDE_TEST_PATHS, path)
+
+
+def test_exclude_test_default_pattern_keeps_regular_contract_paths():
+    assert not re.search(DEFAULT_EXCLUDE_TEST_PATHS, "/repo/contracts/Token.sol")


### PR DESCRIPTION
## Summary
- Add a `--exclude-test` detector flag that appends a default test/mock path filter.
- Allow combining it with existing `--filter-paths`, while rejecting `--include-paths` because include filtering takes the opposite path.
- Cover the helper and default pattern with unit tests.

Fixes #691

## Testing
- uv run pytest tests/unit/utils/test_command_line.py
- uv run ruff check slither/__main__.py slither/utils/command_line.py tests/unit/utils/test_command_line.py
- codespell slither/__main__.py slither/utils/command_line.py tests/unit/utils/test_command_line.py
- git diff --check