### PR TITLE
fix(detectors): recognize Chainlink version function

### DIFF
--- a/slither/detectors/functions/chainlink_feed_registry.py
+++ b/slither/detectors/functions/chainlink_feed_registry.py
@@ -47,7 +47,7 @@ If the contract is deployed on a different chain than Ethereum Mainnet the `getP
         registry_functions = [
             "decimals",
             "description",
-            "versiom",
+            "version",
             "latestRoundData",
             "getRoundData",
             "latestAnswer",

--- a/slither/detectors/functions/modifier.py
+++ b/slither/detectors/functions/modifier.py
@@ -54,7 +54,7 @@ class ModifierDefaultDetection(AbstractDetector):
     # region wiki_exploit_scenario
     WIKI_EXPLOIT_SCENARIO = """
 ```solidity
-    modidfier myModif(){
+    modifier myModif(){
         if(..){
            _;
         }


### PR DESCRIPTION
Recognize the version accessor used by current Chainlink feed-registry deployments and correct the adjacent modifier example so detector documentation matches parser input. 