### PR TITLE
Fix Vyper interface calls omitting a default argument

### DIFF
--- a/slither/slithir/convert.py
+++ b/slither/slithir/convert.py
@@ -1800,6 +1800,17 @@ def convert_type_of_high_and_internal_level_call(
             and not f.is_shadowed
             and len(f.parameters) == len(ir.arguments)
         ]
+        if not candidates:
+            candidates = [
+                f
+                for f in contract.functions
+                if f.name == ir.function_name
+                and not f.is_shadowed
+                and f._default_args_as_expressions
+                and len(f.parameters) - len(f._default_args_as_expressions)
+                <= len(ir.arguments)
+                < len(f.parameters)
+            ]
         if len(candidates) == 1:
             func = candidates[0]
         if func is None:

--- a/tests/unit/slithir/vyper/test_ir_generation.py
+++ b/tests/unit/slithir/vyper/test_ir_generation.py
@@ -97,3 +97,24 @@ def b(x: uint256):
                 if isinstance(op, InternalCall) and op.function.name == "c":
                     assert len(op.arguments) == 2
                     assert op.arguments[1] == Constant("False", ElementaryType("bool"))
+
+
+def test_interface_call_with_default_argument(slither_from_vyper_source) -> None:
+    """Resolve an interface call that omits a defaulted argument."""
+    with slither_from_vyper_source(
+        """
+interface Pool:
+    def price_oracle(i: uint256 = 0) -> uint256: view
+
+@external
+@view
+def price(a: address):
+    p: uint256 = Pool(a).price_oracle()
+"""
+    ) as sl:
+        interface = next(iter(x for x in sl.contracts if x.is_interface))
+        contract = next(iter(x for x in sl.contracts if not x.is_interface))
+        func = contract.get_function_from_signature("price(address)")
+        (called_contract, ir) = func.high_level_calls[0]
+        assert called_contract == interface
+        assert ir.function.name == "price_oracle"


### PR DESCRIPTION
## Summary

Fixes #2375.

Vyper interface functions with default arguments expose call forms with fewer arguments. Slither only considered functions whose parameter count exactly matched the call, so an omitted defaulted argument left the call unresolved and later crashed while dereferencing a missing function.

This change adds a fallback candidate lookup when exact arity finds nothing. A function is eligible only when the omitted arguments are trailing defaulted parameters; the normal exact-arity path remains unchanged.

The regression test verifies that `Pool(a).price_oracle()` resolves to the declared `price_oracle(i: uint256 = 0)` interface function.

This differs from the withdrawn #2984: that patch guarded the null dereference, while this one restores the call target and keeps the SlithIR useful to downstream analyses.

## Validation

- Before: the new test fails with `AttributeError: 'NoneType' object has no attribute 'type'`
- After: `pytest tests/unit/slithir/vyper/test_ir_generation.py -q` — 4 passed
- Ruff check and format check pass for both changed files
- Tested with Vyper 0.3.7, matching the repository test setup

AI-assisted (LLM used for implementation and drafting); the change and tests were reviewed and run by me.