### PR TITLE
Merge inherited using-for directives instead of overwriting them

### DIFF
--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -26,7 +26,7 @@ from slither.solc_parsing.exceptions import ParsingError, VariableNotFound
 from slither.solc_parsing.solidity_types.type_parsing import parse_type
 from slither.solc_parsing.variables.state_variable import StateVariableSolc
 from slither.solc_parsing.expressions.expression_parsing import parse_expression
-from slither.utils.using_for import USING_FOR_KEY
+from slither.utils.using_for import USING_FOR_KEY, merge_using_for
 from slither.visitors.expression.constants_folding import ConstantFolding, NotConstant
 
 LOGGER = logging.getLogger("ContractSolcParsing")
@@ -637,8 +637,17 @@ class ContractSolc(CallerContextExpression):
 
     def analyze_using_for(self) -> None:
         try:
+            # Inherited using-for directives must be merged, not overwritten:
+            # multiple base contracts can attach libraries to the same type
+            # (e.g. two `using X for *` directives in two fathers), and
+            # dict.update() would silently keep only the last one. The dropped
+            # directive then leaves attached library calls unresolved during
+            # IR generation (see crytic/slither#3082).
+            inherited_using_for: dict[USING_FOR_KEY, list] = {}
             for father in self._contract.inheritance:
-                self._contract.using_for.update(father.using_for)
+                inherited_using_for = merge_using_for(inherited_using_for, father.using_for)
+            self._contract.using_for.clear()
+            self._contract.using_for.update(inherited_using_for)
             if self.is_compact_ast:
                 for using_for in self._usingForNotParsed:
                     if using_for.get("typeName"):

--- a/tests/unit/core/test_using_for.py
+++ b/tests/unit/core/test_using_for.py
@@ -134,3 +134,49 @@ def test_using_for_constant_folding(slither_from_solidity_source) -> None:
             if isinstance(ir, LibraryCall) and ir.function_name == "add":
                 found = True
         assert found
+
+
+def test_using_for_inherited_wildcard_collision(slither_from_solidity_source) -> None:
+    # https://github.com/crytic/slither/issues/3082
+    # Two base contracts attach different libraries to the same key ("*") through
+    # `using ... for *`. Merging the inherited directives with dict.update() used to
+    # keep only the last one, leaving the attached library calls inherited from the
+    # other base contract unresolved during IR generation.
+    source = """
+        library LibA {
+            function ping(uint256 v) internal pure returns (uint256) { return v + 1; }
+        }
+        library LibB {
+            function pong(uint256 v) internal pure returns (uint256) { return v + 2; }
+        }
+        abstract contract BaseA {
+            using LibA for *;
+
+            function callPing(uint256 v) internal pure returns (uint256) {
+                return v.ping();
+            }
+        }
+        abstract contract BaseB {
+            using LibB for *;
+
+            function callPong(uint256 v) internal pure returns (uint256) {
+                return v.pong();
+            }
+        }
+        contract Derived is BaseA, BaseB {
+            function go(uint256 v) external pure returns (uint256) {
+                return callPing(v) + callPong(v);
+            }
+        }
+    """
+    with slither_from_solidity_source(source, solc_version="0.8.29") as slither:
+        derived = slither.get_contract_from_name("Derived")[0]
+        irs = [ir for function in derived.functions for ir in function.all_slithir_operations()]
+        assert any(
+            isinstance(ir, LibraryCall) and ir.destination == "LibA" and ir.function_name == "ping"
+            for ir in irs
+        )
+        assert any(
+            isinstance(ir, LibraryCall) and ir.destination == "LibB" and ir.function_name == "pong"
+            for ir in irs
+        )


### PR DESCRIPTION
## Description

Multiple base contracts can attach libraries to the same type through `using ... for *`. `Contract.analyze_using_for()` merged the inherited directives with `dict.update()`, which silently keeps **only the last father's entry** for a given key. The dropped directive leaves the attached library calls inherited from the other base contract unresolved during IR generation, and the run then fails with:

```
ERROR:ContractSolcParsing:Impossible to generate IR for Calibur._isValidTypedDataSig (src/ERC7739.sol#35-55):
 'NoneType' object has no attribute 'parameters'
```

The crash is raised from `convert_constant_types()` (`slither/slithir/convert.py`), which dereferences `ir.function.parameters` on a `HighLevelCall` whose target could not be resolved. Every function that fails IR generation - and, as reported in #3082, every contract relying on them - is silently dropped from the analysis while the run still completes.

Concretely, on Uniswap's [Calibur](https://github.com/Uniswap/calibur) (an audited EIP-7702 delegate that projects are encouraged to subclass):

- `ERC4337Account` declares `using EntrypointLib for *;`
- `ERC7739` declares `using ERC7739Utils for *;` (plus `using WrappedSignatureLib for bytes;` and `using KeyLib for Key;`)
- `Calibur` inherits both, so the `*` key collides and one directive is dropped

`_isValidTypedDataSig` destructures the calldata tuple returned by the attached `ERC7739Utils.decodeTypedDataSig()`; with the directive gone the call stays an unresolved `HighLevelCall` and IR generation crashes for `Calibur._isValidTypedDataSig` and `CaliburEntry._isValidTypedDataSig`.

## Fix

Merge the inherited directives with the existing `merge_using_for()` helper (already used by `using_for_complete` for top-level directives) instead of `dict.update()`, so destinations attached to the same key **accumulate** across ancestors.

## Reproduction / verification

Minimal repro (two fathers attaching different libraries to `*`):

```solidity
library LibA { function ping(uint256 v) internal pure returns (uint256) { return v + 1; } }
library LibB { function pong(uint256 v) internal pure returns (uint256) { return v + 2; } }

abstract contract BaseA {
    using LibA for *;
    function callPing(uint256 v) internal pure returns (uint256) { return v.ping(); }
}
abstract contract BaseB {
    using LibB for *;
    function callPong(uint256 v) internal pure returns (uint256) { return v.pong(); }
}
contract Derived is BaseA, BaseB {
    function go(uint256 v) external pure returns (uint256) { return callPing(v) + callPong(v); }
}
```

Before: one of `callPing`/`callPong` fails IR generation (same `AttributeError`). After: both resolve to `LIBRARY_CALL` (`LibA.ping` and `LibB.pong`).

Full-project check on `Uniswap/calibur@main` (solc 0.8.29, `slither .`):

| | before | after |
|---|---|---|
| `Impossible to generate IR` errors | 2 (`_isValidTypedDataSig`) | **0** |
| contracts analyzed | 121, affected functions silently dropped | 121, **fully analyzed** |

## Test plan

- New regression test `tests/unit/core/test_using_for.py::test_using_for_inherited_wildcard_collision` asserts both attached calls resolve to `LIBRARY_CALL` on the derived contract (fails on `master`, passes with this change).
- `pytest tests/unit/core/ tests/unit/slithir/`: no new failures (remaining failures/errors are pre-existing on `master` and Vyper-related).
- `ruff check` / `ruff format --check` clean.

Fixes #3082
