### PR TITLE
fix(vyper): model loop bounds and range arguments correctly

### DIFF
--- a/slither/vyper_parsing/declarations/function.py
+++ b/slither/vyper_parsing/declarations/function.py
@@ -300,6 +300,21 @@ class FunctionVyper:
 
                 link_underlying_nodes(curr_node, node_startLoop)
 
+                counter_initial = Int("-1:-1:-1", -1, 0)
+                range_end = None
+                if isinstance(expr.iter, Call):
+                    # Vyper's optional ``bound`` keyword limits compilation work;
+                    # it does not change the half-open range endpoint.
+                    if len(expr.iter.args) == 1:
+                        range_end = expr.iter.args[0]
+                    elif len(expr.iter.args) == 2:
+                        counter_initial = expr.iter.args[0]
+                        range_end = expr.iter.args[1]
+                    else:
+                        raise ParsingError(
+                            "Vyper range loops must have one or two positional arguments"
+                        )
+
                 local_var = LocalVariable()
                 local_var.set_function(self._function)
                 local_var.set_offset(expr.src, self._function.compilation_unit)
@@ -309,7 +324,7 @@ class FunctionVyper:
                     expr.target.node_id,
                     target=Name("-1:-1:-1", -1, "counter_var"),
                     annotation=Name("-1:-1:-1", -1, "uint256"),
-                    value=Int("-1:-1:-1", -1, 0),
+                    value=counter_initial,
                 )
                 local_var_parser = LocalVariableVyper(local_var, counter_var)
                 self._add_local_variable(local_var_parser)
@@ -347,7 +362,7 @@ class FunctionVyper:
                         "-1:-1:-1",
                         -1,
                         left=Name("-1:-1:-1", -1, "counter_var"),
-                        op="<=",
+                        op="<",
                         right=Call(
                             "-1:-1:-1",
                             -1,
@@ -380,13 +395,12 @@ class FunctionVyper:
                     )
 
                 elif isinstance(expr.iter, Call):  # range
-                    range_val = expr.iter.args[0]
                     cond_expr = Compare(
                         "-1:-1:-1",
                         -1,
                         left=Name("-1:-1:-1", -1, "counter_var"),
-                        op="<=",
-                        right=range_val,
+                        op="<",
+                        right=range_end,
                     )
                     node_condition = self._new_node(NodeType.IFLOOP, expr.src, scope)
                     node_condition.add_unparsed_expression(cond_expr)

--- a/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for2_for_loop__0.txt
+++ b/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for2_for_loop__0.txt
@@ -26,10 +26,10 @@ counter_var(uint256) := 0(uint256)"];
 5[label="Node Type: IF_LOOP 5
 
 EXPRESSION:
-counter_var <= 10
+counter_var < 10
 
 IRs:
-TMP_0(bool) = counter_var <= 10
+TMP_0(bool) = counter_var < 10
 CONDITION TMP_0"];
 5->7[label="True"];
 5->3[label="False"];

--- a/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for3_get_D__0.txt
+++ b/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for3_get_D__0.txt
@@ -26,11 +26,11 @@ counter_var(uint256) := 0(uint256)"];
 5[label="Node Type: IF_LOOP 5
 
 EXPRESSION:
-counter_var <= len()(_xp)
+counter_var < len()(_xp)
 
 IRs:
 TMP_0(uint256) = SOLIDITY_CALL len()(_xp)
-TMP_1(bool) = counter_var <= TMP_0
+TMP_1(bool) = counter_var < TMP_0
 CONDITION TMP_1"];
 5->7[label="True"];
 5->3[label="False"];

--- a/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for_break_continue_f__0.txt
+++ b/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for_break_continue_f__0.txt
@@ -18,10 +18,10 @@ counter_var(uint256) := 0(uint256)"];
 4[label="Node Type: IF_LOOP 4
 
 EXPRESSION:
-counter_var <= 100
+counter_var < 100
 
 IRs:
-TMP_0(bool) = counter_var <= 100
+TMP_0(bool) = counter_var < 100
 CONDITION TMP_0"];
 4->6[label="True"];
 4->2[label="False"];
@@ -98,10 +98,10 @@ counter_var_scope_0(uint256) := 0(uint256)"];
 17[label="Node Type: IF_LOOP 17
 
 EXPRESSION:
-counter_var <= 10
+counter_var < 10
 
 IRs:
-TMP_3(bool) = counter_var <= 10
+TMP_3(bool) = counter_var < 10
 CONDITION TMP_3"];
 17->19[label="True"];
 17->15[label="False"];

--- a/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for_for_loop__0.txt
+++ b/tests/e2e/vyper_parsing/snapshots/ast_parsing__vyper_cfgir_for_for_loop__0.txt
@@ -18,11 +18,11 @@ counter_var(uint256) := 0(uint256)"];
 4[label="Node Type: IF_LOOP 4
 
 EXPRESSION:
-counter_var <= len()(self.strategies)
+counter_var < len()(self.strategies)
 
 IRs:
 TMP_0(uint256) = SOLIDITY_CALL len()(strategies)
-TMP_1(bool) = counter_var <= TMP_0
+TMP_1(bool) = counter_var < TMP_0
 CONDITION TMP_1"];
 4->6[label="True"];
 4->2[label="False"];

--- a/tests/unit/slithir/vyper/test_ir_generation.py
+++ b/tests/unit/slithir/vyper/test_ir_generation.py
@@ -2,6 +2,7 @@
 
 
 from slither.core.solidity_types import ElementaryType
+from slither.detectors.statements.type_based_tautology import TypeBasedTautology
 from slither.slithir.operations import (
     Phi,
     InternalCall,
@@ -120,3 +121,59 @@ def loop(values: DynArray[uint256, 3]):
         assert "counter_var = 0" in cfg
         assert "counter_var < 7" in cfg
         assert "counter_var_scope_0 = 5" in cfg
+
+
+def test_range_with_bound_keyword(slither_from_vyper_source):
+    with slither_from_vyper_source(
+        """
+@external
+def loop(end: uint256):
+    total: uint256 = 0
+    for i in range(end, bound=10):
+        total += i
+"""
+    ) as sl:
+        function = sl.contracts[0].get_function_from_signature("loop(uint256)")
+        cfg = function.slithir_cfg_to_dot_str()
+
+        assert "counter_var = 0" in cfg
+        assert "counter_var < end" in cfg
+        assert "counter_var = end" not in cfg
+        assert "counter_var < 10" not in cfg
+
+
+def test_range_with_runtime_start(slither_from_vyper_source):
+    with slither_from_vyper_source(
+        """
+@external
+def loop(start: uint256):
+    total: uint256 = 0
+    for i in range(start, start + 5):
+        total += i
+"""
+    ) as sl:
+        function = sl.contracts[0].get_function_from_signature("loop(uint256)")
+        cfg = function.slithir_cfg_to_dot_str()
+
+        assert "counter_var = start" in cfg
+        assert "counter_var < start + 5" in cfg
+
+
+def test_range_with_negative_start_does_not_trigger_tautology(slither_from_vyper_source):
+    with slither_from_vyper_source(
+        """
+@external
+def loop():
+    total: int256 = 0
+    for i in range(-3, 2):
+        total += i
+"""
+    ) as sl:
+        function = sl.contracts[0].get_function_from_signature("loop()")
+        cfg = function.slithir_cfg_to_dot_str()
+
+        assert "counter_var = -3" in cfg
+        assert "counter_var < 2" in cfg
+
+        sl.register_detector(TypeBasedTautology)
+        assert sl.run_detectors() == [[]]

--- a/tests/unit/slithir/vyper/test_ir_generation.py
+++ b/tests/unit/slithir/vyper/test_ir_generation.py
@@ -97,3 +97,26 @@ def b(x: uint256):
                 if isinstance(op, InternalCall) and op.function.name == "c":
                     assert len(op.arguments) == 2
                     assert op.arguments[1] == Constant("False", ElementaryType("bool"))
+
+
+def test_for_loop_bounds_and_range_start(slither_from_vyper_source):
+    with slither_from_vyper_source(
+        """
+@external
+def loop(values: DynArray[uint256, 3]):
+    total: uint256 = 0
+    for value in values:
+        total += value
+    for i in range(5, 7):
+        total += i
+"""
+    ) as sl:
+        function = next(
+            function for function in sl.contracts[0].functions if function.name == "loop"
+        )
+        cfg = function.slithir_cfg_to_dot_str()
+
+        assert "counter_var < len()(values)" in cfg
+        assert "counter_var = 0" in cfg
+        assert "counter_var < 7" in cfg
+        assert "counter_var_scope_0 = 5" in cfg


### PR DESCRIPTION

## Summary

Fix Vyper loop modeling in the CFG and SlithIR generation.

## Root Cause

Vyper loops were modeled with an inclusive upper bound:

```text
counter_var <= len(iterable)
counter_var <= range_end
```

This caused one extra modeled iteration and could produce an invalid access at `iterable[len(iterable)]`.

For two-argument `range(start, end)`, Slither also initialized the artificial counter to `0` and used the first argument as the endpoint. This did not match Vyper's half-open range semantics.

## Changes

- Use `counter_var < len(iterable)` for array iteration.
- Use `counter_var < end` for `range(end)`.
- Initialize the artificial counter with `start` for `range(start, end)`.
- Use the second positional argument as the endpoint.
- Preserve Vyper's `bound` keyword behavior without treating it as the range endpoint.
- Add regression coverage for dynamic array iteration and two-argument ranges.
- Update affected Vyper CFG/SlithIR snapshots.

## Testing

```text
30 passed
ruff check passed
git diff --check passed
```
