### PR TITLE
fix: fold parenthesized type(X).max/min in IR generation

### DIFF
--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -526,15 +526,25 @@ class ExpressionToSlithIR(ExpressionVisitor):
         # Because we looked at the AST structure, we need to look into the nested expression
         # Hopefully this is always on a direct sub field, and there is no weird construction
 
-        if isinstance(expression.expression, CallExpression) and expression.member_name in [
+        # Redundant parentheses, e.g. `(type(X)).max`, wrap the call in a single-element
+        # TupleExpression. Unwrap them so the type(X).max/min folding below still applies;
+        # otherwise the member access reaches convert.py and raises "type(X).max is unknown".
+        called_expression = expression.expression
+        while (
+            isinstance(called_expression, TupleExpression)
+            and len(called_expression.expressions) == 1
+        ):
+            called_expression = called_expression.expressions[0]
+
+        if isinstance(called_expression, CallExpression) and expression.member_name in [
             "min",
             "max",
         ]:
-            if isinstance(expression.expression.called, Identifier):
-                if expression.expression.called.value == SolidityFunction("type()"):
-                    assert len(expression.expression.arguments) == 1
+            if isinstance(called_expression.called, Identifier):
+                if called_expression.called.value == SolidityFunction("type()"):
+                    assert len(called_expression.arguments) == 1
                     val = TemporaryVariable(self._node)
-                    type_expression_found = expression.expression.arguments[0]
+                    type_expression_found = called_expression.arguments[0]
                     type_found: ElementaryType | UserDefinedType
                     if isinstance(type_expression_found, ElementaryTypeNameExpression):
                         type_expression_found_type = type_expression_found.type

--- a/tests/unit/slithir/test_data/type_minmax_parenthesized.sol
+++ b/tests/unit/slithir/test_data/type_minmax_parenthesized.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0;
+
+// Regression test for parenthesized `type(X).max` / `type(X).min`.
+//
+// `(type(uint8)).max` is parsed with the `type()` call wrapped in a
+// single-element TupleExpression. The folding in `expression_to_slithir` must
+// unwrap the redundant parentheses; otherwise the member access reaches
+// `convert.py` and IR generation fails with "type(uint8).max is unknown".
+contract C {
+    function paren_max() external pure returns (uint8) {
+        return (type(uint8)).max;
+    }
+
+    function paren_min() external pure returns (uint8) {
+        return (type(uint8)).min;
+    }
+
+    function nested_paren_max() external pure returns (uint256) {
+        return ((type(uint256))).max;
+    }
+
+    function signed_min() external pure returns (int256) {
+        return (type(int256)).min;
+    }
+
+    // The non-parenthesized form must keep working.
+    function plain_max() external pure returns (uint8) {
+        return type(uint8).max;
+    }
+}

--- a/tests/unit/slithir/test_type_minmax.py
+++ b/tests/unit/slithir/test_type_minmax.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from slither import Slither
+from slither.slithir.operations import Assignment
+from slither.slithir.variables import Constant
+
+TEST_DATA_DIR = Path(__file__).resolve().parent / "test_data"
+
+
+def _folded_constant(func):
+    """Return the value of the first `TMP := <constant>` assignment in `func`."""
+    for op in func.slithir_operations:
+        if isinstance(op, Assignment) and isinstance(op.rvalue, Constant):
+            return op.rvalue.value
+    return None
+
+
+def test_type_minmax_parenthesized(solc_binary_path) -> None:
+    # Regression test for `(type(X)).max` / `.min`: the redundant parentheses
+    # must be unwrapped so the value folds to a constant, exactly like the
+    # non-parenthesized `type(X).max`. Before the fix, building the Slither
+    # object raised "type(uint8).max is unknown" during IR generation.
+    solc_path = solc_binary_path("0.8.19")
+    slither = Slither(
+        Path(TEST_DATA_DIR, "type_minmax_parenthesized.sol").as_posix(), solc=solc_path
+    )
+    contract = slither.get_contract_from_name("C")[0]
+
+    expected = {
+        "paren_max()": 255,
+        "paren_min()": 0,
+        "nested_paren_max()": 2**256 - 1,
+        "signed_min()": -(2**255),
+        "plain_max()": 255,
+    }
+    for signature, value in expected.items():
+        func = contract.get_function_from_full_name(signature)
+        assert _folded_constant(func) == value, signature


### PR DESCRIPTION
### Summary

`(type(uint8)).max` (redundant parentheses around `type(X)`) fails IR generation, while the non-parenthesized `type(uint8).max` works fine:

```
$ slither A.sol
Failed to generate IR for Test.test ...
slither.slithir.exceptions.SlithIRError: type(uint8).max is unknown
```

### Root cause

`type(X).max`/`.min` is folded to a constant in `ExpressionToSlithIR._post_member_access`, but the check required the accessed sub-expression to be a bare `CallExpression`. Parentheses wrap the `type()` call in a single-element `TupleExpression`, so the fold is skipped. The member access then falls through to `convert.py`'s `_convert_type_contract` (which only handles `creationCode`/`runtimeCode`/`interfaceId`/`name`) and raises `type(X).max is unknown`.

### Fix

Unwrap redundant single-element parentheses before the `type(X).max`/`.min` check. `(type(X)).max`, `((type(X))).min`, etc. now fold to the correct constant like the non-parenthesized form (elementary signed and unsigned types covered).

### Testing

- New unit test `tests/unit/slithir/test_type_minmax.py` asserts the folded constants for `uint8`/`uint256`/`int256`, parenthesized and nested, plus the plain form as a regression guard. It fails before the fix (`type(uint8).max is unknown`) and passes after.
- Existing `tests/unit/slithir` and `solc_parsing` minmax tests pass.

Fixes #2645
