### PR TITLE
Fix inheritance resolution for transitive duplicate contract names

### DIFF
--- a/slither/solc_parsing/slither_compilation_unit_solc.py
+++ b/slither/solc_parsing/slither_compilation_unit_solc.py
@@ -462,6 +462,9 @@ class SlitherCompilationUnitSolc(CallerContextExpression):
 
         def resolve_remapping_and_renaming(contract_parser: ContractSolc, want: str) -> Contract:
             contract_name = contract_parser.remapping[want]
+            contract_by_id = self._contracts_by_id.get(want)
+            if contract_by_id is not None and contract_by_id.name == contract_name:
+                return contract_by_id
             target = None
             # For contracts that are imported and aliased e.g. 'import {A as B} from "./C.sol"',
             # we look through the imports's (`Import`) renaming to find the original contract name

--- a/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/BaseLock.sol
+++ b/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/BaseLock.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.8.0;
+
+abstract contract Lock {}

--- a/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/IndirectBase.sol
+++ b/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/IndirectBase.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.0;
+
+import {Lock} from "./LockLibrary.sol";
+
+abstract contract IndirectBase {
+    using Lock for uint256;
+}

--- a/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/LockLibrary.sol
+++ b/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/LockLibrary.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.0;
+
+library Lock {
+    function identity(uint256 value) internal pure returns (uint256) {
+        return value;
+    }
+}

--- a/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/Target.sol
+++ b/tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/Target.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.8.0;
+
+import {Lock} from "./BaseLock.sol";
+import {IndirectBase} from "./IndirectBase.sol";
+
+contract Target is IndirectBase, Lock {}

--- a/tests/unit/core/test_inheritance.py
+++ b/tests/unit/core/test_inheritance.py
@@ -42,3 +42,18 @@ def test_inheritance_with_duplicate_names(solc_binary_path) -> None:
         Path(TEST_DATA_DIR / "duplicate_names", "contract_with_duplicate_names.sol").as_posix(),
         solc=solc_path,
     )
+
+
+def test_inheritance_with_transitive_duplicate_name(solc_binary_path) -> None:
+    solc_path = solc_binary_path("0.8.15")
+    standard_json = SolcStandardJson()
+    for source_file in Path(TEST_DATA_DIR / "transitive_duplicate_name").rglob("*.sol"):
+        standard_json.add_source_file(source_file.as_posix())
+
+    slither = Slither(CryticCompile(standard_json, solc=solc_path), disallow_partial=True)
+    target = slither.get_contract_from_name("Target")[0]
+
+    assert [(base.name, base.contract_kind) for base in target.inheritance] == [
+        ("Lock", "contract"),
+        ("IndirectBase", "contract"),
+    ]


### PR DESCRIPTION
## Problem

Slither can resolve a Solidity base contract to the wrong declaration when a transitive import exposes another declaration with the same name. Solidity's compact AST already identifies every entry in `linearizedBaseContracts` and `baseContracts` with a `referencedDeclaration`, but Slither's remapping path discarded that identity and performed a name-based lookup through imported and current file scopes.

For example, consider four source files:

- `BaseLock.sol` declares an abstract contract named `Lock`.
- `LockLibrary.sol` declares a library named `Lock`.
- `IndirectBase.sol` imports the library and uses it with `using Lock for uint256`.
- `Target.sol` inherits both `IndirectBase` and the contract `Lock`.

The compiler identifies the intended base contract unambiguously. The previous lookup could nevertheless bind `Target` to the transitive `Lock` library. In a larger compilation this incorrect dependency can leave Slither's semantic analysis with no analyzable contracts and make analysis appear to hang.

This occurred in a verified Universal Router compilation from Ethereum. The artifact contains both a contract and a library named `Lock`; Slither selected the library for `Dispatcher`'s inheritance and did not complete within the 10-second diagnostic timeout.

## Change

When resolving a remapped inheritance entry, first look up the compiler-provided declaration ID in `_contracts_by_id`. Use that declaration when its name agrees with the AST remapping name.

The name check is intentional. It keeps the existing import-renaming and file scope lookup as a compatibility path for invalid IDs and aliased imports, while using compiler identity whenever that identity is internally consistent.

A four-file regression fixture reproduces the collision and asserts that `Target` inherits the `Lock` contract rather than the same-named library.

## Tests

### Minimal reproduction

The new fixture is under `tests/unit/core/test_data/inheritance_resolution/transitive_duplicate_name/`.
It is compiled as Solidity Standard JSON with solc 0.8.15.

Before the change, the isolated reproduction did not complete within 10 seconds. After the change, Slither builds the model and resolves:

```text
Target -> Lock (contract), IndirectBase (contract)
```

The complete inheritance-resolution unit module passes:

```text
3 passed in 0.08s
```

This includes the existing renamed-import and duplicate-name tests, so their fallback behavior remains covered.

### Real verified on-chain contract

The fix was validated against existing Solidity Standard JSON artifacts for:

- Chain: Ethereum mainnet (`chainId=1`)
- Contract address: `0x66a9893cc07d91d95644aedd05d03f95e1dba8af`
- Fully qualified contract: `src/pkgs/universal-router/contracts/UniversalRouter.sol:UniversalRouter`
- Compiler: Solidity `0.8.26+commit.8a97fa7a`
- Compilation size: 93 source files and 91 contracts

The patched source tree completed semantic construction in approximately 2.5 seconds and produced the following checked results:

```text
Dispatcher.Lock -> Lock (contract, declaration id 1681)
UniversalRouter immediate parents -> IUniversalRouter, Dispatcher
```

Before the fix, the same artifact selected the `Lock` library and timed out during analysis.

### Slither regression suite

No Solidity or inheritance-resolution regression was observed. Ruff reported `All checks passed`, and `git diff --check` completed without errors.
