### PR TITLE
slither-read-storage: auto-detect and accept solc Standard JSON input files

### DIFF
--- a/docs/src/tools/ReadStorage.md
+++ b/docs/src/tools/ReadStorage.md
@@ -8,7 +8,7 @@ Slither-read-storage is a tool to retrieve the storage slots and values of entir
 
 ```shell
 positional arguments:
-  contract_source       The deployed contract address if verified on etherscan. Prepend project directory for unverified contracts.
+  contract_source       The deployed contract address if verified on etherscan. Prepend project directory, a Solidity file, or a solc Standard JSON input file for unverified contracts.
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -39,6 +39,12 @@ Retrieve the storage slots of a local contract:
 
 ```shell
 slither-read-storage file.sol 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --json storage_layout.json
+```
+
+Retrieve the storage layout from a solc Standard JSON input file (e.g. produced by `solc --standard-json` or other tooling that emits this format), without needing to reconstruct a source tree:
+
+```shell
+slither-read-storage input.json --contract-name MyContract --json storage_layout.json
 ```
 
 Retrieve the storage slots of a contract verified on an Etherscan-like platform:

--- a/slither/tools/read_storage/__main__.py
+++ b/slither/tools/read_storage/__main__.py
@@ -4,12 +4,42 @@ Tool to read on-chain storage from EVM
 
 import json
 import argparse
+import os
 
 from crytic_compile import cryticparser
 
 from slither import Slither
 from slither.exceptions import SlitherError
 from slither.tools.read_storage.read_storage import SlitherReadStorage, RpcInfo
+
+# Top-level keys expected in a solc Standard JSON *input* file, see
+# https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
+_STANDARD_JSON_REQUIRED_KEYS = ("language", "sources")
+
+
+def _is_solc_standard_json(path: str) -> bool:
+    """Best-effort check for whether `path` is a solc Standard JSON input file.
+
+    This lets users point slither-read-storage directly at a Standard JSON file
+    (e.g. produced by `solc --standard-json` tooling, or hand-built) instead of
+    requiring a .sol file or a full project directory.
+
+    Args:
+        path (str): path that was passed on the command line as the contract source
+
+    Returns:
+        bool: True if `path` is a file that looks like a solc Standard JSON input
+    """
+    if not path.endswith(".json") or not os.path.isfile(path):
+        return False
+
+    try:
+        with open(path, encoding="utf8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return False
+
+    return isinstance(data, dict) and all(key in data for key in _STANDARD_JSON_REQUIRED_KEYS)
 
 
 def parse_args() -> argparse.Namespace:
@@ -127,13 +157,19 @@ def main() -> None:
     args = parse_args()
 
     if len(args.contract_source) == 2:
-        # Source code is file.sol or project directory
+        # Source code is file.sol, project directory, or a solc Standard JSON file
         source_code, target = args.contract_source
-        slither = Slither(source_code, **vars(args))
+        kwargs = vars(args)
+        if not kwargs.get("compile_force_framework") and _is_solc_standard_json(source_code):
+            kwargs["compile_force_framework"] = "solc-json"
+        slither = Slither(source_code, **kwargs)
     else:
-        # Source code is published and retrieved via etherscan
+        # Source code is published and retrieved via etherscan, or a solc Standard JSON file
         target = args.contract_source[0]
-        slither = Slither(target, **vars(args))
+        kwargs = vars(args)
+        if not kwargs.get("compile_force_framework") and _is_solc_standard_json(target):
+            kwargs["compile_force_framework"] = "solc-json"
+        slither = Slither(target, **kwargs)
 
     if args.contract_name:
         contracts = slither.get_contract_from_name(args.contract_name)

--- a/tests/tools/read-storage/test_read_storage.py
+++ b/tests/tools/read-storage/test_read_storage.py
@@ -1,5 +1,7 @@
 import re
 import json
+import sys
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -8,6 +10,7 @@ from web3.contract import Contract
 
 from slither import Slither
 from slither.tools.read_storage import SlitherReadStorage, RpcInfo
+from slither.tools.read_storage.__main__ import _is_solc_standard_json
 
 TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
 
@@ -88,4 +91,117 @@ def test_read_storage(test_contract, storage_file, web3, ganache, solc_binary_pa
             with open(f"{path}_actual.txt", "w", encoding="utf8") as f:
                 f.write(str(change.t2))
 
+    assert not diff
+
+
+# --- Regression tests for GitHub issue #2777 -------------------------------
+# slither-read-storage should accept a solc Standard JSON *input* file
+# (https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description)
+# directly as its target, without requiring --compile-force-framework solc-json.
+
+
+def _build_standard_json(sol_path: Path) -> dict:
+    """Wrap a .sol file's contents in a minimal solc Standard JSON input dict."""
+    return {
+        "language": "Solidity",
+        "sources": {sol_path.name: {"content": get_source_file(sol_path.as_posix())}},
+        "settings": {
+            "outputSelection": {
+                "*": {
+                    "*": ["abi", "evm.bytecode", "evm.deployedBytecode", "devdoc", "userdoc"],
+                    "": ["ast"],
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "existing_file, expected",
+    [
+        # Not JSON at all
+        ("StorageLayout.sol", False),
+        # A JSON file that isn't a solc Standard JSON input (missing "language"/"sources")
+        ("not_standard.json", False),
+        # A well-formed solc Standard JSON input
+        ("standard_json_input.json", True),
+    ],
+)
+def test_is_solc_standard_json(tmp_path, existing_file, expected) -> None:
+    """`_is_solc_standard_json` should only return True for genuine Standard JSON input files,
+    and must not raise on non-JSON, malformed JSON, or missing files."""
+
+    if existing_file == "StorageLayout.sol":
+        path = Path(TEST_DATA_DIR, existing_file).as_posix()
+    elif existing_file == "not_standard.json":
+        path = str(tmp_path / existing_file)
+        with open(path, "w", encoding="utf8") as f:
+            json.dump({"foo": "bar"}, f)
+    else:
+        path = str(tmp_path / existing_file)
+        standard_json = _build_standard_json(Path(TEST_DATA_DIR, "StorageLayout.sol"))
+        with open(path, "w", encoding="utf8") as f:
+            json.dump(standard_json, f)
+
+    assert _is_solc_standard_json(path) is expected
+
+    # A nonexistent path must never raise, and must return False
+    assert _is_solc_standard_json(str(tmp_path / "does_not_exist.json")) is False
+
+    # Invalid JSON syntax must never raise, and must return False
+    broken_path = tmp_path / "broken.json"
+    broken_path.write_text("{not valid json", encoding="utf8")
+    assert _is_solc_standard_json(str(broken_path)) is False
+
+
+def test_read_storage_from_standard_json(tmp_path, solc_binary_path) -> None:
+    """slither-read-storage's storage-layout extraction should work identically whether the
+    contract is given as a plain .sol file or as a solc Standard JSON input file, with no
+    extra flags required (i.e. Slither must auto-select the solc-json compilation platform).
+
+    Note: the auto-detection lives in the CLI's main(), not in Slither.__init__ itself, so this
+    exercises the actual slither-read-storage entrypoint (as issue #2777 did) rather than
+    calling Slither() directly, which would bypass the fix.
+    """
+
+    solc_path = solc_binary_path(version="0.8.10")
+    sol_path = Path(TEST_DATA_DIR, "StorageLayout.sol")
+
+    # Write out a genuine solc Standard JSON input file, the same shape a user would get from
+    # `solc --standard-json` tooling.
+    standard_json_path = tmp_path / "StorageLayout.standard-json.json"
+    with open(standard_json_path, "w", encoding="utf8") as f:
+        json.dump(_build_standard_json(sol_path), f)
+
+    def layout_via_cli(target: str, out_name: str) -> dict:
+        out_path = tmp_path / out_name
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "slither.tools.read_storage",
+                target,
+                "--contract-name",
+                "StorageLayout",
+                "--solc",
+                solc_path,
+                "--json",
+                str(out_path),
+            ],
+            cwd=TEST_DATA_DIR,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        with open(out_path, encoding="utf8") as f:
+            return json.load(f)
+
+    # Baseline: compiling the plain .sol file directly.
+    expected_layout = layout_via_cli(sol_path.as_posix(), "expected.json")
+
+    # This is the exact scenario from issue #2777: passing a Standard JSON file as the sole
+    # target, with no --compile-force-framework flag, must work and produce the same layout.
+    actual_layout = layout_via_cli(standard_json_path.as_posix(), "actual.json")
+
+    diff = DeepDiff(expected_layout, actual_layout, ignore_order=True)
     assert not diff


### PR DESCRIPTION
Fixes #2777

## Problem

`slither-read-storage` rejected any target that wasn't a `.sol` file or a
project directory. Feeding it a solc Standard JSON input file (as produced by
`solc --standard-json`, or hand-built, per the [Standard JSON input
format](https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description))
failed with:

```
slither.exceptions.SlitherError: Invalid compilation:
0424.json is not the expected format '.sol'
```

## Root cause

The error comes from crytic-compile's `Solc` platform, which only accepts
`.sol` files. crytic-compile already ships a `SolcStandardJson` platform
(`NAME = "Solc-json"`) that reads a Standard JSON input file directly, but
it's never auto-selected for `.json` targets — its `is_supported()` is
inherited unchanged from `Solc` (`target.endswith(".sol")`). The only way to
reach it today is the undocumented `--compile-force-framework solc-json` flag.

## Fix

`slither-read-storage`'s `main()` now checks whether the given target is a
`.json` file containing the two keys that define a solc Standard JSON input
(`"language"`, `"sources"`). If so, and the user hasn't already passed
`--compile-force-framework`, it's set to `solc-json` automatically. Detection
is safe on missing files, non-JSON files, and malformed JSON — it just
returns `False` and falls through to the original, clear error message.

Docs updated in `docs/src/tools/ReadStorage.md` to document the new
`contract_source` behavior and add a usage example.

## Testing

Added to `tests/tools/read-storage/test_read_storage.py`:

- `test_is_solc_standard_json` — unit tests of the detection helper (valid
  Standard JSON, non-standard JSON, non-JSON file, missing file, malformed
  JSON syntax).
- `test_read_storage_from_standard_json` — end-to-end test that runs the real
  `slither-read-storage` CLI once against a `.sol` file and once against an
  equivalent Standard JSON file with **no extra flags**, and asserts the
  resulting storage layouts are identical.

```
$ pytest tests/tools/read-storage/test_read_storage.py -k "standard_json" -v

tests/tools/read-storage/test_read_storage.py::test_is_solc_standard_json[StorageLayout.sol-False] PASSED
tests/tools/read-storage/test_read_storage.py::test_is_solc_standard_json[not_standard.json-False] PASSED
tests/tools/read-storage/test_read_storage.py::test_is_solc_standard_json[standard_json_input.json-True] PASSED
tests/tools/read-storage/test_read_storage.py::test_read_storage_from_standard_json PASSED

4 passed, 2 deselected in 1.31s
```

Manual verification, reproducing the exact scenario from the issue:

```
$ uv run slither-read-storage 0424.json --contract-name TestVariables --json out.json

INFO:Slither-read-storage:
Contract 'TestVariables'
TestVariables.x with type uint256 is located at slot: 0

INFO:Slither-read-storage:
Name: x
Type: uint256
Slot: 0

INFO:Slither-read-storage:
Contract 'TestVariables'
TestVariables.owner with type address is located at slot: 1

INFO:Slither-read-storage:
Name: owner
Type: address
Slot: 1

INFO:Slither-read-storage:
Contract 'TestVariables'
TestVariables.paused with type bool is located at slot: 1

INFO:Slither-read-storage:
Name: paused
Type: bool
Slot: 1

$ cat out.json

{
    "x": {
        "name": "x",
        "type_string": "uint256",
        "slot": 0,
        "size": 256,
        "offset": 0,
        "value": null,
        "elems": {}
    },
    "owner": {
        "name": "owner",
        "type_string": "address",
        "slot": 1,
        "size": 160,
        "offset": 0,
        "value": null,
        "elems": {}
    },
    "paused": {
        "name": "paused",
        "type_string": "bool",
        "slot": 1,
        "size": 8,
        "offset": 160,
        "value": null,
        "elems": {}
    }
}
```

No extra flags required — matches the exact command from the issue report.

## Scope note for maintainers

This fix is scoped to `slither-read-storage` only. A more general fix — giving
`SolcStandardJson.is_supported()` real content-based detection in
`crytic-compile` — would let every Slither tool accept Standard JSON targets
directly, not just `read_storage`. Happy to open a follow-up issue/PR there
if that's of interest.