### PR TITLE
fix: use SlithIR operations for external call classification in function summary

### DIFF
--- a/slither/core/declarations/function_contract.py
+++ b/slither/core/declarations/function_contract.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING
 from slither.core.declarations.contract_level import ContractLevel
 from slither.core.declarations import Function
 from slither.utils.code_complexity import compute_cyclomatic_complexity
+from slither.slithir.operations.high_level_call import HighLevelCall
+from slither.slithir.operations.library_call import LibraryCall
+from slither.slithir.operations.low_level_call import LowLevelCall
 
 
 if TYPE_CHECKING:
@@ -112,7 +115,7 @@ class FunctionContract(Function, ContractLevel):
             [str(x) for x in self.state_variables_read + self.solidity_variables_read],
             [str(x) for x in self.state_variables_written],
             [str(x) for x in self.internal_calls],
-            [str(x) for x in self.external_calls_as_expressions],
+            [str(op.expression) for op in self.all_slithir_operations() if isinstance(op, (HighLevelCall, LowLevelCall)) and not isinstance(op, LibraryCall) and op.expression is not None],
             compute_cyclomatic_complexity(self),
         )
 

--- a/slither/core/declarations/function_top_level.py
+++ b/slither/core/declarations/function_top_level.py
@@ -5,6 +5,9 @@ Function module
 from typing import TYPE_CHECKING
 
 from slither.core.declarations import Function
+from slither.slithir.operations.high_level_call import HighLevelCall
+from slither.slithir.operations.library_call import LibraryCall
+from slither.slithir.operations.low_level_call import LowLevelCall
 from slither.core.declarations.top_level import TopLevel
 from slither.utils.using_for import USING_FOR, merge_using_for
 
@@ -85,7 +88,7 @@ class FunctionTopLevel(Function, TopLevel):
             [str(x) for x in self.state_variables_read + self.solidity_variables_read],
             [str(x) for x in self.state_variables_written],
             [str(x) for x in self.internal_calls],
-            [str(x) for x in self.external_calls_as_expressions],
+            [str(op.expression) for op in self.all_slithir_operations() if isinstance(op, (HighLevelCall, LowLevelCall)) and not isinstance(op, LibraryCall) and op.expression is not None],
         )
 
     # endregion


### PR DESCRIPTION
The function-summary printer used expression-level call classification which incorrectly reported library calls (via using-for), abi.encode, and struct accesses as external calls.

Switch to filtering HighLevelCall and LowLevelCall SlithIR operations (excluding LibraryCall) which correctly resolve call semantics after the IR pass.

Changes:
- `function_contract.py`: SlithIR-based filtering in `get_summary()`
- `function_top_level.py`: same

Fixes #2073