### PR TITLE
fix: analyse Vyper function bodies that start with pass

### DIFF
--- a/slither/vyper_parsing/declarations/function.py
+++ b/slither/vyper_parsing/declarations/function.py
@@ -179,7 +179,7 @@ class FunctionVyper:
 
         body = self._functionNotParsed.body
 
-        if body and not isinstance(body[0], Pass):
+        if body and not all(isinstance(stmt, Pass) for stmt in body):
             self._function.is_implemented = True
             self._function.is_empty = False
             self._parse_cfg(body)

--- a/tests/unit/core/test_function_declaration.py
+++ b/tests/unit/core/test_function_declaration.py
@@ -425,3 +425,34 @@ def __default__():
             ElementaryType("address"),
             MappingType(ElementaryType("address"), ElementaryType("uint256")),
         )
+
+
+def test_vyper_function_body_starting_with_pass(slither_from_vyper_source) -> None:
+    """`pass` as the first statement must not discard the rest of the body.
+
+    https://github.com/crytic/slither/issues/2192
+    """
+    with slither_from_vyper_source(
+        """
+var: uint256
+
+@internal
+def bar(a: uint256):
+    pass
+    self.var = 2
+
+@internal
+def only_pass():
+    pass
+"""
+    ) as sl:
+        functions = sl.contracts[0].available_functions_as_dict()
+
+        f = functions["bar(uint256)"]
+        assert f.is_implemented
+        assert not f.is_empty
+        assert f.nodes
+
+        f = functions["only_pass()"]
+        assert not f.is_implemented
+        assert f.is_empty


### PR DESCRIPTION
Fixes #2192.

**Root cause.** `FunctionVyper.analyze_content` decides whether a Vyper function has a body with

```python
if body and not isinstance(body[0], Pass):
```

The intent is "an empty Vyper body is written as `pass`", but the check only looks at the *first*
statement. Any function whose body merely *starts* with `pass` is therefore treated as
unimplemented: no CFG is built and every detector sees an empty function.

`_parse_statement` already handles `Pass` anywhere in a body
(`elif isinstance(expr, Pass): pass`), so the guard is only needed for the genuinely empty case.

**Fix.** Treat the body as empty only when every statement is `Pass`.

**Effect.** On the contract from the issue, `slither` reported three findings before the change
(`unimplemented-functions`, `unused-state`, `constable-states`) and reports none after it.

**Test.** `tests/unit/core/test_function_declaration.py::test_vyper_function_body_starting_with_pass`,
next to the existing `test_vyper_functions`. It covers both directions: a body starting with `pass`
must be analysed, and a body consisting solely of `pass` must stay empty — the latter is the
contract already asserted for `__init__()` and `__default__()` in `test_vyper_functions`.

Verified per CLAUDE.md ("temporarily break code to verify the test fails"): with the test added and
the fix reverted the run fails on `assert f.is_implemented`; with the fix applied
`tests/unit/slithir/vyper`, `tests/e2e/vyper_parsing` and the vyper tests in
`tests/unit/core/test_function_declaration.py` are green.
