### PR TITLE
chore: improve slither maintenance path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,24 +9,24 @@ import pytest
 from slither import Slither
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     """Create a temporary directory for the tests to use."""
     if is_master():
         config.stash["shared_directory"] = tempfile.mkdtemp()
 
 
-def pytest_unconfigure(config):
+def pytest_unconfigure(config) -> None:
     """Remove the temporary directory after the tests are done."""
     if is_master():
         shutil.rmtree(config.stash["shared_directory"])
 
 
-def pytest_configure_node(node):
+def pytest_configure_node(node) -> None:
     """Configure each worker node with the shared directory."""
     node.workerinput["shared_directory"] = node.config.stash["shared_directory"]
 
 
-def is_master():
+def is_master() -> bool:
     """Returns True if the current process is the master process (which does not have a worker id)."""
     return os.environ.get("PYTEST_XDIST_WORKER") is None
 

--- a/tests/unit/core/test_literal.py
+++ b/tests/unit/core/test_literal.py
@@ -89,3 +89,10 @@ class TestLiteralEquality:
         lit = Literal("100", "uint256")
         assert lit != "100"
         assert lit != 100
+        assert lit != None
+
+    def test_equal_none_subdenomination(self):
+        """Literals with None and absent subdenomination should be equal."""
+        lit1 = Literal("100", "uint256")
+        lit2 = Literal("100", "uint256", subdenomination=None)
+        assert lit1 == lit2


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tests/conftest.py, tests/unit/core/test_literal.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.