### PR TITLE
fix: improve error handling in similarity tools

### DIFF
--- a/slither/tools/similarity/encode.py
+++ b/slither/tools/similarity/encode.py
@@ -94,7 +94,7 @@ def load_contracts(dirname: str, ext: str | None = None, nsamples: int | None = 
     for x, y, files in walk:
         for f in files:
             if ext is None or f.endswith(ext):
-                r.append(x + "/".join(y) + "/" + f)
+                r.append(os.path.join(x, f))
 
     if nsamples is None:
         return r
@@ -225,7 +225,7 @@ def encode_contract(cfilename, **kwargs):
     try:
         slither = Slither(cfilename, **kwargs)
     except Exception:
-        simil_logger.error("Compilation failed for %s using %s", cfilename, kwargs["solc"])
+        simil_logger.error("Compilation failed for %s using %s", cfilename, kwargs.get("solc", "unknown"))
         return r
 
     # Iterate over all the contracts

--- a/slither/tools/similarity/plot.py
+++ b/slither/tools/similarity/plot.py
@@ -79,6 +79,6 @@ def plot(args: argparse.Namespace) -> None:
         plt.savefig("plot.png", bbox_inches="tight")
 
     except Exception:
-        logger.error(f"Error in {args.filename}")
+        logger.error(f"Error in {getattr(args, 'filename', '<unknown>')}")
         logger.error(traceback.format_exc())
         sys.exit(-1)

--- a/slither/tools/similarity/test.py
+++ b/slither/tools/similarity/test.py
@@ -47,6 +47,6 @@ def test(args: Namespace) -> None:
             logger.info(format_table.format(*(list(x) + [score])))
 
     except Exception:
-        logger.error(f"Error in {args.filename}")
+        logger.error(f"Error in {getattr(args, 'filename', '<unknown>')}")
         logger.error(traceback.format_exc())
         sys.exit(-1)

--- a/slither/tools/similarity/train.py
+++ b/slither/tools/similarity/train.py
@@ -49,6 +49,6 @@ def train(args: argparse.Namespace) -> None:
         logger.info("Done!")
 
     except Exception:
-        logger.error(f"Error in {args.filename}")
+        logger.error(f"Error in {getattr(args, 'filename', '<unknown>')}")
         logger.error(traceback.format_exc())
         sys.exit(-1)


### PR DESCRIPTION
## Description

This PR fixes several error handling issues in the similarity tools (slither-simil) that could cause crashes or misleading error messages.

## Problems Fixed

### 1. Path Concatenation Bug (encode.py:96)
- **Issue**: Incorrect path construction using string concatenation: x + '/'.join(y) + '/' + f 
- **Fix**: Use os.path.join(x, f) for proper cross-platform path handling
- **Impact**: Prevents path errors on Windows and ensures consistent path separators

### 2. Unsafe Attribute Access (train.py:52, test.py:50, plot.py:82)
- **Issue**: Direct access to rgs.filename in exception handlers could raise AttributeError
- **Fix**: Use getattr(args, 'filename', '<unknown>') for safe attribute access
- **Impact**: Prevents secondary crashes when reporting errors

### 3. Potential KeyError (encode.py:228)
- **Issue**: Direct dictionary access kwargs['solc'] could raise KeyError
- **Fix**: Use kwargs.get('solc', 'unknown') for safe access
- **Impact**: Provides graceful error reporting when solc parameter is missing

## Testing

- Verified syntax correctness
- No functional behavior changes for valid inputs
- Error messages now more robust for edge cases

## Note

These are defensive programming improvements that enhance tool stability. All changes are backward compatible.

---

I apologize for any inconvenience caused by previous submissions. This is a focused fix for error handling in similarity tools.

Local environment limitations: Dependency constraints (missing wn module), relying on CI/CD automated testing.

cc @crytic maintainers