### PR TITLE
fix: convert every struct field, not just the first of a repeated type

### DIFF
--- a/slither/utils/type.py
+++ b/slither/utils/type.py
@@ -23,8 +23,10 @@ def _convert_type_for_solidity_signature_to_string(
         # While having an array of a struct of two uint leads to a (uint, uint)[] signature
         if isinstance(types, ArrayType):
             underlying_type = convert_type_for_solidity_signature(types.type, seen)
+            # Descending through the array adds its element type to the ancestor set, so a
+            # struct that reaches itself via an array still terminates.
             underlying_type_str = _convert_type_for_solidity_signature_to_string(
-                underlying_type, seen
+                underlying_type, seen | {types.type}
             )
 
             if types.length is None:
@@ -70,9 +72,13 @@ def convert_type_for_solidity_signature(t: Type, seen: set[Type]) -> Type | list
     #    function f(St memory s) internal{}
     #
     # }
+    # `seen` tracks the ancestors of `t` in the current descent, not every type visited
+    # anywhere in the traversal. Mutating a single shared set would make a type that appears
+    # twice as a *sibling* (e.g. two fields of the same user defined type) look like a
+    # recursive back-edge, and the second occurrence would be returned unconverted.
     if t in seen:
         return t
-    seen.add(t)
+    seen = seen | {t}
 
     if isinstance(t, UserDefinedType):
         underlying_type = t.type

--- a/tests/unit/utils/test_data/type_helpers_repeated_fields.sol
+++ b/tests/unit/utils/test_data/type_helpers_repeated_fields.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+type Amount is uint256;
+
+enum Flag {
+    A,
+    B
+}
+
+interface IThing {}
+
+// Each struct holds the same convertible type twice. The second occurrence must be
+// converted just like the first one -- it is a sibling, not a recursive back-edge.
+struct WithAlias {
+    Amount a;
+    Amount b;
+}
+
+struct WithEnum {
+    Flag a;
+    Flag b;
+}
+
+struct WithContract {
+    IThing a;
+    IThing b;
+}
+
+contract B {
+    function fAlias(WithAlias calldata p) external {}
+
+    function fEnum(WithEnum calldata p) external {}
+
+    function fContract(WithContract calldata p) external {}
+}

--- a/tests/unit/utils/test_type_helpers.py
+++ b/tests/unit/utils/test_type_helpers.py
@@ -10,3 +10,17 @@ def test_function_id_rec_structure(solc_binary_path) -> None:
     for compilation_unit in slither.compilation_units:
         for function in compilation_unit.functions:
             assert function.solidity_signature
+
+
+def test_solidity_signature_repeated_struct_field_types(solc_binary_path) -> None:
+    """A type used by two fields of the same struct must be converted for both of them."""
+    solc_path = solc_binary_path("0.8.20")
+    slither = Slither(
+        Path(TEST_DATA_DIR, "type_helpers_repeated_fields.sol").as_posix(), solc=solc_path
+    )
+    contract = slither.get_contract_from_name("B")[0]
+    signatures = {f.name: f.solidity_signature for f in contract.functions_entry_points}
+
+    assert signatures["fAlias"] == "fAlias((uint256,uint256))"
+    assert signatures["fEnum"] == "fEnum((uint8,uint8))"
+    assert signatures["fContract"] == "fContract((address,address))"


### PR DESCRIPTION
Fixes #3064.

### The bug

`convert_type_for_solidity_signature` uses a `seen` set to stop recursive struct definitions from
looping forever. That set was mutated in place and shared across the *entire* traversal, including
across sibling fields of the same struct — so a type used by two fields was treated as a recursive
back-edge on its second appearance and returned unconverted.

```solidity
type Amount is uint256;
struct Pair { Amount a; Amount b; }
function f(Pair calldata p) external;
```

```
before   f((uint256,Amount))
after    f((uint256,uint256))     # matches solc --combined-json abi
```

It is not specific to user-defined value types — any sibling type that needs conversion collides:

| struct fields | before | after |
|---|---|---|
| `Amount a; Amount b;` (UDVT) | `fAlias((uint256,Amount))` | `fAlias((uint256,uint256))` |
| `Flag a; Flag b;` (enum) | `fEnum((uint8,Flag))` | `fEnum((uint8,uint8))` |
| `IThing a; IThing b;` (interface) | `fContract((address,IThing))` | `fContract((address,address))` |

Two `uint256` fields were never affected, which is why this stayed hidden: returning a type
unconverted is harmless exactly when no conversion was needed.

Because `get_function_from_signature` matches strictly, affected functions were unresolvable by
signature — silently, with no exception or warning.

### The fix

Treat `seen` as the **ancestors of the current descent** rather than every type visited anywhere:
rebind it to a new set on entry instead of mutating the caller's. Siblings then each see only their
shared ancestors, not each other.

One subtlety worth flagging for review: the shared mutable set was also load-bearing for
*termination*. `_convert_type_for_solidity_signature_to_string` re-enters
`convert_type_for_solidity_signature` when it unwraps an `ArrayType`, and relied on entries left
behind by the first phase to stop `struct St { St[] a; uint b; }` from recursing forever. Scoping
`seen` without accounting for that reintroduces infinite recursion — I hit it while testing. So the
array branch now passes the element type down as an ancestor, which preserves the guard across the
phase boundary.

The existing `test_function_id_rec_structure` (the recursive-struct case) still passes. Its rendering
does change: that struct now expands one level further before the cycle is cut, since the outer `St`
is no longer in `seen` when the array branch is first reached. The existing test asserts only that a
signature is produced, and the value is not part of any ABI-meaningful signature — recursive structs
cannot appear in public/external functions, which is the only reason they are permitted at all.

### Tests

Added `test_solidity_signature_repeated_struct_field_types` covering all three conversion kinds
(UDVT, enum, contract). It fails on `master`:

```
E  AssertionError: assert 'fAlias((uint256,Amount))' == 'fAlias((uint256,uint256))'
```

`tests/unit/utils/` and `tests/unit/core/test_function_declaration.py` pass — 36 passed, with the
one unrelated `test_vyper_functions` failure reproducing identically on unpatched `master` in my
environment (local vyper version). `ruff format --check` and `ruff check` are clean.
